### PR TITLE
feat: adding TransactionTimeToConfirmation event for confirmations

### DIFF
--- a/src/background/services/wallet/handlers/bitcoin_sendTransaction.test.ts
+++ b/src/background/services/wallet/handlers/bitcoin_sendTransaction.test.ts
@@ -32,6 +32,7 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
   const signMock = jest.fn();
   const sendTransactionMock = jest.fn();
   const getBalancesForNetworksMock = jest.fn();
+  const captureEventMock = jest.fn();
 
   const getBitcoinNetworkMock = jest.fn();
   const activeAccountMock = {
@@ -50,6 +51,9 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
   const accountsServiceMock = {};
   const balanceAggregatorServiceMock = {
     getBalancesForNetworks: getBalancesForNetworksMock,
+  };
+  const analyticsServiceMock = {
+    captureEvent: captureEventMock,
   };
 
   beforeEach(() => {
@@ -91,6 +95,7 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
         {} as any,
         {} as any,
         {} as any,
+        {} as any,
         {} as any
       );
       const result = await handler.handleUnauthenticated(buildRpcCall(request));
@@ -113,7 +118,8 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
           type: AccountType.PRIMARY,
         },
       } as any,
-      balanceAggregatorServiceMock as any
+      balanceAggregatorServiceMock as any,
+      analyticsServiceMock as any
     );
 
     it('returns error if the active account is imported via WalletConnect', async () => {
@@ -128,7 +134,8 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
             type: AccountType.WALLET_CONNECT,
           },
         } as any,
-        balanceAggregatorServiceMock as any
+        balanceAggregatorServiceMock as any,
+        analyticsServiceMock as any
       );
 
       const result = await sendHandler.handleAuthenticated(
@@ -153,7 +160,8 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
             addressC: 'abcd1234',
           },
         } as any,
-        balanceAggregatorServiceMock as any
+        balanceAggregatorServiceMock as any,
+        analyticsServiceMock as any
       );
 
       const result = await sendHandler.handleAuthenticated(
@@ -230,7 +238,8 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
         walletServiceMock as any,
         networkServiceMock as any,
         {} as any,
-        balanceAggregatorServiceMock as any
+        balanceAggregatorServiceMock as any,
+        analyticsServiceMock as any
       );
       const result = await sendHandler.handleAuthenticated({ request } as any);
       expect(result).toEqual({
@@ -260,7 +269,8 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
         walletServiceMock as any,
         networkServiceMock as any,
         accountsServiceMock as any,
-        balanceAggregatorServiceMock as any
+        balanceAggregatorServiceMock as any,
+        analyticsServiceMock as any
       );
 
       const result = await sendHandler.handleAuthenticated(
@@ -298,7 +308,8 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
           },
         } as any,
         accountsServiceMock as any,
-        balanceAggregatorServiceMock as any
+        balanceAggregatorServiceMock as any,
+        analyticsServiceMock as any
       );
 
       const result = await sendHandler.handleAuthenticated(
@@ -329,7 +340,8 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
         walletServiceMock as any,
         networkServiceMock as any,
         accountsServiceMock as any,
-        balanceAggregatorServiceMock as any
+        balanceAggregatorServiceMock as any,
+        analyticsServiceMock as any
       );
 
       getBitcoinNetworkMock.mockResolvedValue({
@@ -362,7 +374,8 @@ describe('src/background/services/wallet/handlers/bitcoin_sendTransaction.ts', (
         walletServiceMock as any,
         networkServiceMock as any,
         accountsServiceMock as any,
-        balanceAggregatorServiceMock as any
+        balanceAggregatorServiceMock as any,
+        analyticsServiceMock as any
       );
 
       getBitcoinNetworkMock.mockResolvedValue({

--- a/src/background/services/wallet/handlers/bitcoin_sendTransaction.ts
+++ b/src/background/services/wallet/handlers/bitcoin_sendTransaction.ts
@@ -8,6 +8,7 @@ import { DAppRequestHandler } from '@src/background/connections/dAppConnection/D
 import { Action } from '../../actions/models';
 import { DEFERRED_RESPONSE } from '@src/background/connections/middlewares/models';
 import { NetworkService } from '@src/background/services/network/NetworkService';
+import { AnalyticsServicePosthog } from '@src/background/services/analytics/AnalyticsServicePosthog';
 import { ethErrors } from 'eth-rpc-errors';
 import {
   DisplayData_BitcoinSendTx,
@@ -33,6 +34,7 @@ import { resolve } from '@avalabs/core-utils-sdk';
 
 import { openApprovalWindow } from '@src/background/runtime/openApprovalWindow';
 import { runtime } from 'webextension-polyfill';
+import { measureTransactionTime } from '@src/background/services/wallet/utils/measureTransactionTime';
 
 type BitcoinTxParams = [
   address: string,
@@ -52,7 +54,8 @@ export class BitcoinSendTransactionHandler extends DAppRequestHandler<
     private walletService: WalletService,
     private networkService: NetworkService,
     private accountService: AccountsService,
-    private balanceAggregatorService: BalanceAggregatorService
+    private balanceAggregatorService: BalanceAggregatorService,
+    private analyticsServicePosthog: AnalyticsServicePosthog
   ) {
     super();
   }
@@ -256,8 +259,12 @@ export class BitcoinSendTransactionHandler extends DAppRequestHandler<
     frontendTabId?: number
   ) => {
     try {
+      measureTransactionTime().startMeasure();
       const { address, amount, from, feeRate, balance } =
         pendingAction.displayData;
+      const btcChainID = this.networkService.isMainnet()
+        ? ChainId.BITCOIN
+        : ChainId.BITCOIN_TESTNET;
 
       const [network, networkError] = await resolve(
         this.networkService.getBitcoinNetwork()
@@ -266,16 +273,14 @@ export class BitcoinSendTransactionHandler extends DAppRequestHandler<
         throw new Error('Bitcoin network not found');
       }
 
-      const { inputs, outputs } = await buildBtcTx(
-        from,
-        getProviderForNetwork(network) as BitcoinProvider,
-        {
-          amount,
-          address,
-          token: balance,
-          feeRate,
-        }
-      );
+      const provider = getProviderForNetwork(network) as BitcoinProvider;
+
+      const { inputs, outputs } = await buildBtcTx(from, provider, {
+        amount,
+        address,
+        token: balance,
+        feeRate,
+      });
 
       if (!inputs || !outputs) {
         throw new Error('Unable to create transaction');
@@ -293,7 +298,23 @@ export class BitcoinSendTransactionHandler extends DAppRequestHandler<
       if (this.#isSupportedAccount(this.accountService.activeAccount)) {
         this.#getBalance(this.accountService.activeAccount);
       }
+
       onSuccess(hash);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      provider.waitForTx(hash).then((_tx) => {
+        measureTransactionTime().endMeasure(async (duration) => {
+          this.analyticsServicePosthog.captureEvent({
+            name: 'TransactionTimeToConfirmation',
+            windowId: crypto.randomUUID(),
+            properties: {
+              duration,
+              txType: 'txType',
+              chainId: btcChainID,
+            },
+          });
+        });
+      });
     } catch (e) {
       onError(e);
     }

--- a/src/background/services/wallet/handlers/eth_sendTransaction/eth_sendTransaction.test.ts
+++ b/src/background/services/wallet/handlers/eth_sendTransaction/eth_sendTransaction.test.ts
@@ -52,6 +52,17 @@ jest.mock('@src/background/services/analytics/utils/encryptAnalyticsData');
 jest.mock('./contracts/contractParsers/parseWithERC20Abi');
 jest.mock('./utils/getTxDescription');
 jest.mock('./contracts/contractParsers/utils/parseBasicDisplayValues');
+jest.mock(
+  '@src/background/services/wallet/utils/measureTransactionTime',
+  () => ({
+    measureTransactionTime: function () {
+      return {
+        startMeasure: jest.fn(),
+        endMeasure: jest.fn(),
+      };
+    },
+  })
+);
 jest.mock('./contracts/contractParsers/contractParserMap', () => ({
   contractParserMap: new Map([['function', jest.fn()]]),
 }));

--- a/src/background/services/wallet/handlers/eth_sendTransaction/eth_sendTransaction.ts
+++ b/src/background/services/wallet/handlers/eth_sendTransaction/eth_sendTransaction.ts
@@ -45,6 +45,7 @@ import { openApprovalWindow } from '@src/background/runtime/openApprovalWindow';
 import { EnsureDefined } from '@src/background/models';
 import { caipToChainId } from '@src/utils/caipConversion';
 import { TxDisplayOptions } from '../models';
+import { measureTransactionTime } from '@src/background/services/wallet/utils/measureTransactionTime';
 
 type TxPayload = EthSendTransactionParams | ContractTransaction;
 type Params = [TxPayload] | [TxPayload, TxDisplayOptions];
@@ -207,6 +208,7 @@ export class EthSendTransactionHandler extends DAppRequestHandler<
     tabId?: number | undefined
   ) => {
     try {
+      measureTransactionTime().startMeasure();
       const network = await getTargetNetworkForTx(
         pendingAction.displayData.txParams,
         this.networkService,
@@ -223,6 +225,7 @@ export class EthSendTransactionHandler extends DAppRequestHandler<
       const nonce = await provider.getTransactionCount(
         pendingAction.displayData.txParams.from
       );
+      const chainId = pendingAction.displayData.chainId;
 
       const {
         maxFeePerGas,
@@ -237,7 +240,7 @@ export class EthSendTransactionHandler extends DAppRequestHandler<
       const signingResult = await this.walletService.sign(
         {
           nonce,
-          chainId: Number(BigInt(pendingAction.displayData.chainId)),
+          chainId: Number(BigInt(chainId)),
           maxFeePerGas,
           maxPriorityFeePerGas,
           gasLimit: gasLimit,
@@ -296,11 +299,26 @@ export class EthSendTransactionHandler extends DAppRequestHandler<
           address: this.accountsService.activeAccount?.addressC,
           txHash,
           method: pendingAction.method,
-          chainId: pendingAction.displayData.chainId,
+          chainId,
         },
       });
 
       onSuccess(txHash);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      provider.waitForTransaction(txHash).then((_tx) => {
+        measureTransactionTime().endMeasure(async (duration) => {
+          this.analyticsServicePosthog.captureEvent({
+            name: 'TransactionTimeToConfirmation',
+            windowId: crypto.randomUUID(),
+            properties: {
+              duration,
+              txType: 'txType',
+              chainId,
+            },
+          });
+        });
+      });
     } catch (err: any) {
       const errorMessage: string =
         err instanceof Error ? err.message : err.toString();

--- a/src/background/services/wallet/utils/measureTransactionTime.ts
+++ b/src/background/services/wallet/utils/measureTransactionTime.ts
@@ -1,0 +1,32 @@
+enum TransactionTimeEvents {
+  TRANSACTION_TIMED = 'transaction-timed',
+  TRANSACTION_SUCCEEDED = 'transaction-succeeded',
+  TRANSACTION_APPROVED = 'transaction-approved',
+}
+
+export const measureTransactionTime = (): {
+  startMeasure: () => void;
+  endMeasure: (callback: (duration: number) => void) => void;
+} => {
+  const startMeasure = () => {
+    performance.mark(TransactionTimeEvents.TRANSACTION_APPROVED);
+  };
+
+  const endMeasure = (callback: (duration: number) => void) => {
+    performance.mark(TransactionTimeEvents.TRANSACTION_SUCCEEDED);
+
+    const measurement = performance.measure(
+      TransactionTimeEvents.TRANSACTION_TIMED,
+      TransactionTimeEvents.TRANSACTION_APPROVED,
+      TransactionTimeEvents.TRANSACTION_SUCCEEDED
+    );
+
+    performance.clearMarks(TransactionTimeEvents.TRANSACTION_APPROVED);
+    performance.clearMarks(TransactionTimeEvents.TRANSACTION_SUCCEEDED);
+    performance.clearMarks(TransactionTimeEvents.TRANSACTION_TIMED);
+
+    callback(measurement.duration);
+  };
+
+  return { startMeasure, endMeasure };
+};

--- a/src/tests/setupTests.ts
+++ b/src/tests/setupTests.ts
@@ -26,6 +26,8 @@ Object.defineProperty(global.document, 'prerendering', {
   value: false,
 });
 
+performance.mark = jest.fn();
+
 global.chrome = {
   runtime: {
     id: 'testid',


### PR DESCRIPTION
## Description
Described in issue: https://ava-labs.atlassian.net/browse/CP-8783

## Changes
Added new tracking event called `TransactionTimeToConfirmation` for successful token/nft sends, swaps, and bridge. There are no functional changes to the extension

## Testing
1. Do a smoke test of the transaction flows
2. To confirm the tx event, add the following snippet to the `captureTime` function while testing:
```
console.log('Capturing TransactionTimeToConfirmation', {
  chainId: chainId,
  time: measurement.duration,
  txOrigin: txType,
});
```

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [X] I've tested the changes myself before sending it to code review and QA.
