### PR TITLE
fix: handle newlines in address input

### DIFF
--- a/src/pages/Send/components/ContactInput.tsx
+++ b/src/pages/Send/components/ContactInput.tsx
@@ -205,7 +205,7 @@ export const ContactInput = ({
             multiline
             minRows={2}
             onChange={(e) => {
-              onChange(identifyAddress(e.target.value));
+              onChange(identifyAddress(e.target.value.trim()));
               setCursor(e.target.selectionStart);
             }}
             value={getInputDisplayValue()}


### PR DESCRIPTION
## Description
Described in: https://ava-labs.atlassian.net/browse/CP-8970

## Changes
Simply trims input within the `<ContactInput />` TextField. This brings it in parity with how the address input on core.app behaves. 

## Testing
1. Following the steps in the issue, attempt to prepend a newline to the input, then paste an address
2. Confirm the newline is trimmed and no Unknown or other errors occur
3. See the send form on core.app for comparison

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [X] I've tested the changes myself before sending it to code review and QA.
