### PR TITLE
fix: improve pasting p/x address in contact form

### DIFF
--- a/src/components/settings/components/ContactForm.tsx
+++ b/src/components/settings/components/ContactForm.tsx
@@ -142,6 +142,14 @@ export const ContactForm = ({
     setAddressXpError('');
   };
 
+  const sanitizeXPAddress = (address: string) => {
+    if (address.startsWith('P-') || address.startsWith('X-')) {
+      return address.substring(2, address.length);
+    } else {
+      return address;
+    }
+  };
+
   const handleUpdate = (name: keyof Contact, value: string) => {
     resetErrors();
 
@@ -211,6 +219,11 @@ export const ContactForm = ({
         onChange={(e) => {
           e.stopPropagation();
           handleUpdate('addressXP', e.target.value);
+        }}
+        onPaste={(e) => {
+          e.preventDefault();
+          const pastedAddress = e.clipboardData.getData('Text');
+          handleUpdate('addressXP', sanitizeXPAddress(pastedAddress));
         }}
         value={contact.addressXP}
         label={t('Avalanche (X/P-Chain) Address')}


### PR DESCRIPTION
## Description
Description in: https://ava-labs.atlassian.net/browse/CP-8558

## Changes
This implements the suggested solution in the linked issue by removing the X/P- address prefixes when pasting an address in to the new contact form

## Testing
Confirm by following the Steps to Reproduce in the issue and ensure that X/P- chain addresses are sanitized when pasting in to the X/P- address field in the new contact form. Ensure there is no sanitization upon manual entry

## Screenshots:
https://github.com/user-attachments/assets/0a6ed5e4-f3b9-48b9-9bc3-acd822b07000

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [X] I've tested the changes myself before sending it to code review and QA.
