### PR TITLE
fix: add extension key to e2e ci workflow so snapshots work

### DIFF
--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: Remove onboarding video
         run: |
           rm -fv ./dist/images/core-ext-hero-hq.webm
+      - name: Add extension key to manifest file
+        run: |
+          echo $(cat ./dist/manifest.json | jq '.key = "${{ secrets.EXTENSION_PUBLIC_KEY }}"') > ./dist/manifest.json
       - name: Generate a zip
         run: yarn zip
       - name: Output extension file version before renaming

--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -112,3 +112,31 @@ jobs:
         run: |
           echo $(head -n 1 testrail_run_id.txt)
           echo "TESTRAIL_RUN_ID=$(head -n 1 testrail_run_id.txt)" >> $GITHUB_ENV
+      - name: Success slack notification
+        if: success()
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "GH_RUN_LINK": "https://github.com/ava-labs/core-extension/actions/runs/${{ github.run_id }}",
+              "GH_RUN_STATUS": "PASSED",
+              "STATUS_EMOJI": ":white_check_mark:",
+              "TEST_RUN_TYPE": "Browser extension smoke tests are running against branch= ${{ github.head_ref }}",
+              "TR_RUN_LINK": "https://avalabs.testrail.io/index.php?/runs/view/${{ env.TESTRAIL_RUN_ID }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Failure slack notification
+        if: failure()
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "GH_RUN_LINK": "https://github.com/ava-labs/core-extension/actions/runs/${{ github.run_id }}",
+              "GH_RUN_STATUS": "FAILED",
+              "STATUS_EMOJI": ":alert:",
+              "TEST_RUN_TYPE": "Browser extension smoke tests are running against branch= ${{ github.head_ref }}",
+              "TR_RUN_LINK": "https://avalabs.testrail.io/index.php?/runs/view/${{ env.TESTRAIL_RUN_ID }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -13,15 +13,15 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     environment: alpha
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
       - name: Checkout extension
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
       - name: Create .npmrc
         run: echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}' >> .npmrc
       - name: Create env file
@@ -105,6 +105,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extension
+      - name: Show directory content
+        run: |
+          ls
       - name: Running browser extension smoke tests on testnet/mainnet against generated zip
         run: yarn ext:testnet/mainnet-smoke
       - if: always()
@@ -112,31 +115,3 @@ jobs:
         run: |
           echo $(head -n 1 testrail_run_id.txt)
           echo "TESTRAIL_RUN_ID=$(head -n 1 testrail_run_id.txt)" >> $GITHUB_ENV
-      - name: Success slack notification
-        if: success()
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          payload: |
-            {
-              "GH_RUN_LINK": "https://github.com/ava-labs/core-extension/actions/runs/${{ github.run_id }}",
-              "GH_RUN_STATUS": "PASSED",
-              "STATUS_EMOJI": ":white_check_mark:",
-              "TEST_RUN_TYPE": "Browser extension smoke tests are running against branch= ${{ github.head_ref }}",
-              "TR_RUN_LINK": "https://avalabs.testrail.io/index.php?/runs/view/${{ env.TESTRAIL_RUN_ID }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      - name: Failure slack notification
-        if: failure()
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          payload: |
-            {
-              "GH_RUN_LINK": "https://github.com/ava-labs/core-extension/actions/runs/${{ github.run_id }}",
-              "GH_RUN_STATUS": "FAILED",
-              "STATUS_EMOJI": ":alert:",
-              "TEST_RUN_TYPE": "Browser extension smoke tests are running against branch= ${{ github.head_ref }}",
-              "TR_RUN_LINK": "https://avalabs.testrail.io/index.php?/runs/view/${{ env.TESTRAIL_RUN_ID }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: Remove onboarding video
         run: |
           rm -fv ./dist/images/core-ext-hero-hq.webm
+      - name: Add extension key to manifest file
+        run: |
+          echo $(cat ./dist/manifest.json | jq '.key = "${{ secrets.EXTENSION_PUBLIC_KEY }}"') > ./dist/manifest.json
       - name: Generate a zip
         run: yarn zip
       - name: Output extension file version before renaming
@@ -102,9 +105,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extension
-      - name: Show directory content
-        run: |
-          ls
       - name: Running browser extension smoke tests on testnet/mainnet against generated zip
         run: yarn ext:testnet/mainnet-smoke
       - if: always()

--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -57,9 +57,6 @@ jobs:
       - name: Remove onboarding video
         run: |
           rm -fv ./dist/images/core-ext-hero-hq.webm
-      - name: Add extension key to manifest file
-        run: |
-          echo $(cat ./dist/manifest.json | jq '.key = "${{ secrets.EXTENSION_PUBLIC_KEY }}"') > ./dist/manifest.json
       - name: Generate a zip
         run: yarn zip
       - name: Output extension file version before renaming


### PR DESCRIPTION
## Description

The E2E smoke tests need to have the extension key added to the manifest file so that the extension ID is the expected ID after building. The local storage snapshots set at the beginning of tests need this to work properly (set testnet/mainnet, set active network etc).

✅  ~~**NOTE: Needs `EXTENSION_PUBLIC_KEY` to be added as a secret to this repo for this to work. Please let me know if the secret already exists and is named something else.**~~

## Changes

Adds command in e2e CI flow to add extension public key to manifest file after building extension

## Testing

This command currently works across all regression and smoke CI workflows in the test automation repo. Same command is being used here.

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
