### PR TITLE
fix: await tx broadcast requests

### DIFF
--- a/src/pages/Send/hooks/useSend/useAVMSend.ts
+++ b/src/pages/Send/hooks/useSend/useAVMSend.ts
@@ -155,7 +155,7 @@ export const useAvmSend: SendAdapterAVM = ({
           ),
         };
 
-        return request<AvalancheSendTransactionHandler>({
+        return await request<AvalancheSendTransactionHandler>({
           method: DAppProviderRequest.AVALANCHE_SEND_TRANSACTION,
           params,
         });

--- a/src/pages/Send/hooks/useSend/useBTCSend.ts
+++ b/src/pages/Send/hooks/useSend/useBTCSend.ts
@@ -100,7 +100,7 @@ export const useBtcSend: SendAdapterBTC = ({
         const amountBN = stringToBN(amount || '0', nativeToken.decimals);
         const amountInSatoshis = amountBN.toNumber();
 
-        return request<
+        return await request<
           BitcoinSendTransactionHandler,
           DAppProviderRequest.BITCOIN_SEND_TRANSACTION,
           string

--- a/src/pages/Send/hooks/useSend/usePVMSend.ts
+++ b/src/pages/Send/hooks/useSend/usePVMSend.ts
@@ -152,7 +152,7 @@ export const usePvmSend: SendAdapterPVM = ({
             utils.bufferToHex(utxo.toBytes(codec))
           ),
         };
-        return request<AvalancheSendTransactionHandler>({
+        return await request<AvalancheSendTransactionHandler>({
           method: DAppProviderRequest.AVALANCHE_SEND_TRANSACTION,
           params,
         });

--- a/src/utils/errors/errorHelpers.ts
+++ b/src/utils/errors/errorHelpers.ts
@@ -51,7 +51,7 @@ export const isUserRejectionError = (err: any) => {
   }
 
   if (typeof err === 'object') {
-    return err.message.startsWith('User rejected') || err.code === 4001;
+    return err.message?.startsWith('User rejected') || err.code === 4001;
   }
 
   return false;


### PR DESCRIPTION
## Description
_no ticket_

Issue found by @blockqa:
https://github.com/user-attachments/assets/2cbe6518-fc31-4a96-bbd7-3a35a0e49a81

## Changes

* Fixes error in error handling 😅 where we try to call `.startsWith()` on `error.message` which may not be present.
* Awaits `eth_sendTransaction` / `bitcoin_sendTransaction` / `avalanche_sendTransaction` calls so the loading state is properly displayed on send screen (otherwise it's set to `true` and then immediately back to `false` which does not disable the button)


## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
