### PR TITLE
fix: invisible no-thanks option

### DIFF
--- a/src/pages/Onboarding/pages/AnalyticsConsent.tsx
+++ b/src/pages/Onboarding/pages/AnalyticsConsent.tsx
@@ -132,7 +132,7 @@ export const AnalyticsConsent = () => {
         }}
         nextText={t('Unlock')}
         disableNext={false}
-        expand={onboardingPhase !== OnboardingPhase.CREATE_WALLET}
+        expand
         steps={getSteps.stepsNumber}
         activeStep={getSteps.activeStep}
       >
@@ -143,6 +143,7 @@ export const AnalyticsConsent = () => {
             stopDataCollection();
             setAnalyticsConsent(false);
           }}
+          disableRipple
           sx={{
             color: 'secondary',
           }}


### PR DESCRIPTION
## Description
* https://ava-labs.atlassian.net/browse/CP-9123

## Testing
* Go through onboarding with different wallet types, `No Thanks` option should always be visible on the analytics consent screen.

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
