### PR TITLE
fix: alt+shift+b shortcut

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -8,7 +8,7 @@
   "description": "Your home for Avalanche (AVAX) and beyond.",
   "default_locale": "en",
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
         "windows": "Alt+Shift+B",
         "mac": "Alt+Shift+B",


### PR DESCRIPTION
## Description

Gets rid of the error being reported every time extension boots up:

https://github.com/user-attachments/assets/3fd5b4b0-9b46-4310-a913-66f94023618d

☝️ This should be no more. Also fixes `Alt+Shift+B` shortcut I never used ¯\\\_(ツ)_/¯ 

## Changes
* Updates `manifest.json` to use the proper command name: `_execute_action` instead of `_execute_browser_action`:
    * [Reference](https://developer.chrome.com/docs/extensions/reference/api/commands#action_commands)

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
