### PR TITLE
fix: treat BTC as known network

### DIFF
--- a/src/background/services/network/NetworkService.test.ts
+++ b/src/background/services/network/NetworkService.test.ts
@@ -147,25 +147,7 @@ describe('background/services/network/NetworkService', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    jest.mocked(getChainsAndTokens).mockResolvedValue({
-      // [43114]: {
-      //   chainName: 'test chain x',
-      //   chainId: 123,
-      //   vmName: NetworkVMType.EVM,
-      //   rpcUrl: 'https://rpcurl.example',
-      //   explorerUrl: 'https://explorer.url',
-      //   networkToken: {
-      //     name: 'test network token',
-      //     symbol: 'TNT',
-      //     description: '',
-      //     decimals: 18,
-      //     logoUri: '',
-      //   },
-      //   logoUri: '',
-      //   primaryColor: 'blue',
-      //   isTestnet: false,
-      // },
-    });
+    jest.mocked(getChainsAndTokens).mockResolvedValue({});
 
     jest.mocked(FetchRequest).mockImplementation((url) => ({ url } as any));
     mockChainList(service);
@@ -208,7 +190,7 @@ describe('background/services/network/NetworkService', () => {
         .mockResolvedValueOnce(chainlist);
 
       await service.init();
-      await service.setNetwork(runtime.id, leetNetwork.chainId);
+      await service.setNetwork(runtime.id, leetNetwork.caipId);
 
       const network = await service.getInitialNetworkForDapp('test.app');
 
@@ -223,7 +205,7 @@ describe('background/services/network/NetworkService', () => {
         .mockResolvedValueOnce(chainlist);
 
       await service.init();
-      await service.setNetwork(runtime.id, btcNetwork.chainId);
+      await service.setNetwork(runtime.id, btcNetwork.caipId);
 
       const network = await service.getInitialNetworkForDapp('core.app');
 
@@ -238,7 +220,7 @@ describe('background/services/network/NetworkService', () => {
         .mockResolvedValueOnce(chainlist);
 
       await service.init();
-      await service.setNetwork(runtime.id, btcNetwork.chainId);
+      await service.setNetwork(runtime.id, btcNetwork.caipId);
 
       const network = await service.getInitialNetworkForDapp('test.app');
 
@@ -267,10 +249,8 @@ describe('background/services/network/NetworkService', () => {
       storageServiceMock.save.mockResolvedValue();
     });
 
-    // it('defaults to saved config instead of accepting');
-
     it('persists current network for given domain', async () => {
-      await service.setNetwork('test.app', ethMainnet.chainId);
+      await service.setNetwork('test.app', ethMainnet.caipId);
 
       expect(storageServiceMock.save).toHaveBeenCalledWith(
         NETWORK_STORAGE_KEY,
@@ -287,7 +267,7 @@ describe('background/services/network/NetworkService', () => {
 
       service.dappScopeChanged.addOnce(listener);
 
-      await service.setNetwork('test.app', ethMainnet.chainId);
+      await service.setNetwork('test.app', ethMainnet.caipId);
 
       expect(listener).toHaveBeenCalledWith({
         domain: 'test.app',
@@ -303,7 +283,7 @@ describe('background/services/network/NetworkService', () => {
         );
         mockChainList(service);
         // Set Ethereum Mainnet directly for the frontend
-        await service.setNetwork(runtime.id, ethMainnet.chainId);
+        await service.setNetwork(runtime.id, ethMainnet.caipId);
         expect(service.uiActiveNetwork).toEqual(ethMainnet);
       });
 
@@ -311,7 +291,7 @@ describe('background/services/network/NetworkService', () => {
         storageServiceMock.load.mockResolvedValueOnce({
           [runtime.id]: sepolia.caipId,
         });
-        await service.setNetwork('app.uniswap.io', sepolia.chainId);
+        await service.setNetwork('app.uniswap.io', sepolia.caipId);
         expect(storageServiceMock.save).toHaveBeenCalledWith(
           NETWORK_STORAGE_KEY,
           expect.objectContaining({
@@ -326,7 +306,7 @@ describe('background/services/network/NetworkService', () => {
         storageServiceMock.load.mockResolvedValueOnce({
           [runtime.id]: sepolia.caipId,
         });
-        await service.setNetwork('app.uniswap.io', sepolia.chainId);
+        await service.setNetwork('app.uniswap.io', sepolia.caipId);
         expect(service.uiActiveNetwork).toEqual(sepolia);
         expect(storageServiceMock.save).toHaveBeenCalledWith(
           NETWORK_STORAGE_KEY,
@@ -344,7 +324,7 @@ describe('background/services/network/NetworkService', () => {
 
         service.developerModeChanged.addOnce(onDevModeChange);
 
-        await service.setNetwork('app.uniswap.io', sepolia.chainId);
+        await service.setNetwork('app.uniswap.io', sepolia.caipId);
         expect(service.uiActiveNetwork).toEqual(sepolia);
 
         expect(onDevModeChange).toHaveBeenCalledWith(true);
@@ -353,7 +333,7 @@ describe('background/services/network/NetworkService', () => {
 
     describe('when changing network for synchronized dApps', () => {
       it('uses the extension ID as domain', async () => {
-        await service.setNetwork('core.app', ethMainnet.chainId);
+        await service.setNetwork('core.app', ethMainnet.caipId);
 
         expect(storageServiceMock.save).toHaveBeenCalledWith(
           NETWORK_STORAGE_KEY,
@@ -373,11 +353,11 @@ describe('background/services/network/NetworkService', () => {
           })
         );
         // Set Ethereum directly for the frontend
-        await service.setNetwork(runtime.id, ethMainnet.chainId);
+        await service.setNetwork(runtime.id, ethMainnet.caipId);
         expect(service.uiActiveNetwork).toEqual(ethMainnet);
 
         // Set C-Chain for core.app and expect it to change also for the extension UI
-        await service.setNetwork('core.app', avaxMainnet.chainId);
+        await service.setNetwork('core.app', avaxMainnet.caipId);
         expect(service.uiActiveNetwork).toEqual(avaxMainnet);
       });
 
@@ -391,7 +371,7 @@ describe('background/services/network/NetworkService', () => {
           })
         );
 
-        await service.setNetwork('core.app', ethMainnet.chainId);
+        await service.setNetwork('core.app', ethMainnet.caipId);
 
         expect(listener).toHaveBeenCalledWith({
           domain: runtime.id,
@@ -410,6 +390,7 @@ describe('background/services/network/NetworkService', () => {
     it('saves custom RPC headers', async () => {
       const overrides = {
         chainId: 1337,
+        caipId: 'eip155:1337',
         customRpcHeaders: {
           'X-Glacier-Api-Key': 'my-elite-api-key',
         },
@@ -458,7 +439,7 @@ describe('background/services/network/NetworkService', () => {
         })
       );
 
-      await networkService.setNetwork(runtime.id, activeNetwork.chainId);
+      await networkService.setNetwork(runtime.id, activeNetwork.caipId);
 
       await networkService.updateNetworkOverrides({
         caipId: 'eip155:1337',

--- a/src/background/services/network/NetworkService.ts
+++ b/src/background/services/network/NetworkService.ts
@@ -149,18 +149,25 @@ export class NetworkService implements OnLock, OnStorageReady {
     );
   }
 
-  async setNetwork(domain: string, selectedNetwork: NetworkWithCaipId) {
+  async setNetwork(domain: string, chainId: number) {
     const isSynced = isSyncDomain(domain);
+    // For supported networks, use config from saved chainlist
+    // instead of relying on payload that may come from a 3rd party:
+    const targetNetwork = await this.getNetwork(chainId);
+    if (!targetNetwork) {
+      throw new Error(`Network not found: ${chainId}`);
+    }
+
     const changesEnvironment =
       Boolean(this._uiActiveNetwork?.isTestnet) !==
-      Boolean(selectedNetwork.isTestnet);
+      Boolean(targetNetwork.isTestnet);
 
     if (isSynced || changesEnvironment) {
-      this.uiActiveNetwork = selectedNetwork;
+      this.uiActiveNetwork = targetNetwork;
     }
 
     // Save scope for requesting dApp
-    await this.#updateDappScopes({ [domain]: selectedNetwork.caipId });
+    await this.#updateDappScopes({ [domain]: targetNetwork.caipId });
 
     // If change resulted in an environment switch, also notify other dApps
     if (changesEnvironment) {
@@ -173,7 +180,7 @@ export class NetworkService implements OnLock, OnStorageReady {
           .map(([savedDomain]) => [
             savedDomain,
             chainIdToCaip(
-              selectedNetwork.isTestnet
+              targetNetwork.isTestnet
                 ? ChainId.AVALANCHE_TESTNET_ID
                 : ChainId.AVALANCHE_MAINNET_ID
             ),
@@ -679,7 +686,7 @@ export class NetworkService implements OnLock, OnStorageReady {
       );
 
       if (network) {
-        await this.setNetwork(runtime.id, network);
+        await this.setNetwork(runtime.id, network.chainId);
       }
     }
 

--- a/src/background/services/network/NetworkService.ts
+++ b/src/background/services/network/NetworkService.ts
@@ -149,13 +149,13 @@ export class NetworkService implements OnLock, OnStorageReady {
     );
   }
 
-  async setNetwork(domain: string, chainId: number) {
+  async setNetwork(domain: string, caipId: string) {
     const isSynced = isSyncDomain(domain);
     // For supported networks, use config from saved chainlist
     // instead of relying on payload that may come from a 3rd party:
-    const targetNetwork = await this.getNetwork(chainId);
+    const targetNetwork = await this.getNetwork(caipId);
     if (!targetNetwork) {
-      throw new Error(`Network not found: ${chainId}`);
+      throw new Error(`Network not found: ${caipId}`);
     }
 
     const changesEnvironment =
@@ -686,7 +686,7 @@ export class NetworkService implements OnLock, OnStorageReady {
       );
 
       if (network) {
-        await this.setNetwork(runtime.id, network.chainId);
+        await this.setNetwork(runtime.id, network.caipId);
       }
     }
 

--- a/src/background/services/network/handlers/avalanche_setDeveloperMode.ts
+++ b/src/background/services/network/handlers/avalanche_setDeveloperMode.ts
@@ -7,6 +7,7 @@ import { NetworkService } from '../NetworkService';
 import { ethErrors } from 'eth-rpc-errors';
 import { openApprovalWindow } from '@src/background/runtime/openApprovalWindow';
 import { ChainId } from '@avalabs/core-chains-sdk';
+import { chainIdToCaip } from '@src/utils/caipConversion';
 
 @injectable()
 export class AvalancheSetDeveloperModeHandler extends DAppRequestHandler {
@@ -73,7 +74,11 @@ export class AvalancheSetDeveloperModeHandler extends DAppRequestHandler {
 
       await this.networkService.setNetwork(
         domain,
-        isTestmode ? ChainId.AVALANCHE_TESTNET_ID : ChainId.AVALANCHE_MAINNET_ID
+        chainIdToCaip(
+          isTestmode
+            ? ChainId.AVALANCHE_TESTNET_ID
+            : ChainId.AVALANCHE_MAINNET_ID
+        )
       );
 
       onSuccess(null);

--- a/src/background/services/network/handlers/avalanche_setDeveloperMode.ts
+++ b/src/background/services/network/handlers/avalanche_setDeveloperMode.ts
@@ -71,15 +71,10 @@ export class AvalancheSetDeveloperModeHandler extends DAppRequestHandler {
         throw new Error('Unrecognized domain');
       }
 
-      const network = await this.networkService.getNetwork(
+      await this.networkService.setNetwork(
+        domain,
         isTestmode ? ChainId.AVALANCHE_TESTNET_ID : ChainId.AVALANCHE_MAINNET_ID
       );
-
-      if (!network) {
-        throw new Error('Target network not found');
-      }
-
-      await this.networkService.setNetwork(domain, network);
 
       onSuccess(null);
     } catch (e) {

--- a/src/background/services/network/handlers/saveCustomNetwork.ts
+++ b/src/background/services/network/handlers/saveCustomNetwork.ts
@@ -50,7 +50,7 @@ export class SaveCustomNetworkHandler implements HandlerType {
       };
     }
 
-    await this.networkService.setNetwork(runtime.id, addedNetwork.chainId);
+    await this.networkService.setNetwork(runtime.id, addedNetwork.caipId);
 
     return {
       ...request,

--- a/src/background/services/network/handlers/saveCustomNetwork.ts
+++ b/src/background/services/network/handlers/saveCustomNetwork.ts
@@ -1,10 +1,10 @@
 import { ExtensionRequest } from '@src/background/connections/extensionConnection/models';
 import { ExtensionRequestHandler } from '@src/background/connections/models';
-import { resolve } from '@src/utils/promiseResolver';
 import { injectable } from 'tsyringe';
 import { NetworkService } from '../NetworkService';
 import { CustomNetworkPayload } from '../models';
 import { runtime } from 'webextension-polyfill';
+import { resolve } from '@avalabs/core-utils-sdk';
 
 type HandlerType = ExtensionRequestHandler<
   ExtensionRequest.NETWORK_SAVE_CUSTOM,
@@ -43,14 +43,14 @@ export class SaveCustomNetworkHandler implements HandlerType {
       this.networkService.saveCustomNetwork(network)
     );
 
-    if (err) {
+    if (err || !addedNetwork) {
       return {
         ...request,
-        error: err.toString(),
+        error: err?.toString() ?? 'Adding custom network failed',
       };
     }
 
-    await this.networkService.setNetwork(runtime.id, addedNetwork);
+    await this.networkService.setNetwork(runtime.id, addedNetwork.chainId);
 
     return {
       ...request,

--- a/src/background/services/network/handlers/setActiveNetwork.ts
+++ b/src/background/services/network/handlers/setActiveNetwork.ts
@@ -6,6 +6,7 @@ import { ExtensionRequest } from '@src/background/connections/extensionConnectio
 import { ExtensionRequestHandler } from '@src/background/connections/models';
 
 import { NetworkService } from '../NetworkService';
+import { caipToChainId } from '@src/utils/caipConversion';
 
 type HandlerType = ExtensionRequestHandler<
   ExtensionRequest.NETWORK_SET_ACTIVE,
@@ -21,19 +22,8 @@ export class SetActiveNetworkHandler implements HandlerType {
 
   handle: HandlerType['handle'] = async ({ request }) => {
     const [scope] = request.params;
-    const [network, networkErr] = await resolve(
-      this.networkService.getNetwork(scope)
-    );
-
-    if (networkErr || !network) {
-      return {
-        ...request,
-        error: 'Ttarget network not found',
-      };
-    }
-
     const [, err] = await resolve(
-      this.networkService.setNetwork(runtime.id, network)
+      this.networkService.setNetwork(runtime.id, caipToChainId(scope))
     );
 
     if (err) {

--- a/src/background/services/network/handlers/setActiveNetwork.ts
+++ b/src/background/services/network/handlers/setActiveNetwork.ts
@@ -6,7 +6,6 @@ import { ExtensionRequest } from '@src/background/connections/extensionConnectio
 import { ExtensionRequestHandler } from '@src/background/connections/models';
 
 import { NetworkService } from '../NetworkService';
-import { caipToChainId } from '@src/utils/caipConversion';
 
 type HandlerType = ExtensionRequestHandler<
   ExtensionRequest.NETWORK_SET_ACTIVE,
@@ -23,7 +22,7 @@ export class SetActiveNetworkHandler implements HandlerType {
   handle: HandlerType['handle'] = async ({ request }) => {
     const [scope] = request.params;
     const [, err] = await resolve(
-      this.networkService.setNetwork(runtime.id, caipToChainId(scope))
+      this.networkService.setNetwork(runtime.id, scope)
     );
 
     if (err) {

--- a/src/background/services/network/handlers/setDeveloperMode.ts
+++ b/src/background/services/network/handlers/setDeveloperMode.ts
@@ -7,6 +7,7 @@ import { ExtensionRequestHandler } from '@src/background/connections/models';
 import { resolve } from '@src/utils/promiseResolver';
 
 import { NetworkService } from '../NetworkService';
+import { chainIdToCaip } from '@src/utils/caipConversion';
 
 type HandlerType = ExtensionRequestHandler<
   ExtensionRequest.NETWORK_SET_DEVELOPER_MODE,
@@ -25,9 +26,11 @@ export class SetDevelopermodeNetworkHandler implements HandlerType {
     const [, err] = await resolve(
       this.networkService.setNetwork(
         runtime.id,
-        enableDeveloperMode
-          ? ChainId.AVALANCHE_TESTNET_ID
-          : ChainId.AVALANCHE_MAINNET_ID
+        chainIdToCaip(
+          enableDeveloperMode
+            ? ChainId.AVALANCHE_TESTNET_ID
+            : ChainId.AVALANCHE_MAINNET_ID
+        )
       )
     );
 

--- a/src/background/services/network/handlers/setDeveloperMode.ts
+++ b/src/background/services/network/handlers/setDeveloperMode.ts
@@ -22,19 +22,13 @@ export class SetDevelopermodeNetworkHandler implements HandlerType {
 
   handle: HandlerType['handle'] = async ({ request }) => {
     const [enableDeveloperMode] = request.params;
-
-    const network = await this.networkService.getNetwork(
-      enableDeveloperMode
-        ? ChainId.AVALANCHE_TESTNET_ID
-        : ChainId.AVALANCHE_MAINNET_ID
-    );
-
-    if (!network) {
-      throw new Error('Target network not found');
-    }
-
     const [, err] = await resolve(
-      this.networkService.setNetwork(runtime.id, network)
+      this.networkService.setNetwork(
+        runtime.id,
+        enableDeveloperMode
+          ? ChainId.AVALANCHE_TESTNET_ID
+          : ChainId.AVALANCHE_MAINNET_ID
+      )
     );
 
     if (err) {

--- a/src/background/services/network/handlers/wallet_addEthereumChain.test.ts
+++ b/src/background/services/network/handlers/wallet_addEthereumChain.test.ts
@@ -105,30 +105,7 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
         },
       ],
     };
-    const supportedNetwork = {
-      caipId: 'eip155:43113',
-      chainId: 43113,
-      chainName: 'Avalanche',
-      vmName: NetworkVMType.EVM,
-      primaryColor: 'black',
-      rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
-      explorerUrl: 'https://snowtrace.io/',
-      logoUri: '',
-      networkToken: {
-        symbol: 'AVAX',
-        decimals: 18,
-        description: '',
-        name: 'AVAX',
-        logoUri: '',
-      },
-      isTestnet: false,
-    };
-
-    jest
-      .mocked(mockNetworkService.getNetwork)
-      .mockResolvedValueOnce(mockActiveNetwork as any)
-      .mockResolvedValueOnce(supportedNetwork);
-
+    openExtensionNewWindow;
     const result = await handler.handleUnauthenticated(buildRpcCall(request));
 
     expect(openExtensionNewWindow).toHaveBeenCalledTimes(1);
@@ -141,7 +118,24 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
       actionId: 'uuid',
       scope: 'eip155:43113',
       displayData: {
-        network: supportedNetwork,
+        network: {
+          caipId: 'eip155:43113',
+          chainId: 43113,
+          chainName: 'Avalanche',
+          vmName: NetworkVMType.EVM,
+          primaryColor: 'black',
+          rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+          explorerUrl: 'https://snowtrace.io/',
+          logoUri: '',
+          networkToken: {
+            symbol: 'AVAX',
+            decimals: 18,
+            description: '',
+            name: 'AVAX',
+            logoUri: '',
+          },
+          isTestnet: false,
+        },
       },
       popupWindowId: 123,
     });
@@ -542,29 +536,25 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
   it('does not opens approval dialog and switch to a known network if the request is from core web', async () => {
     jest.mocked(isCoreWeb).mockResolvedValue(true);
 
-    const supportedNetwork = {
-      chainId: '0xa869', // 43113
-      chainName: 'Avalanche',
-      nativeCurrency: { name: 'AVAX', symbol: 'AVAX', decimals: 18 },
-      rpcUrls: ['https://api.avax.network/ext/bc/C/rpc'],
-      blockExplorerUrls: ['https://snowtrace.io/'],
-      iconUrls: ['logo.png'],
-    };
     const request = {
       id: '852',
       method: DAppProviderRequest.WALLET_ADD_CHAIN,
-      params: [supportedNetwork],
+      params: [
+        {
+          chainId: '0xa869', // 43113
+          chainName: 'Avalanche',
+          nativeCurrency: { name: 'AVAX', symbol: 'AVAX', decimals: 18 },
+          rpcUrls: ['https://api.avax.network/ext/bc/C/rpc'],
+          blockExplorerUrls: ['https://snowtrace.io/'],
+          iconUrls: ['logo.png'],
+        },
+      ],
       site: {
         domain: 'core.app',
         name: 'Core',
         tabId: 123,
       },
     };
-
-    jest
-      .mocked(mockNetworkService.getNetwork)
-      .mockResolvedValueOnce(mockActiveNetwork as any)
-      .mockResolvedValueOnce(supportedNetwork as any);
 
     const result = await handler.handleAuthenticated(buildRpcCall(request));
 
@@ -578,7 +568,7 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
     expect(mockNetworkService.setNetwork).toHaveBeenCalledTimes(1);
     expect(mockNetworkService.setNetwork).toHaveBeenCalledWith(
       'core.app',
-      supportedNetwork
+      43113
     );
   });
 
@@ -795,7 +785,7 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
 
       expect(mockNetworkService.setNetwork).toHaveBeenCalledWith(
         mockPendingAction.site?.domain,
-        mockPendingAction.displayData.network
+        mockPendingAction.displayData.network.chainId
       );
       expect(mockNetworkService.saveCustomNetwork).toHaveBeenCalledTimes(1);
       expect(mockNetworkService.saveCustomNetwork).toHaveBeenCalledWith({
@@ -858,7 +848,7 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
       expect(mockNetworkService.saveCustomNetwork).not.toHaveBeenCalled();
       expect(mockNetworkService.setNetwork).toHaveBeenCalledWith(
         mockPendingAction.site?.domain,
-        network
+        network.chainId
       );
 
       expect(successHandler).toHaveBeenCalledTimes(1);

--- a/src/background/services/network/handlers/wallet_addEthereumChain.test.ts
+++ b/src/background/services/network/handlers/wallet_addEthereumChain.test.ts
@@ -568,7 +568,7 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
     expect(mockNetworkService.setNetwork).toHaveBeenCalledTimes(1);
     expect(mockNetworkService.setNetwork).toHaveBeenCalledWith(
       'core.app',
-      43113
+      'eip155:43113'
     );
   });
 
@@ -785,7 +785,7 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
 
       expect(mockNetworkService.setNetwork).toHaveBeenCalledWith(
         mockPendingAction.site?.domain,
-        mockPendingAction.displayData.network.chainId
+        mockPendingAction.displayData.network.caipId
       );
       expect(mockNetworkService.saveCustomNetwork).toHaveBeenCalledTimes(1);
       expect(mockNetworkService.saveCustomNetwork).toHaveBeenCalledWith({
@@ -828,6 +828,7 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
       const network = {
         ...mockPendingAction.displayData.network,
         chainId: 43113,
+        caipId: 'eip155:43113',
       };
 
       await handler.onActionApproved(
@@ -848,7 +849,7 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
       expect(mockNetworkService.saveCustomNetwork).not.toHaveBeenCalled();
       expect(mockNetworkService.setNetwork).toHaveBeenCalledWith(
         mockPendingAction.site?.domain,
-        network.chainId
+        network.caipId
       );
 
       expect(successHandler).toHaveBeenCalledTimes(1);
@@ -871,6 +872,7 @@ describe('background/services/network/handlers/wallet_addEthereumChain.ts', () =
             network: {
               ...mockPendingAction.displayData.network,
               chainId: 43113,
+              caipId: 'eip155:43113',
             },
             options: {
               requiresGlacierApiKey: false,

--- a/src/background/services/network/handlers/wallet_addEthereumChain.ts
+++ b/src/background/services/network/handlers/wallet_addEthereumChain.ts
@@ -188,7 +188,7 @@ export class WalletAddEthereumChainHandler extends DAppRequestHandler {
       await this.networkService.saveCustomNetwork(network);
     }
 
-    await this.networkService.setNetwork(domain, network.chainId);
+    await this.networkService.setNetwork(domain, network.caipId);
   }
 
   onActionApproved = async (

--- a/src/background/services/network/handlers/wallet_addEthereumChain.ts
+++ b/src/background/services/network/handlers/wallet_addEthereumChain.ts
@@ -118,14 +118,8 @@ export class WalletAddEthereumChainHandler extends DAppRequestHandler {
     }
     const skipApproval = await isCoreWeb(request);
 
-    const targetNetwork = chainRequestedIsSupported
-      ? ((await this.networkService.getNetwork(
-          requestedChainId
-        )) as NetworkWithCaipId)
-      : customNetwork;
-
     if (skipApproval) {
-      await this.actionHandler(chains, targetNetwork, request.site.domain);
+      await this.actionHandler(chains, customNetwork, request.site.domain);
       return { ...request, result: null };
     }
 
@@ -134,7 +128,7 @@ export class WalletAddEthereumChainHandler extends DAppRequestHandler {
         ...request,
         scope,
         displayData: {
-          network: targetNetwork,
+          network: customNetwork,
         },
       };
 
@@ -194,7 +188,7 @@ export class WalletAddEthereumChainHandler extends DAppRequestHandler {
       await this.networkService.saveCustomNetwork(network);
     }
 
-    await this.networkService.setNetwork(domain, network);
+    await this.networkService.setNetwork(domain, network.chainId);
   }
 
   onActionApproved = async (

--- a/src/background/services/network/handlers/wallet_addEthereumChain.ts
+++ b/src/background/services/network/handlers/wallet_addEthereumChain.ts
@@ -118,8 +118,14 @@ export class WalletAddEthereumChainHandler extends DAppRequestHandler {
     }
     const skipApproval = await isCoreWeb(request);
 
+    const targetNetwork = chainRequestedIsSupported
+      ? ((await this.networkService.getNetwork(
+          requestedChainId
+        )) as NetworkWithCaipId)
+      : customNetwork;
+
     if (skipApproval) {
-      await this.actionHandler(chains, customNetwork, request.site.domain);
+      await this.actionHandler(chains, targetNetwork, request.site.domain);
       return { ...request, result: null };
     }
 
@@ -128,7 +134,7 @@ export class WalletAddEthereumChainHandler extends DAppRequestHandler {
         ...request,
         scope,
         displayData: {
-          network: customNetwork,
+          network: targetNetwork,
         },
       };
 

--- a/src/background/services/network/handlers/wallet_switchEthereumChain.ts
+++ b/src/background/services/network/handlers/wallet_switchEthereumChain.ts
@@ -55,7 +55,7 @@ export class WalletSwitchEthereumChainHandler extends DAppRequestHandler {
       if (skipApproval) {
         await this.networkService.setNetwork(
           request.site.domain,
-          supportedNetwork
+          supportedNetwork.chainId
         );
         return { ...request, result: null };
       }
@@ -98,7 +98,7 @@ export class WalletSwitchEthereumChainHandler extends DAppRequestHandler {
     try {
       await this.networkService.setNetwork(
         pendingAction.site.domain,
-        pendingAction.displayData.network
+        pendingAction.displayData.network.chainId
       );
 
       onSuccess(null);

--- a/src/background/services/network/handlers/wallet_switchEthereumChain.ts
+++ b/src/background/services/network/handlers/wallet_switchEthereumChain.ts
@@ -55,7 +55,7 @@ export class WalletSwitchEthereumChainHandler extends DAppRequestHandler {
       if (skipApproval) {
         await this.networkService.setNetwork(
           request.site.domain,
-          supportedNetwork.chainId
+          supportedNetwork.caipId
         );
         return { ...request, result: null };
       }
@@ -98,7 +98,7 @@ export class WalletSwitchEthereumChainHandler extends DAppRequestHandler {
     try {
       await this.networkService.setNetwork(
         pendingAction.site.domain,
-        pendingAction.displayData.network.chainId
+        pendingAction.displayData.network.caipId
       );
 
       onSuccess(null);

--- a/src/background/services/onboarding/finalizeOnboarding.ts
+++ b/src/background/services/onboarding/finalizeOnboarding.ts
@@ -27,7 +27,7 @@ export async function finalizeOnboarding({
   await networkService.addFavoriteNetwork(ChainId.ETHEREUM_HOMESTEAD);
 
   const cChain = await networkService.getAvalancheNetwork();
-  await networkService.setNetwork(runtime.id, cChain.chainId);
+  await networkService.setNetwork(runtime.id, cChain.caipId);
 
   const allAccounts = accountsService.getAccounts();
   const addedAccounts = allAccounts.primary[walletId];

--- a/src/background/services/onboarding/finalizeOnboarding.ts
+++ b/src/background/services/onboarding/finalizeOnboarding.ts
@@ -26,10 +26,8 @@ export async function finalizeOnboarding({
   await networkService.addFavoriteNetwork(ChainId.BITCOIN);
   await networkService.addFavoriteNetwork(ChainId.ETHEREUM_HOMESTEAD);
 
-  await networkService.setNetwork(
-    runtime.id,
-    await networkService.getAvalancheNetwork()
-  );
+  const cChain = await networkService.getAvalancheNetwork();
+  await networkService.setNetwork(runtime.id, cChain.chainId);
 
   const allAccounts = accountsService.getAccounts();
   const addedAccounts = allAccounts.primary[walletId];


### PR DESCRIPTION
## Description
* [CP-9154](https://ava-labs.atlassian.net/browse/CP-9154)

## Changes
* When network is already supported by the extension, do not use the request's payload, but rather resolve the network object via `NetworkService` and use that instead.

## Testing
1. Open extension, switch to C-Chain, go to Send
2. Connect to Core Web
3. Switch to Bitcoin _**via Core Web**_
4. Open extension again, you should not see `Unknown error`

## Screenshots:
### Before

https://github.com/user-attachments/assets/e8f54b13-4318-47ec-abf0-f49eaaf2e601

### After

https://github.com/user-attachments/assets/685504c9-72c0-4fe7-b124-b0e0f24ba267


<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
