### PR TITLE
fix: CP-9334 add network page padding

### DIFF
--- a/src/pages/Networks/AddNetwork.tsx
+++ b/src/pages/Networks/AddNetwork.tsx
@@ -114,10 +114,10 @@ export const AddNetwork = () => {
   };
 
   return (
-    <Stack sx={{ width: 1, px: 2 }}>
-      <PageTitle margin="8 0 12px">{t('Add Network')}</PageTitle>
+    <Stack sx={{ width: 1 }}>
+      <PageTitle>{t('Add Network')}</PageTitle>
       <FlexScrollbars ref={scrollbarRef}>
-        <Stack sx={{ gap: 1 }}>
+        <Stack sx={{ gap: 1, px: 2 }}>
           {errorMessage && (
             <Typography
               variant="body2"
@@ -143,6 +143,7 @@ export const AddNetwork = () => {
           alignItems: 'center',
           py: 3,
           gap: 1,
+          px: 2,
         }}
       >
         <Button


### PR DESCRIPTION
## Description

Some padding issues in the Add Network page.

## Changes

Fixed X Axis paddings

## Testing

Go to the ADd network page and it should look like as the Edit Network (spacing wise).

## Screenshots:

<img width="428" alt="image" src="https://github.com/user-attachments/assets/81ef8f31-b60f-4b14-b6ce-bf0e58ad5607">


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
