### PR TITLE
fix: CP-9331 add avacloud to whitelist

### DIFF
--- a/src/background/services/accounts/handlers/avalanche_getAddressesInRange.test.ts
+++ b/src/background/services/accounts/handlers/avalanche_getAddressesInRange.test.ts
@@ -35,12 +35,12 @@ describe('background/services/accounts/handlers/avalanche_getAddressesInRange.ts
     return handler.handleAuthenticated(request);
   };
 
-  const getPayload = (payload) =>
+  const getPayload = (payload, domain = 'core.app') =>
     ({
       id: '1234',
       method: DAppProviderRequest.AVALANCHE_GET_ADDRESSES_IN_RANGE,
       site: {
-        domain: 'core.app',
+        domain,
         tabId: 3,
       },
       ...payload,
@@ -143,6 +143,21 @@ describe('background/services/accounts/handlers/avalanche_getAddressesInRange.ts
             }),
           }),
           'getAddressesInRange'
+        );
+      });
+
+      it('should call `canSkipApproval` with whitelisted domains', async () => {
+        const EXPOSED_DOMAINS = [
+          'develop.avacloud-app.pages.dev',
+          'avacloud.io',
+          'staging--ava-cloud.avacloud-app.pages.dev',
+        ];
+        const request = getPayload({ params: [0, 0, 2, 2] });
+        await handleRequest(buildRpcCall(request));
+        expect(canSkipApproval).toHaveBeenCalledWith(
+          'core.app',
+          3,
+          EXPOSED_DOMAINS
         );
       });
 

--- a/src/background/services/accounts/handlers/avalanche_getAddressesInRange.ts
+++ b/src/background/services/accounts/handlers/avalanche_getAddressesInRange.ts
@@ -22,6 +22,12 @@ type Params = [
 ];
 import { AccountsService } from '../AccountsService';
 
+const EXPOSED_DOMAINS = [
+  'develop.avacloud-app.pages.dev',
+  'avacloud.io',
+  'staging--ava-cloud.avacloud-app.pages.dev',
+];
+
 @injectable()
 export class AvalancheGetAddressesInRangeHandler extends DAppRequestHandler<
   Params,
@@ -140,7 +146,13 @@ export class AvalancheGetAddressesInRangeHandler extends DAppRequestHandler<
         externalLimit: correctedExternalLimit,
       });
 
-      if (await canSkipApproval(request.site.domain, request.site.tabId)) {
+      if (
+        await canSkipApproval(
+          request.site.domain,
+          request.site.tabId,
+          EXPOSED_DOMAINS
+        )
+      ) {
         return {
           ...request,
           result: addresses,

--- a/src/background/services/network/utils/getSyncDomain.ts
+++ b/src/background/services/network/utils/getSyncDomain.ts
@@ -7,6 +7,7 @@ const SYNCED_DOMAINS = [
   runtime.id,
   'develop.avacloud-app.pages.dev',
   'avacloud.io',
+  'staging--ava-cloud.avacloud-app.pages.dev',
 ];
 
 export const isSyncDomain = (domain: string) => {

--- a/src/background/services/network/utils/getSyncDomain.ts
+++ b/src/background/services/network/utils/getSyncDomain.ts
@@ -5,13 +5,13 @@ const SYNCED_DOMAINS = [
   'core.app',
   'test.core.app',
   runtime.id,
-  'develop.avacloud-app.pages.dev',
-  'avacloud.io',
-  'staging--ava-cloud.avacloud-app.pages.dev',
 ];
 
-export const isSyncDomain = (domain: string) => {
-  return SYNCED_DOMAINS.some((syncDomain) => {
+export const isSyncDomain = (
+  domain: string,
+  exposedDomainList: string[] = []
+) => {
+  return [...SYNCED_DOMAINS, ...exposedDomainList].some((syncDomain) => {
     // Match exact domains, but also allow subdomains (i.e. develop.core-web.pages.dev)
     return syncDomain === domain || domain.endsWith(`.${syncDomain}`);
   });

--- a/src/background/services/network/utils/getSyncDomain.ts
+++ b/src/background/services/network/utils/getSyncDomain.ts
@@ -5,6 +5,8 @@ const SYNCED_DOMAINS = [
   'core.app',
   'test.core.app',
   runtime.id,
+  'develop.avacloud-app.pages.dev',
+  'avacloud.io',
 ];
 
 export const isSyncDomain = (domain: string) => {

--- a/src/utils/canSkipApproval.ts
+++ b/src/utils/canSkipApproval.ts
@@ -3,9 +3,13 @@ import { isSyncDomain } from '@src/background/services/network/utils/getSyncDoma
 import { isActiveTab } from './isActiveTab';
 import { runtime } from 'webextension-polyfill';
 
-export const canSkipApproval = async (domain: string, tabId: number) => {
+export const canSkipApproval = async (
+  domain: string,
+  tabId: number,
+  exposedDomainList?: string[]
+) => {
   return (
-    isSyncDomain(domain) &&
+    isSyncDomain(domain, exposedDomainList) &&
     // chrome.tabs.get(...) does not see extension popup
     (domain === runtime.id || (await isActiveTab(tabId)))
   );


### PR DESCRIPTION
## Description

 AvaCloud users have to approve the expose addresses transaction after browser refreshing

## Changes

AvaCloud has been added to the whitelist besides Core web

## Testing

Go to avacloud -> try to reproduce the ticket description [CP-9331](https://ava-labs.atlassian.net/jira/software/c/projects/CP/boards/72?selectedIssue=CP-9331)

## Screenshots:



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
