### PR TITLE
fix: getAddresses popup appearing randomly on core.app

### DIFF
--- a/src/background/services/accounts/handlers/avalanche_getAddressesInRange.test.ts
+++ b/src/background/services/accounts/handlers/avalanche_getAddressesInRange.test.ts
@@ -154,11 +154,10 @@ describe('background/services/accounts/handlers/avalanche_getAddressesInRange.ts
         ];
         const request = getPayload({ params: [0, 0, 2, 2] });
         await handleRequest(buildRpcCall(request));
-        expect(canSkipApproval).toHaveBeenCalledWith(
-          'core.app',
-          3,
-          EXPOSED_DOMAINS
-        );
+        expect(canSkipApproval).toHaveBeenCalledWith('core.app', 3, {
+          allowInactiveTabs: true,
+          domainWhitelist: EXPOSED_DOMAINS,
+        });
       });
 
       it('sets the limit to 0 if not provided', async () => {

--- a/src/background/services/accounts/handlers/avalanche_getAddressesInRange.ts
+++ b/src/background/services/accounts/handlers/avalanche_getAddressesInRange.ts
@@ -147,11 +147,10 @@ export class AvalancheGetAddressesInRangeHandler extends DAppRequestHandler<
       });
 
       if (
-        await canSkipApproval(
-          request.site.domain,
-          request.site.tabId,
-          EXPOSED_DOMAINS
-        )
+        await canSkipApproval(request.site.domain, request.site.tabId, {
+          domainWhitelist: EXPOSED_DOMAINS,
+          allowInactiveTabs: true,
+        })
       ) {
         return {
           ...request,

--- a/src/utils/canSkipApproval.ts
+++ b/src/utils/canSkipApproval.ts
@@ -3,14 +3,23 @@ import { isSyncDomain } from '@src/background/services/network/utils/getSyncDoma
 import { isActiveTab } from './isActiveTab';
 import { runtime } from 'webextension-polyfill';
 
+type SkipApprovalOptions = {
+  allowInactiveTabs?: boolean;
+  domainWhitelist?: string[];
+};
+
 export const canSkipApproval = async (
   domain: string,
   tabId: number,
-  exposedDomainList?: string[]
+  { allowInactiveTabs, domainWhitelist }: SkipApprovalOptions = {}
 ) => {
+  if (!isSyncDomain(domain, domainWhitelist)) {
+    return false;
+  }
+
   return (
-    isSyncDomain(domain, exposedDomainList) &&
-    // chrome.tabs.get(...) does not see extension popup
-    (domain === runtime.id || (await isActiveTab(tabId)))
+    allowInactiveTabs ||
+    domain === runtime.id || // chrome.tabs.get(...) does not see extension popup
+    (await isActiveTab(tabId))
   );
 };


### PR DESCRIPTION
Fix for `Expose addresses?` popup showing up randomly on core.app.

It seems core.app is polling for accounts and reacting to accounts being created/renamed in the extension. If core.app is not the active tab, we show up the approval window.