### PR TITLE
fix: make localhost a synced domain

### DIFF
--- a/src/background/services/network/utils/getSyncDomain.ts
+++ b/src/background/services/network/utils/getSyncDomain.ts
@@ -5,6 +5,9 @@ const SYNCED_DOMAINS = [
   'core.app',
   'test.core.app',
   runtime.id,
+  // Helpful for Core Web devs:
+  'localhost',
+  '127.0.0.1',
 ];
 
 export const isSyncDomain = (


### PR DESCRIPTION
No ticket. Core Web devs are getting spammed with `Expose Addresses?` prompts when working on `localhost`. This change makes `localhost` whitelisted + makes it behave the same as `core.app` (it will sync the active network between local `Core Web` and Core Extension, sync account names after renaming, etc.)