### PR TITLE
fix: collectibles view quirks

### DIFF
--- a/src/background/services/balances/BalancePollingService.ts
+++ b/src/background/services/balances/BalancePollingService.ts
@@ -35,7 +35,6 @@ export class BalancePollingService implements OnLock, OnAllExtensionClosed {
     // Stop any polling that may be occurring already
     this.stopPolling();
     // Start a new interval
-    // this._preventSchedulingNextUpdate = false;
     return this.pollBalances(
       account,
       activeChainId,

--- a/src/pages/Collectibles/Collectibles.tsx
+++ b/src/pages/Collectibles/Collectibles.tsx
@@ -33,7 +33,7 @@ import { useLiveBalance } from '@src/hooks/useLiveBalance';
 
 interface CollectiblesProps {
   listType: ListType;
-  setListType: Dispatch<SetStateAction<ListType>>;
+  setListType: Dispatch<SetStateAction<ListType | undefined>>;
 }
 
 const POLLED_BALANCES = [TokenType.ERC721, TokenType.ERC1155];

--- a/src/pages/Collectibles/components/CollectibleMedia.tsx
+++ b/src/pages/Collectibles/components/CollectibleMedia.tsx
@@ -94,6 +94,7 @@ export function CollectibleMedia({
 }: CollectibleMediaProps) {
   const [isImageFullScreen, setIsImageFullScreen] = useState(false);
   const [shouldUseLightIcon, setShouldUseLightIcon] = useState(false);
+  const [isMediaSettled, setIsMediaSettled] = useState(false); // Either loaded or errored out.
 
   return (
     <Stack
@@ -103,54 +104,50 @@ export function CollectibleMedia({
       }}
       className={className}
     >
-      {
-        <Stack
-          sx={{
-            flexDirection: 'row',
-            maxWidth: maxWidth ? maxWidth : 'unset',
-            width: width ? width : '32px',
-            position: 'absolute',
-            justifyContent: 'flex-end',
-            alignItems: 'flex-end',
-            columnGap: 1,
-            zIndex: 3,
-            mr: 3,
-            mt: 1,
-            pr: 1,
-          }}
-        >
-          {showBalance && (
-            <Chip
-              size="small"
-              sx={{
-                backgroundColor: (theme) =>
-                  shouldUseLightIcon
-                    ? 'primary.light'
-                    : theme.palette.grey[600],
-                color: shouldUseLightIcon
-                  ? 'primary.contrastText'
-                  : 'primary.light',
-                px: 1,
-              }}
-              label={balance.toString()}
-            />
-          )}
-          {showExpandOption && (
-            <ArrowsMaximizeIcon
-              onClick={() => {
-                setIsImageFullScreen(true);
-              }}
-              size="24"
-              sx={{
-                color: shouldUseLightIcon
-                  ? 'primary.light'
-                  : 'primary.contrastText',
-                cursor: 'pointer',
-              }}
-            />
-          )}
-        </Stack>
-      }
+      <Stack
+        sx={{
+          flexDirection: 'row',
+          maxWidth: maxWidth ? maxWidth : 'unset',
+          width: width ? width : '32px',
+          position: 'absolute',
+          justifyContent: 'flex-end',
+          alignItems: 'flex-end',
+          columnGap: 1,
+          zIndex: 3,
+          mr: 3,
+          mt: 1,
+          pr: 1,
+        }}
+      >
+        {showBalance && isMediaSettled && (
+          <Chip
+            size="small"
+            sx={{
+              backgroundColor: (theme) =>
+                shouldUseLightIcon ? 'primary.light' : theme.palette.grey[600],
+              color: shouldUseLightIcon
+                ? 'primary.contrastText'
+                : 'primary.light',
+              px: 1,
+            }}
+            label={balance.toString()}
+          />
+        )}
+        {showExpandOption && (
+          <ArrowsMaximizeIcon
+            onClick={() => {
+              setIsImageFullScreen(true);
+            }}
+            size="24"
+            sx={{
+              color: shouldUseLightIcon
+                ? 'primary.light'
+                : 'primary.contrastText',
+              cursor: 'pointer',
+            }}
+          />
+        )}
+      </Stack>
       {isVideo(url) ? (
         <Stack sx={{ position: 'relative', flexDirection: 'row' }}>
           <NftVideo
@@ -162,7 +159,10 @@ export function CollectibleMedia({
             controls={controls}
             borderRadius={borderRadius}
           >
-            <source src={ipfsResolverWithFallback(url)} />
+            <source
+              src={ipfsResolverWithFallback(url)}
+              onLoadStart={() => setIsMediaSettled(true)}
+            />
           </NftVideo>
           {showPlayIcon && (
             <TriangleRightIcon
@@ -202,7 +202,9 @@ export function CollectibleMedia({
                   setShouldUseLightIcon(isDark);
                 });
               }
+              setIsMediaSettled(true);
             }}
+            onError={() => setIsMediaSettled(true)}
           />
         </ImageWrapper>
       )}

--- a/src/pages/Home/components/Portfolio/Portfolio.tsx
+++ b/src/pages/Home/components/Portfolio/Portfolio.tsx
@@ -7,6 +7,7 @@ import { WalletBalances } from './WalletBalances';
 import { useTranslation } from 'react-i18next';
 import {
   Box,
+  CircularProgress,
   Scrollbars,
   Stack,
   Tab,
@@ -57,7 +58,7 @@ export function Portfolio() {
   const { featureFlags } = useFeatureFlagContext();
   const { activeTab, setActiveTab } = usePersistedTabs(PortfolioTabs.ASSETS);
   const { isReady, checkIsFunctionSupported } = useIsFunctionAvailable();
-  const [listType, setListType] = useState(ListType.GRID);
+  const [listType, setListType] = useState<ListType>();
   const [hadDefiEnabled, setHadDefiEnabled] = useState(false);
   const { getPageHistoryData, isHistoryLoading } = usePageHistory();
 
@@ -176,7 +177,11 @@ export function Portfolio() {
               sx={{ height: '100%' }}
             >
               {shouldShow(PortfolioTabs.COLLECTIBLES) ? (
-                <Collectibles listType={listType} setListType={setListType} />
+                listType ? (
+                  <Collectibles listType={listType} setListType={setListType} />
+                ) : (
+                  <CircularProgress size={60} />
+                )
               ) : (
                 isReady && ( // Only redirect when we have all the context needed to decide
                   <Redirect to={'/'} />

--- a/src/pages/ManageCollectibles/ManageCollectiblesList.tsx
+++ b/src/pages/ManageCollectibles/ManageCollectiblesList.tsx
@@ -52,7 +52,7 @@ export const ManageCollectiblesList = ({
       {displayableNfts?.map((nft) => (
         <ManageCollectiblesListItem
           nft={nft}
-          key={`collectible-${nft.name.toLowerCase()}`}
+          key={`collectible-${nft.address}-${nft.tokenId}`}
         />
       ))}
     </Stack>


### PR DESCRIPTION
_no ticket, fixes for issues found during blue build testing (+ some additional quirks)_

## Fixed issues
* the weird UI issue where ERC-1155 balances would show up bunched together before the images load
* toggling visibility of NFTs (previously we would toggle based on NFT's `address` only, but it's possible to have multiple NFTs of the same address but different `tokenId` -- this resulted in hiding entire batches of NFTs when trying to hide a specific NFT)
* the Collectibles tab appearing in grid view for a fraction of a second even if the user switched to list view (extension takes a moment to load the preferred state from storage)

## Testing
Go to the Collectibles tab and play around

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
