### PR TITLE
fix: ledger btc policy issues

### DIFF
--- a/src/background/services/secrets/SecretsService.test.ts
+++ b/src/background/services/secrets/SecretsService.test.ts
@@ -883,7 +883,7 @@ describe('src/background/services/secrets/SecretsService.ts', () => {
       mockMnemonicWallet();
 
       await expect(
-        secretsService.getBtcWalletPolicyDetails()
+        secretsService.getBtcWalletPolicyDetails(activeAccountData)
       ).resolves.toBeUndefined();
     });
 

--- a/src/background/services/secrets/SecretsService.ts
+++ b/src/background/services/secrets/SecretsService.ts
@@ -413,14 +413,14 @@ export class SecretsService {
   }
 
   async getBtcWalletPolicyDetails(
-    activeAccount?: Account
+    account: Account
   ): Promise<
     { accountIndex: number; details?: BtcWalletPolicyDetails } | undefined
   > {
-    if (!activeAccount) {
+    if (!account) {
       return undefined;
     }
-    const secrets = await this.getAccountSecrets(activeAccount);
+    const secrets = await this.getAccountSecrets(account);
 
     if (secrets.secretType === SecretType.LedgerLive && secrets.account) {
       const accountIndex = secrets.account.index;

--- a/src/background/services/wallet/WalletService.test.ts
+++ b/src/background/services/wallet/WalletService.test.ts
@@ -1466,9 +1466,9 @@ describe('background/services/wallet/WalletService.ts', () => {
     it('throws if it fails to find policy details', async () => {
       secretsService.getBtcWalletPolicyDetails.mockResolvedValueOnce(undefined);
 
-      await expect(walletService['parseWalletPolicyDetails']()).rejects.toThrow(
-        'Error while parsing wallet policy: missing data.'
-      );
+      await expect(
+        walletService['parseWalletPolicyDetails']({} as Account)
+      ).rejects.toThrow('Error while parsing wallet policy: missing data.');
     });
 
     it('returns the correct data for Ledger Live', async () => {
@@ -1485,7 +1485,7 @@ describe('background/services/wallet/WalletService.ts', () => {
       (createWalletPolicy as jest.Mock).mockReturnValueOnce(walletPolicy);
 
       await expect(
-        walletService['parseWalletPolicyDetails']()
+        walletService['parseWalletPolicyDetails']({} as Account)
       ).resolves.toStrictEqual({
         hmac: Buffer.from(hmacHex, 'hex'),
         policy: walletPolicy,
@@ -1513,7 +1513,7 @@ describe('background/services/wallet/WalletService.ts', () => {
       (createWalletPolicy as jest.Mock).mockReturnValueOnce(walletPolicy);
 
       await expect(
-        walletService['parseWalletPolicyDetails']()
+        walletService['parseWalletPolicyDetails']({} as Account)
       ).resolves.toStrictEqual({
         hmac: Buffer.from(hmacHex, 'hex'),
         policy: walletPolicy,

--- a/src/background/services/wallet/WalletService.ts
+++ b/src/background/services/wallet/WalletService.ts
@@ -61,6 +61,7 @@ import { getProviderForNetwork } from '@src/utils/network/getProviderForNetwork'
 import { Network } from '../network/models';
 import { AccountsService } from '../accounts/AccountsService';
 import { utils } from '@avalabs/avalanchejs';
+import { Account } from '../accounts/models';
 
 @singleton()
 export class WalletService implements OnLock, OnUnlock {
@@ -327,7 +328,9 @@ export class WalletService implements OnLock, OnUnlock {
           throw new Error('Ledger transport not available');
         }
 
-        const walletPolicy = await this.parseWalletPolicyDetails();
+        const walletPolicy = await this.parseWalletPolicyDetails(
+          this.accountsService.activeAccount
+        );
         const accountIndexToUse =
           accountIndex === undefined ? secrets.account.index : accountIndex;
 
@@ -358,7 +361,9 @@ export class WalletService implements OnLock, OnUnlock {
           throw new Error('Account public key not available');
         }
 
-        const walletPolicy = await this.parseWalletPolicyDetails();
+        const walletPolicy = await this.parseWalletPolicyDetails(
+          secrets.account
+        );
 
         return new BitcoinLedgerWallet(
           Buffer.from(addressPublicKey.evm, 'hex'),
@@ -835,9 +840,9 @@ export class WalletService implements OnLock, OnUnlock {
     );
   }
 
-  private async parseWalletPolicyDetails() {
+  private async parseWalletPolicyDetails(account: Account) {
     const policyInfo = await this.secretService.getBtcWalletPolicyDetails(
-      this.accountsService.activeAccount
+      account
     );
 
     if (!policyInfo || !policyInfo.details) {

--- a/src/background/services/wallet/handlers/getBtcWalletPolicyDetails.ts
+++ b/src/background/services/wallet/handlers/getBtcWalletPolicyDetails.ts
@@ -21,7 +21,7 @@ export class GetBtcWalletPolicyDetails implements HandlerType {
 
   handle: HandlerType['handle'] = async ({ request }) => {
     try {
-      const activeAccount = this.accountService.activeAccount;
+      const { activeAccount } = this.accountService;
 
       if (!activeAccount) {
         throw new Error('no account selected');
@@ -31,7 +31,9 @@ export class GetBtcWalletPolicyDetails implements HandlerType {
         throw new Error('incorrect account type');
       }
 
-      const policyInfo = await this.secretsService.getBtcWalletPolicyDetails();
+      const policyInfo = await this.secretsService.getBtcWalletPolicyDetails(
+        activeAccount
+      );
 
       return {
         ...request,

--- a/src/contexts/LedgerProvider.tsx
+++ b/src/contexts/LedgerProvider.tsx
@@ -292,7 +292,7 @@ export function LedgerContextProvider({ children }: { children: any }) {
    * Get the extended public key for the given path (m/44'/60'/0' by default)
    * @returns Promise<extended public key>
    */
-  async function getExtendedPublicKey(path?: string) {
+  const getExtendedPublicKey = useCallback(async (path?: string) => {
     if (!transportRef.current) {
       throw new Error('no device detected');
     }
@@ -303,23 +303,22 @@ export function LedgerContextProvider({ children }: { children: any }) {
       throw new Error(pubKeyError);
     }
     return pubKey;
-  }
+  }, []);
 
-  async function getPublicKey(
-    accountIndex: number,
-    pathType: DerivationPath,
-    vm: VM = 'EVM'
-  ) {
-    if (!transportRef.current) {
-      throw new Error('no device detected');
-    }
-    return getPubKeyFromTransport(
-      transportRef.current,
-      accountIndex,
-      pathType,
-      vm
-    );
-  }
+  const getPublicKey = useCallback(
+    async (accountIndex: number, pathType: DerivationPath, vm: VM = 'EVM') => {
+      if (!transportRef.current) {
+        throw new Error('no device detected');
+      }
+      return getPubKeyFromTransport(
+        transportRef.current,
+        accountIndex,
+        pathType,
+        vm
+      );
+    },
+    []
+  );
 
   /**
    * When the user plugs-in/connects their ledger for the first time a


### PR DESCRIPTION
* [CP-9365](https://ava-labs.atlassian.net/browse/CP-9365)


## Changes
Two issues fixed:
* the `account` parameter for `SecretsService.getBtcWalletPolicyDetails` method was optional, and we were not providing it in some cases, resulting in the method returning `undefined` (UI did not know the policy was already stored)
* `LedgerProvider` was spamming the device with requests, because some functions were not memoized (they were changing, causing `useEffect()` to run and query the device for `masterFingerprint`). Those requests sometimes coincided with actual sign requests, causing them to fail with `Action was already pending on the device` error

## Testing
* Onboard with Ledger
* Sign a BTC transaction (you should be prompted to store the BTC policy)
* Sign another BTC transaction from the same account (you should NOT be prompted to store the BTC policy)

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
