### PR TITLE
fix: CP-9311 x and p send set address

### DIFF
--- a/src/pages/Send/components/SendAVM.tsx
+++ b/src/pages/Send/components/SendAVM.tsx
@@ -110,7 +110,7 @@ export const SendAVM = ({
       token={nativeToken}
       tokenList={tokenList}
       onContactChanged={(contact) => {
-        if (contact?.addressXP) setAddress(contact.addressXP);
+        setAddress(contact?.addressXP ?? '');
       }}
       onAmountChanged={(newAmount) => setAmount(newAmount)}
       onTokenChanged={() => {}} // noop, AVAX has only one token

--- a/src/pages/Send/components/SendPVM.tsx
+++ b/src/pages/Send/components/SendPVM.tsx
@@ -119,7 +119,7 @@ export const SendPVM = ({
       token={nativeToken}
       tokenList={tokenList}
       onContactChanged={(contact) => {
-        if (contact?.addressXP) setAddress(contact.addressXP);
+        setAddress(contact?.addressXP ?? '');
       }}
       onAmountChanged={(newAmount) => setAmount(newAmount)}
       onTokenChanged={() => {}} // noop, AVAX has only one token

--- a/src/pages/Send/hooks/useIdentifyAddress.ts
+++ b/src/pages/Send/hooks/useIdentifyAddress.ts
@@ -24,7 +24,12 @@ export const useIdentifyAddress = () => {
   const identifyAddress = useCallback(
     (address: string): Contact => {
       if (!address)
-        return { ...UNSAVED_CONTACT_BASE, address: '', addressBTC: '' };
+        return {
+          ...UNSAVED_CONTACT_BASE,
+          address: '',
+          addressBTC: '',
+          addressXP: '',
+        };
       const addressLowerCase = address.toLowerCase();
       for (const contact of contacts) {
         if (
@@ -57,13 +62,13 @@ export const useIdentifyAddress = () => {
             ? { addressBTC: account.addressBTC, address: '' }
             : isPchainNetwork(network)
             ? {
-                addressXP: account.addressPVM ? account.addressPVM : '',
+                addressXP: address,
                 address: '',
                 addressBTC: '',
               }
             : isXchainNetwork(network)
             ? {
-                addressXP: account.addressAVM ? account.addressAVM : '',
+                addressXP: address,
                 address: '',
                 addressBTC: '',
               }

--- a/src/pages/Send/hooks/useIdentifyAddress.ts
+++ b/src/pages/Send/hooks/useIdentifyAddress.ts
@@ -6,6 +6,7 @@ import { useCallback } from 'react';
 import { isBitcoin } from '@src/utils/isBitcoin';
 import { isPchainNetwork } from '@src/background/services/network/utils/isAvalanchePchainNetwork';
 import { isXchainNetwork } from '@src/background/services/network/utils/isAvalancheXchainNetwork';
+import { correctAddressByPrefix } from '../utils/correctAddressByPrefix';
 
 const UNSAVED_CONTACT_BASE = {
   id: '',
@@ -35,8 +36,10 @@ export const useIdentifyAddress = () => {
         if (
           contact.address.toLowerCase() === addressLowerCase ||
           contact.addressBTC?.toLowerCase() === addressLowerCase ||
-          `p-${contact.addressXP?.toLowerCase()}` === addressLowerCase ||
-          `x-${contact.addressXP?.toLowerCase()}` === addressLowerCase
+          `p-${contact.addressXP?.toLowerCase()}` ===
+            correctAddressByPrefix(addressLowerCase, 'p-') ||
+          `x-${contact.addressXP?.toLowerCase()}` ===
+            correctAddressByPrefix(addressLowerCase, 'x-')
         ) {
           const addressToUse = isBitcoin(network)
             ? { addressBTC: address, address: '', addressPVM: '' }
@@ -55,8 +58,10 @@ export const useIdentifyAddress = () => {
         if (
           account.addressC.toLowerCase() === addressLowerCase ||
           account.addressBTC?.toLocaleLowerCase() === addressLowerCase ||
-          account.addressPVM?.toLocaleLowerCase() === addressLowerCase ||
-          account.addressAVM?.toLowerCase() === addressLowerCase
+          account.addressPVM?.toLocaleLowerCase() ===
+            correctAddressByPrefix(addressLowerCase, 'p-') ||
+          account.addressAVM?.toLowerCase() ===
+            correctAddressByPrefix(addressLowerCase, 'x-')
         ) {
           const addressToUse = isBitcoin(network)
             ? { addressBTC: account.addressBTC, address: '' }

--- a/src/pages/Send/hooks/useSend/useAVMSend.ts
+++ b/src/pages/Send/hooks/useSend/useAVMSend.ts
@@ -17,6 +17,7 @@ import type { AvalancheSendTransactionHandler } from '@src/background/services/w
 import { getMaxUtxoSet } from '../../utils/getMaxUtxos';
 import { SendAdapterAVM } from './models';
 import { AVMSendOptions } from '../../models';
+import { correctAddressByPrefix } from '../../utils/correctAddressByPrefix';
 
 const XCHAIN_ALIAS = 'X' as const;
 
@@ -135,7 +136,7 @@ export const useAvmSend: SendAdapterAVM = ({
         const unsignedTx = wallet.baseTX({
           utxoSet: utxos.utxos,
           chain: XCHAIN_ALIAS,
-          toAddress: address,
+          toAddress: correctAddressByPrefix(address, 'X-'),
           amountsPerAsset: {
             [avax]: amountBigInt,
           },

--- a/src/pages/Send/hooks/useSend/usePVMSend.ts
+++ b/src/pages/Send/hooks/useSend/usePVMSend.ts
@@ -18,6 +18,7 @@ import type { AvalancheSendTransactionHandler } from '@src/background/services/w
 import { getMaxUtxoSet } from '../../utils/getMaxUtxos';
 import { PVMSendOptions } from '../../models';
 import { SendAdapterPVM } from './models';
+import { correctAddressByPrefix } from '../../utils/correctAddressByPrefix';
 
 const PCHAIN_ALIAS = 'P' as const;
 
@@ -134,7 +135,7 @@ export const usePvmSend: SendAdapterPVM = ({
         const unsignedTx = wallet.baseTX({
           utxoSet: utxos,
           chain: PCHAIN_ALIAS,
-          toAddress: address,
+          toAddress: correctAddressByPrefix(address, 'P-'),
           amountsPerAsset: {
             [avax]: amountBigInt,
           },

--- a/src/pages/Send/utils/correctAddressByPrefix.test.ts
+++ b/src/pages/Send/utils/correctAddressByPrefix.test.ts
@@ -1,0 +1,14 @@
+import { correctAddressByPrefix } from './correctAddressByPrefix';
+
+describe('src/pages/Send/utils/correctAddressByPrefix', () => {
+  it('should add the prefix when the address does not start with that', () => {
+    const address = 'address';
+    expect(correctAddressByPrefix(address, 'PREFIX-')).toBe(
+      `PREFIX-${address}`
+    );
+  });
+  it('sgould not duplicate the prefix when it is the start of the address', () => {
+    const address = 'PREFIX-address';
+    expect(correctAddressByPrefix(address, 'PREFIX-')).toBe(address);
+  });
+});

--- a/src/pages/Send/utils/correctAddressByPrefix.ts
+++ b/src/pages/Send/utils/correctAddressByPrefix.ts
@@ -1,0 +1,3 @@
+export const correctAddressByPrefix = (address: string, prefix: string) => {
+  return !address.startsWith(prefix) ? `${prefix}${address}` : address;
+};

--- a/src/utils/isAddressValid.test.ts
+++ b/src/utils/isAddressValid.test.ts
@@ -12,10 +12,6 @@ describe('src/utils/isAddressValid.ts', () => {
   });
 
   describe('isValidPvmAddress', () => {
-    it('should return false if address does not start with P-', async () => {
-      const result = isValidPvmAddress(address);
-      expect(result).toEqual(false);
-    });
     it('should return false if not valid', async () => {
       const result = isValidPvmAddress(`P-testAddress}`);
       expect(result).toEqual(false);

--- a/src/utils/isAddressValid.ts
+++ b/src/utils/isAddressValid.ts
@@ -1,6 +1,5 @@
 import { isBech32Address } from '@avalabs/core-bridge-sdk';
 import { isAddress } from 'ethers';
-import { isNil, isString } from 'lodash';
 import { stripAddressPrefix } from './stripAddressPrefix';
 import { utils } from '@avalabs/avalanchejs';
 
@@ -20,15 +19,13 @@ export const isValidAvmAddress = (address: string) => {
   return isValidXPAddressWithPrefix(address, 'X-');
 };
 
-function isValidXPAddressWithPrefix(value: unknown, forcedPrefix?: string) {
-  if (
-    isNil(value) ||
-    !isString(value) ||
-    (forcedPrefix && !value.startsWith(forcedPrefix))
-  ) {
-    return false;
-  }
-  const addressBody = stripAddressPrefix(value);
+function isValidXPAddressWithPrefix(value: string, forcedPrefix?: string) {
+  const address =
+    forcedPrefix && !value.startsWith(forcedPrefix)
+      ? `${forcedPrefix}${value}`
+      : value;
+
+  const addressBody = stripAddressPrefix(address);
   return isValidXPAddress(addressBody);
 }
 


### PR DESCRIPTION
## Description

We don't want to completely control the contact input anymore. 


## Changes

Let the user changes the address to any value.

## Testing

Go to send on X or P chain -> try to change the address -> it hould let you set an empty string or whatever you want meanwhile it validates correctly.

## Screenshots:


https://github.com/user-attachments/assets/67504f22-8190-4d1e-bd88-1e8edf29964c



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
