### PR TITLE
feat: add default tokens to swap

### DIFF
--- a/src/hooks/usePageHistory.ts
+++ b/src/hooks/usePageHistory.ts
@@ -13,9 +13,10 @@ import { GetNavigationHistoryDataHandler } from '@src/background/services/naviga
 
 export function usePageHistory() {
   const { request } = useConnectionContext();
-  const [historyDataState, setHistoryDataState] = useState<Record<string, any>>(
-    { isLoading: true }
-  );
+  const [historyDataState, setHistoryDataState] = useState<{
+    isLoading: boolean;
+    [key: string]: any;
+  }>({ isLoading: true });
   const [historyState, setHistoryState] = useState<NavigationHistoryState>({});
 
   const setNavigationHistoryData = useCallback(

--- a/src/hooks/usePageHistory.ts
+++ b/src/hooks/usePageHistory.ts
@@ -14,7 +14,9 @@ import { GetNavigationHistoryDataHandler } from '@src/background/services/naviga
 export function usePageHistory() {
   const { request } = useConnectionContext();
   const [isLoading, setIsLoading] = useState(true);
-  const [historyDataState, setHistoryDataState] = useState({});
+  const [historyDataState, setHistoryDataState] = useState<Record<string, any>>(
+    { isLoading: true }
+  );
   const [historyState, setHistoryState] = useState<NavigationHistoryState>({});
 
   const setNavigationHistoryData = useCallback(
@@ -31,7 +33,7 @@ export function usePageHistory() {
     const result = await request<GetNavigationHistoryDataHandler>({
       method: ExtensionRequest.NAVIGATION_HISTORY_DATA_GET,
     });
-    setHistoryDataState(result);
+    setHistoryDataState({ ...result, isLoading: false });
   }, [request]);
 
   const setNavigationHistory = useCallback(
@@ -56,7 +58,6 @@ export function usePageHistory() {
       setIsLoading(true);
       await getNavigationHistory();
       await getNavigationHistoryData();
-      setIsLoading(false);
     };
     getHistory();
   }, [getNavigationHistory, getNavigationHistoryData]);

--- a/src/hooks/usePageHistory.ts
+++ b/src/hooks/usePageHistory.ts
@@ -13,7 +13,6 @@ import { GetNavigationHistoryDataHandler } from '@src/background/services/naviga
 
 export function usePageHistory() {
   const { request } = useConnectionContext();
-  const [isLoading, setIsLoading] = useState(true);
   const [historyDataState, setHistoryDataState] = useState<Record<string, any>>(
     { isLoading: true }
   );
@@ -55,7 +54,6 @@ export function usePageHistory() {
 
   useEffect(() => {
     const getHistory = async () => {
-      setIsLoading(true);
       await getNavigationHistory();
       await getNavigationHistoryData();
     };
@@ -77,6 +75,5 @@ export function usePageHistory() {
     getPageHistoryData,
     setNavigationHistory,
     getNavigationHistoryState,
-    isHistoryLoading: isLoading,
   };
 }

--- a/src/pages/Bridge/Bridge.tsx
+++ b/src/pages/Bridge/Bridge.tsx
@@ -106,6 +106,7 @@ export function Bridge() {
     selectedToken?: string;
     inputAmount?: Big;
     selectedTokenAddress?: string;
+    isLoading: boolean;
   } = getPageHistoryData();
 
   // derive blockchain/network from network

--- a/src/pages/Collectibles/Collectibles.tsx
+++ b/src/pages/Collectibles/Collectibles.tsx
@@ -34,11 +34,16 @@ import { useLiveBalance } from '@src/hooks/useLiveBalance';
 interface CollectiblesProps {
   listType: ListType;
   setListType: Dispatch<SetStateAction<ListType | undefined>>;
+  isHistoryLoading: boolean;
 }
 
 const POLLED_BALANCES = [TokenType.ERC721, TokenType.ERC1155];
 
-export function Collectibles({ listType, setListType }: CollectiblesProps) {
+export function Collectibles({
+  listType,
+  setListType,
+  isHistoryLoading,
+}: CollectiblesProps) {
   useLiveBalance(POLLED_BALANCES);
   const { t } = useTranslation();
   const { balances } = useBalancesContext();
@@ -47,7 +52,7 @@ export function Collectibles({ listType, setListType }: CollectiblesProps) {
   const { network } = useNetworkContext();
   const history = useHistory();
   const setCollectibleParams = useSetCollectibleParams();
-  const { setNavigationHistoryData, isHistoryLoading } = usePageHistory();
+  const { setNavigationHistoryData } = usePageHistory();
   const { isFunctionSupported: isManageCollectiblesSupported } =
     useIsFunctionAvailable(FunctionNames.MANAGE_COLLECTIBLES);
   const { getCollectibleVisibility } = useSettingsContext();

--- a/src/pages/Home/components/Portfolio/Portfolio.tsx
+++ b/src/pages/Home/components/Portfolio/Portfolio.tsx
@@ -60,10 +60,12 @@ export function Portfolio() {
   const { isReady, checkIsFunctionSupported } = useIsFunctionAvailable();
   const [listType, setListType] = useState<ListType>();
   const [hadDefiEnabled, setHadDefiEnabled] = useState(false);
-  const { getPageHistoryData, isHistoryLoading } = usePageHistory();
+  const { getPageHistoryData } = usePageHistory();
 
-  const { listType: historyListType }: { listType?: ListType } =
-    getPageHistoryData();
+  const {
+    listType: historyListType,
+    isLoading: isHistoryLoading,
+  }: { listType?: ListType; isLoading: boolean } = getPageHistoryData();
   const [isScrolling, setIsScrolling] = useState(false);
 
   useEffect(() => {
@@ -178,7 +180,11 @@ export function Portfolio() {
             >
               {shouldShow(PortfolioTabs.COLLECTIBLES) ? (
                 listType ? (
-                  <Collectibles listType={listType} setListType={setListType} />
+                  <Collectibles
+                    listType={listType}
+                    setListType={setListType}
+                    isHistoryLoading={isHistoryLoading}
+                  />
                 ) : (
                   <CircularProgress size={60} />
                 )

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -1,6 +1,6 @@
 import { useSwapContext } from '@src/contexts/SwapProvider/SwapProvider';
 import { useTokensWithBalances } from '@src/hooks/useTokensWithBalances';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { resolve } from '@src/utils/promiseResolver';
 import { TransactionDetails } from './components/TransactionDetails';
 import { PageTitle } from '@src/components/common/PageTitle';
@@ -82,6 +82,13 @@ export function Swap() {
     useState(false);
   const [isConfirming, setIsConfirming] = useState(false);
 
+  const AVAX_TOKEN = tokensWBalances.find(
+    (token) => token.symbol === 'AVAX'
+  ) as NetworkTokenWithBalance | TokenWithBalanceERC20;
+  const USDC_TOKEN = allTokensOnNetwork.find(
+    (token) => token.symbol === 'USDC'
+  ) as TokenWithBalanceERC20;
+
   const {
     calculateTokenValueToInput,
     reverseTokens,
@@ -103,31 +110,10 @@ export function Swap() {
     maxFromValue,
     optimalRate,
     destAmount,
-  } = useSwapStateFunctions();
-
-  useEffect(() => {
-    if (!selectedFromToken && !selectedToToken) {
-      const AVAX_TOKEN = tokensWBalances.find(
-        (token) => token.symbol === 'AVAX'
-      ) as NetworkTokenWithBalance | TokenWithBalanceERC20;
-      const USDC_TOKEN = allTokensOnNetwork.find(
-        (token) => token.symbol === 'USDC'
-      ) as TokenWithBalanceERC20;
-
-      onTokenChange({
-        token: AVAX_TOKEN,
-        fromToken: AVAX_TOKEN,
-        toToken: USDC_TOKEN,
-        destination: 'to',
-      });
-    }
-  }, [
-    allTokensOnNetwork,
-    onTokenChange,
-    selectedFromToken,
-    selectedToToken,
-    tokensWBalances,
-  ]);
+  } = useSwapStateFunctions({
+    defaultFromToken: AVAX_TOKEN,
+    defaultToToken: USDC_TOKEN,
+  });
 
   const activeAddress = useMemo(
     () =>

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -1,6 +1,6 @@
 import { useSwapContext } from '@src/contexts/SwapProvider/SwapProvider';
 import { useTokensWithBalances } from '@src/hooks/useTokensWithBalances';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { resolve } from '@src/utils/promiseResolver';
 import { TransactionDetails } from './components/TransactionDetails';
 import { PageTitle } from '@src/components/common/PageTitle';
@@ -66,6 +66,7 @@ export function Swap() {
   const tokensWBalances = useTokensWithBalances({
     disallowedAssets: DISALLOWED_SWAP_ASSETS,
   });
+
   const allTokensOnNetwork = useTokensWithBalances({
     forceShowTokensWithoutBalances: true,
     disallowedAssets: DISALLOWED_SWAP_ASSETS,
@@ -103,6 +104,30 @@ export function Swap() {
     optimalRate,
     destAmount,
   } = useSwapStateFunctions();
+
+  useEffect(() => {
+    if (!selectedFromToken && !selectedToToken) {
+      const AVAX_TOKEN = tokensWBalances.find(
+        (token) => token.symbol === 'AVAX'
+      ) as NetworkTokenWithBalance | TokenWithBalanceERC20;
+      const USDC_TOKEN = allTokensOnNetwork.find(
+        (token) => token.symbol === 'USDC'
+      ) as TokenWithBalanceERC20;
+
+      onTokenChange({
+        token: AVAX_TOKEN,
+        fromToken: AVAX_TOKEN,
+        toToken: USDC_TOKEN,
+        destination: 'to',
+      });
+    }
+  }, [
+    allTokensOnNetwork,
+    onTokenChange,
+    selectedFromToken,
+    selectedToToken,
+    tokensWBalances,
+  ]);
 
   const activeAddress = useMemo(
     () =>

--- a/src/pages/Swap/hooks/useSwapStateFunctions.ts
+++ b/src/pages/Swap/hooks/useSwapStateFunctions.ts
@@ -33,6 +33,7 @@ export function useSwapStateFunctions({
     selectedToToken?: NetworkTokenWithBalance | TokenWithBalanceERC20;
     destinationInputField?: DestinationInput;
     tokenValue?: Amount;
+    isLoading?: boolean;
   } = getPageHistoryData();
 
   const [destinationInputField, setDestinationInputField] =
@@ -41,6 +42,7 @@ export function useSwapStateFunctions({
   const [selectedFromToken, setSelectedFromToken] = useState<
     NetworkTokenWithBalance | TokenWithBalanceERC20
   >();
+
   const [selectedToToken, setSelectedToToken] = useState<
     NetworkTokenWithBalance | TokenWithBalanceERC20
   >();
@@ -90,7 +92,11 @@ export function useSwapStateFunctions({
 
   // reload and recalculate the data from the history
   useEffect(() => {
-    if (Object.keys(pageHistory).length && !isHistoryLoaded.current) {
+    if (
+      Object.keys(pageHistory).length > 1 &&
+      !pageHistory.isLoading &&
+      !isHistoryLoaded.current
+    ) {
       const historyFromToken = pageHistory.selectedFromToken
         ? {
             ...pageHistory.selectedFromToken,
@@ -135,12 +141,21 @@ export function useSwapStateFunctions({
         historyFromToken,
         historyToToken
       );
+
       isHistoryLoaded.current = true;
-      return;
     }
-    if (defaultFromToken && defaultFromToken) {
+
+    if (
+      !pageHistory.selectedFromToken &&
+      !pageHistory.selectedToToken &&
+      !pageHistory.isLoading &&
+      !isHistoryLoaded.current &&
+      defaultFromToken &&
+      defaultFromToken
+    ) {
       setSelectedFromToken(defaultFromToken);
       setSelectedToToken(defaultToToken);
+      isHistoryLoaded.current = true;
     }
   }, [
     calculateTokenValueToInput,
@@ -243,8 +258,8 @@ export function useSwapStateFunctions({
     }
     const data =
       destination === 'to'
-        ? { fromToken: token, toToken, fromValue }
-        : { fromToken, toToken: token, fromValue };
+        ? { selectedFromToken: token, selectedToToken: toToken, fromValue }
+        : { selectedFromToken: fromToken, selectedToToken: token, fromValue };
     calculateSwapValue(data);
     setNavigationHistoryData({
       ...data,

--- a/src/pages/Swap/hooks/useSwapStateFunctions.ts
+++ b/src/pages/Swap/hooks/useSwapStateFunctions.ts
@@ -33,7 +33,7 @@ export function useSwapStateFunctions({
     selectedToToken?: NetworkTokenWithBalance | TokenWithBalanceERC20;
     destinationInputField?: DestinationInput;
     tokenValue?: Amount;
-    isLoading?: boolean;
+    isLoading: boolean;
   } = getPageHistoryData();
 
   const [destinationInputField, setDestinationInputField] =

--- a/src/pages/Swap/hooks/useSwapStateFunctions.ts
+++ b/src/pages/Swap/hooks/useSwapStateFunctions.ts
@@ -14,7 +14,13 @@ import {
 import { stringToBigint } from '@src/utils/stringToBigint';
 import { TokenUnit } from '@avalabs/core-utils-sdk';
 
-export function useSwapStateFunctions() {
+export function useSwapStateFunctions({
+  defaultFromToken,
+  defaultToToken,
+}: {
+  defaultFromToken: NetworkTokenWithBalance | TokenWithBalanceERC20;
+  defaultToToken: NetworkTokenWithBalance | TokenWithBalanceERC20;
+}) {
   const tokensWBalances = useTokensWithBalances({
     disallowedAssets: DISALLOWED_SWAP_ASSETS,
   });
@@ -130,8 +136,18 @@ export function useSwapStateFunctions() {
         historyToToken
       );
       isHistoryLoaded.current = true;
+      return;
     }
-  }, [calculateTokenValueToInput, pageHistory]);
+    if (defaultFromToken && defaultFromToken) {
+      setSelectedFromToken(defaultFromToken);
+      setSelectedToToken(defaultToToken);
+    }
+  }, [
+    calculateTokenValueToInput,
+    defaultFromToken,
+    defaultToToken,
+    pageHistory,
+  ]);
 
   const resetValues = () => {
     setFromTokenValue(undefined);

--- a/src/pages/Swap/hooks/useSwapStateFunctions.ts
+++ b/src/pages/Swap/hooks/useSwapStateFunctions.ts
@@ -221,6 +221,7 @@ export function useSwapStateFunctions() {
     if (destination === 'to') {
       setSelectedFromToken(token);
       setMaxFromValue(token?.balance);
+      toToken && setSelectedToToken(toToken);
     } else {
       setSelectedToToken(token);
     }


### PR DESCRIPTION
## Description

We want to add default tokens to the Swap page

## Changes

Set the AVAX and USDC tokens as default transaction pairs.

## Testing

Go to the swap page -> you should see the AVAX in the `from` and the USDC in the `to` field -> swap should work as before

## Screenshots:


https://github.com/user-attachments/assets/0cc4998b-7627-4284-ad56-e807c69cd9ba



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
