### PR TITLE
fix: add back account name data-testid

### DIFF
--- a/src/pages/Accounts/components/AccountName.tsx
+++ b/src/pages/Accounts/components/AccountName.tsx
@@ -71,7 +71,9 @@ export default function AccountName({
     >
       <Stack sx={{ flexDirection: 'row', alignItems: 'center' }}>
         {!isAccountNameEditing && (
-          <Typography variant="h6">{accountName}</Typography>
+          <Typography data-testid="account-name" variant="h6">
+            {accountName}
+          </Typography>
         )}
         {isAccountNameEditing && (
           <AccountNameInput


### PR DESCRIPTION
## Description

- Updates `AccountName` component to have a data-testid that was removed with the account name rework causing automation failures

## Screenshots:

![Screenshot 2024-11-06 at 5 38 00 PM](https://github.com/user-attachments/assets/94ac9715-a118-4abf-9fbb-fea1c8a0458c)

