### PR TITLE
feat: CP-9474 import private key activate account, design fixes

### DIFF
--- a/src/pages/Accounts/AccountItemChip.tsx
+++ b/src/pages/Accounts/AccountItemChip.tsx
@@ -11,27 +11,30 @@ import { Account, AccountType } from '@src/background/services/accounts/models';
 
 interface AccountItemChipProps {
   account: Account;
+  isActive?: boolean;
 }
 
-export function AccountItemChip({ account }: AccountItemChipProps) {
+export function AccountItemChip({ account, isActive }: AccountItemChipProps) {
   const { t } = useTranslation();
   const { type: accountType } = account;
+
+  const fontColor = isActive ? 'white' : 'default';
 
   const icon = useMemo(() => {
     switch (accountType) {
       case AccountType.IMPORTED:
-        return <KeyIcon />;
+        return <KeyIcon color={fontColor} />;
 
       case AccountType.FIREBLOCKS:
-        return <FireblocksIcon />;
+        return <FireblocksIcon color={fontColor} />;
 
       case AccountType.WALLET_CONNECT:
-        return <WalletConnectIcon />;
+        return <WalletConnectIcon color={fontColor} />;
 
       default:
         return null;
     }
-  }, [accountType]);
+  }, [accountType, fontColor]);
 
   const label = useMemo(() => {
     switch (accountType) {
@@ -58,7 +61,11 @@ export function AccountItemChip({ account }: AccountItemChipProps) {
       icon={icon}
       label={label}
       size="small"
-      sx={{ fontWeight: 'normal' }}
+      sx={{
+        fontWeight: isActive ? '600' : 'normal',
+        color: fontColor,
+        backgroundColor: isActive ? 'grey.400' : 'default',
+      }}
     />
   );
 }

--- a/src/pages/Accounts/components/AccountItem.tsx
+++ b/src/pages/Accounts/components/AccountItem.tsx
@@ -262,7 +262,7 @@ export const AccountItem = forwardRef(
 
               {isImportedAccount && (
                 <Stack direction="row">
-                  <AccountItemChip account={account} />
+                  <AccountItemChip account={account} isActive={isActive} />
                 </Stack>
               )}
             </Stack>

--- a/src/pages/ImportPrivateKey/ImportPrivateKey.tsx
+++ b/src/pages/ImportPrivateKey/ImportPrivateKey.tsx
@@ -28,6 +28,7 @@ import { AccountsTab } from '../Accounts/Accounts';
 import { DerivedAddress, NetworkType } from './components/DerivedAddress';
 import { utils } from '@avalabs/avalanchejs';
 import { usePrivateKeyImport } from '../Accounts/hooks/usePrivateKeyImport';
+import { useAccountsContext } from '@src/contexts/AccountsProvider';
 
 type DerivedAddresses = {
   addressC: string;
@@ -49,6 +50,7 @@ export function ImportPrivateKey() {
   const balance = useBalanceTotalInCurrency(derivedAddresses as Account);
   const { isImporting: isImportLoading, importPrivateKey } =
     usePrivateKeyImport();
+  const { selectAccount } = useAccountsContext();
   const history = useHistory();
 
   const isLoading = hasFocus && !derivedAddresses && !error;
@@ -56,13 +58,13 @@ export function ImportPrivateKey() {
   const handleImport = async () => {
     capture('ImportPrivateKeyClicked');
     try {
-      await importPrivateKey(privateKey);
+      const importedAccountId = await importPrivateKey(privateKey);
+      await selectAccount(importedAccountId);
       toast.success(t('Private Key Imported'), { duration: 2000 });
       capture('ImportPrivateKeySucceeded');
       history.replace(`/accounts?activeTab=${AccountsTab.Imported}`);
     } catch (err) {
       toast.error(t('Private Key Import Failed'), { duration: 2000 });
-      console.error(err);
     }
   };
 


### PR DESCRIPTION
## Description

We want to make the latest imported account to be the active account. 

## Changes

After the import phase we select the account. There are few design fixes in addition.

## Testing

Go to accounts page -> import an account

## Screenshots:


https://github.com/user-attachments/assets/119ccde5-b0e7-4f5e-919f-3669a8edd317



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
