### PR TITLE
fix: price warning always visible

### DIFF
--- a/src/hooks/useTokenPriceIsMissing.ts
+++ b/src/hooks/useTokenPriceIsMissing.ts
@@ -2,6 +2,7 @@ import { isBitcoinChainId } from '@src/background/services/network/utils/isBitco
 import { useAccountsContext } from '@src/contexts/AccountsProvider';
 import { useBalancesContext } from '@src/contexts/BalancesProvider';
 import { useNetworkContext } from '@src/contexts/NetworkProvider';
+import { useSettingsContext } from '@src/contexts/SettingsProvider';
 import { useCallback, useMemo } from 'react';
 
 type UseTokenPriceMissingProps = {
@@ -16,6 +17,7 @@ export function useTokenPriceMissing(): UseTokenPriceMissingProps {
     accounts: { active: activeAccount },
   } = useAccountsContext();
   const { network: activeNetwork, favoriteNetworks } = useNetworkContext();
+  const { getTokenVisibility } = useSettingsContext();
 
   const networksMissingPrice: Record<string, boolean> = useMemo(() => {
     if (isTokensCached) {
@@ -52,10 +54,11 @@ export function useTokenPriceMissing(): UseTokenPriceMissingProps {
       if (!tokensForActiveAccount) {
         return;
       }
-
-      const isMissingPrices = Object.values(tokensForActiveAccount).some(
-        (token) => token.priceInCurrency === undefined
-      );
+      const isMissingPrices = Object.values(tokensForActiveAccount)
+        .filter(getTokenVisibility) // Disregard hidden tokens
+        .some(
+          (token) => token.balance > 0n && token.priceInCurrency === undefined // Only look at tokens that actually have some balance
+        );
 
       networksIsMissingPrices[networkId] = isMissingPrices;
     });
@@ -66,6 +69,7 @@ export function useTokenPriceMissing(): UseTokenPriceMissingProps {
     activeAccount?.addressC,
     isTokensCached,
     balances.tokens,
+    getTokenVisibility,
   ]);
 
   const favoriteNetworksMissingPrice = useMemo(


### PR DESCRIPTION
## Description

For the missing price warning, we look at all the tokens, even those with `balance: 0n`. We also take into consideration the tokens that the user has hidden.

This provides a way to fix the price warning, which right now is visible basically all the time right now.

## Changes

## Testing
* If you get the missing price warning, hide the spam/testing tokens or tokens which don't have a price.

## Screenshots:

https://github.com/user-attachments/assets/45b77ab5-12f1-45cf-8c39-e6299515f766


## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
