### PR TITLE
feat: add response check for Paraswap API

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
   transformIgnorePatterns: [`/node_modules/(?!micro-eth-signer)`],
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
   globals: {
     EVM_PROVIDER_INFO_NAME: 'EVM_PROVIDER_INFO_NAME',
     EVM_PROVIDER_INFO_UUID: 'EVM_PROVIDER_INFO_UUID',

--- a/src/contexts/SwapProvider/SwapProvider.test.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.test.tsx
@@ -481,6 +481,7 @@ describe('contexts/SwapProvider', () => {
       let requestMock;
 
       const mockedTx = {
+        gas: '0x2710', // 10000n
         data: 'approval-tx-data',
       };
 
@@ -491,6 +492,7 @@ describe('contexts/SwapProvider', () => {
             to: '0xParaswapContractAddress',
             from: '0x123',
             value: '0x0',
+            gas: '1223',
             chainId: 123,
           }),
         } as any);

--- a/src/contexts/SwapProvider/SwapProvider.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.tsx
@@ -244,7 +244,7 @@ export function SwapContextProvider({ children }: { children: any }) {
         transactionParamsOrError
       );
 
-      if (validationResult.error) {
+      if (!response.ok || validationResult.error) {
         if (isAPIError(transactionParamsOrError)) {
           throw new Error(transactionParamsOrError.message);
         }

--- a/src/contexts/SwapProvider/SwapProvider.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.tsx
@@ -388,7 +388,8 @@ export function SwapContextProvider({ children }: { children: any }) {
                 params: [
                   {
                     chainId: ChainId.AVALANCHE_MAINNET_ID.toString(),
-                    gasLimit: String(approveGasLimit || gasLimit),
+                    gas:
+                      '0x' + Number(approveGasLimit || gasLimit).toString(16),
                     data,
                     from: activeAccount.addressC,
                     to: srcTokenAddress,
@@ -455,7 +456,7 @@ export function SwapContextProvider({ children }: { children: any }) {
           params: [
             {
               chainId: ChainId.AVALANCHE_MAINNET_ID.toString(),
-              gasLimit: String(txBuildData.gas),
+              gas: '0x' + Number(txBuildData.gas).toString(16),
               data: txBuildData.data,
               to: txBuildData.to,
               from: activeAccount.addressC,


### PR DESCRIPTION
## Description

Adds response content checks to detect API errors on the Paraswap API.

## Changes

Add schema validation on the buildTx response

## Testing

- Make sure swaps still work
- Mock the API response to trigger the error checks.

## Screenshots:

<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author

Tick each of them when done or if not applicable.

- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
