### PR TITLE
feat: open up avalanche methods CP-9587

### DIFF
--- a/src/background/connections/middlewares/PermissionMiddleware.ts
+++ b/src/background/connections/middlewares/PermissionMiddleware.ts
@@ -91,6 +91,10 @@ export const UNRESTRICTED_METHODS = Object.freeze([
   'avalanche_getIsDefaultExtensionState',
   'avalanche_selectWallet',
   DAppProviderRequest.AVALANCHE_GET_ADDRESSES_IN_RANGE,
+  DAppProviderRequest.AVALANCHE_SEND_TRANSACTION,
+  DAppProviderRequest.AVALANCHE_SIGN_TRANSACTION,
+  DAppProviderRequest.AVALANCHE_SIGN_MESSAGE,
+  DAppProviderRequest.AVALANCHE_GET_ACCOUNT_PUB_KEY,
 ]);
 
 const CORE_METHODS = Object.freeze([
@@ -104,10 +108,6 @@ const CORE_METHODS = Object.freeze([
   'avalanche_selectAccount',
   'avalanche_setDeveloperMode',
   DAppProviderRequest.ACCOUNT_RENAME,
-  DAppProviderRequest.AVALANCHE_SEND_TRANSACTION,
-  DAppProviderRequest.AVALANCHE_SIGN_TRANSACTION,
-  DAppProviderRequest.AVALANCHE_SIGN_MESSAGE,
-  DAppProviderRequest.AVALANCHE_GET_ACCOUNT_PUB_KEY,
   DAppProviderRequest.BITCOIN_SEND_TRANSACTION,
   DAppProviderRequest.WALLET_GET_CHAIN,
   DAppProviderRequest.WALLET_RENAME,


### PR DESCRIPTION
## Description

Opens up avalanche methods to allow external developers and dApps to interact with the P and X chains. 
It exposes:
- `avalanche_sendTransaction`. When user signs the transaction, it is sent immediately. Prompts the user with an approval window.
- `avalanche_signTransaction`. Signs the transaction and returns the signed transaction to the caller.  Prompts the user with an approval window.
- `avalanche_signMessage`. Sign messages using the X/P derivation path. Can be used to prove owneship of the account simiar to how `personal_sign` works for eth. Prompts the user with an approval window.
- `avalanche_getAccountPubKey`. Returns the the current account's evm and pvm public keys.

## Changes

Change Core only method list.

## Testing

Attempt to call the above mentioned RPC methods from a non Core and non localhost domains.

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
