### PR TITLE
fix: max button using rounded up value

### DIFF
--- a/src/pages/Send/components/ContactSelect.tsx
+++ b/src/pages/Send/components/ContactSelect.tsx
@@ -142,8 +142,8 @@ export const ContactSelect = ({
         return;
       }
       const result = walletAccount.map(
-        ({ addressC, name, addressBTC, addressPVM, addressAVM }) => ({
-          id: '',
+        ({ id, addressC, name, addressBTC, addressPVM, addressAVM }) => ({
+          id,
           address: network?.vmName == NetworkVMType.EVM ? addressC : '',
           addressBTC:
             network?.vmName === NetworkVMType.BITCOIN ? addressBTC : '',
@@ -166,8 +166,8 @@ export const ContactSelect = ({
     }
 
     const formattedImported = importedAccountToPrep?.map(
-      ({ addressC, name, addressBTC, addressPVM, addressAVM }) => ({
-        id: '',
+      ({ id, addressC, name, addressBTC, addressPVM, addressAVM }) => ({
+        id,
         address: network?.vmName == NetworkVMType.EVM ? addressC : '',
         addressBTC:
           network?.vmName === NetworkVMType.BITCOIN && addressBTC


### PR DESCRIPTION
* [CP-9544](https://ava-labs.atlassian.net/browse/CP-9544)

## Changes
* Uses `bigIntToString()` to avoid the rounding mechanism of `TokenUnit` (78c9a7947)
* Fixes some console warnings about `key`s being identical (2947da8c784848ab4befec1834d8d3901695a4ba)
<!--- What types of changes does your code introduce? -->

## Testing
* Go to Send on an EVM network (i.e. C-Chain)
* Choose any address and a token that has lots of decimal places in the balance (token list rounds it up, so beware - see attached video)
* Click `Max` - you should not see an `Unknown Error`

## Screenshots:
### Before
https://github.com/user-attachments/assets/08844674-6ec4-4ce4-b6cc-c0864595f9db

### After

https://github.com/user-attachments/assets/410fb69e-729a-4dc0-86b0-6f2c9de24267


## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
