### PR TITLE
fix: provide default value to convert

### DIFF
--- a/src/components/common/BNInput.tsx
+++ b/src/components/common/BNInput.tsx
@@ -66,7 +66,7 @@ export function BNInput({
 
     if (value) {
       const valueAsString = bigIntToString(value, denomination);
-      const oldValue = stringToBigint(valStr, denomination);
+      const oldValue = stringToBigint(valStr || '0', denomination);
       /**
        * When deleting zeros after decimal, all zeros delete without this check.
        * This also preserves zeros in the input ui.


### PR DESCRIPTION
## Description
_N/A_

## Changes
* We were calling `stringToBigint(...)` on an empty string

## Testing
* Go to Swap and enter an amount, it should not crash

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [X] I've tested the changes myself before sending it to code review and QA.
