### PR TITLE
fix: only show P-Chain Details link for active wallet

### DIFF
--- a/src/pages/Accounts/components/WalletContainer.tsx
+++ b/src/pages/Accounts/components/WalletContainer.tsx
@@ -64,7 +64,7 @@ export const WalletContainer = ({
             />
           ))}
         </Stack>
-        <Grow in={hasBalanceOnUnderivedAccounts}>
+        <Grow in={isActive && hasBalanceOnUnderivedAccounts}>
           <Stack
             sx={{
               flexDirection: 'row',


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
<!--- Link and relevant resources e.g JIRA ticket, Figma Designs, PRs -->

## Changes
* Since Core Web's UTXO Manager will display UTXOs only for the active wallet, we should display the `View P-Chain Details` link only for the active wallet as well.

## Screenshots:

https://github.com/user-attachments/assets/2b1c2cf9-5a2e-4331-a02a-dfc091048509

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
