### PR TITLE
fix: contact dropdown size

### DIFF
--- a/src/pages/Send/components/SendForm.tsx
+++ b/src/pages/Send/components/SendForm.tsx
@@ -5,6 +5,7 @@ import {
   Stack,
   Scrollbars,
   Tooltip,
+  styled,
 } from '@avalabs/core-k2-components';
 import { Contact } from '@avalabs/types';
 import { useTranslation } from 'react-i18next';
@@ -48,6 +49,12 @@ const errorsToExcludeForTokenSelect: string[] = [
   ...generalErrors,
 ];
 
+const FlexScrollbars = styled(Scrollbars)`
+	> div {
+		display: flex;
+	}
+}`;
+
 export const SendForm = ({
   address,
   inputAmount,
@@ -81,8 +88,15 @@ export const SendForm = ({
 
   return (
     <Stack sx={{ flexGrow: 1, alignItems: 'center', width: '100%', pt: 1 }}>
-      <Scrollbars style={{ flexGrow: 1, maxHeight: 'unset', height: '100%' }}>
-        <Stack ref={formRef}>
+      <FlexScrollbars
+        style={{
+          flexGrow: 1,
+          maxHeight: 'unset',
+          height: '100%',
+          display: 'flex',
+        }}
+      >
+        <Stack ref={formRef} sx={{ display: 'flex', flexGrow: 1, mb: 2 }}>
           <ContactInput
             contact={contact}
             onChange={(newContact, tab) => {
@@ -148,7 +162,7 @@ export const SendForm = ({
             </Stack>
           )}
         </Stack>
-      </Scrollbars>
+      </FlexScrollbars>
       {!isContactsOpen && !isTokenSelectOpen && (
         <Stack
           sx={{


### PR DESCRIPTION
## Description

Fixes a UI bug found during regression testing of the latest blue.

## Testing
1. Have many accounts/contacts
2. Open Send -> click the contact icon
3. Verify the dropdown is of proper size

## Screenshots

### Before


https://github.com/user-attachments/assets/4fc44d3f-11b6-437e-bbe7-0e2b600f9d61


### After


https://github.com/user-attachments/assets/46155f47-fc91-4662-947d-72eda9b588fc


## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.