### PR TITLE
fix: prompting invalid ledger app

### DIFF
--- a/src/pages/ApproveAction/GenericApprovalScreen.tsx
+++ b/src/pages/ApproveAction/GenericApprovalScreen.tsx
@@ -99,7 +99,7 @@ export function GenericApprovalScreen() {
   }, [requestId, updateAction, isUsingLedgerWallet, isUsingKeystoneWallet]);
 
   // Make the user switch to the correct app or close the window
-  useLedgerDisconnectedDialog(handleRejection);
+  useLedgerDisconnectedDialog(handleRejection, undefined, network);
 
   if (!action || !displayData) {
     return <LoadingOverlay />;


### PR DESCRIPTION
* [CP-9520](https://ava-labs.atlassian.net/browse/CP-9520)

## Description
* We were prompting opening a Ledger app based on the extension's active network when `GenericApprovalScreen` was being used. Now that dApps can connect to different networks without impacting Extension's active network, this stopped working properly.

## Changes
* With this change, we pass the transaction network to the `useLedgerDisconnectedDialog(...)` hook which will be able to derive the correct app to be opened.

## Testing
* Connect Ledger and make it your active wallet in extension
* Open Avalanche app on Ledger
* Enable testnet mode & go to [the playground app](https://ava-labs.github.io/extension-avalanche-playground/)
* Switch Extension's network to Bitcoin Testnet
* In the playground app, go to `RPC Calls` and choose `eth_sendTransaction`
* You should **_NOT_** be prompted to open Bitcoin App

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.