### PR TITLE
chore: remove .npmrc from workflows

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-      - name: Create .npmrc
-        run: echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}' >> .npmrc
       - name: Create env file
         run: |
           touch .env.production

--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -22,8 +22,6 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      - name: Create .npmrc
-        run: echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}' >> .npmrc
       - name: Create env file
         run: |
           touch .env.production

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-      - name: Create .npmrc
-        run: echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}' >> .npmrc
       - name: Create env file
         run: |
           touch .env.production

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 20.x
-      - name: Create .npmrc
-        run: echo '//registry.npmjs.org/:_authToken= ${{ secrets.NPM_TOKEN }}' >> .npmrc
       - name: Create env file
         run: |
           touch .env.production


### PR DESCRIPTION
## Description

Removes unnecessary .npmrc creation form the workflows. The extension should be buildable by the community. By removing the .npmrc file with the NPM_TOKEN we can ensure that no private npm packages are used in the app.

## Changes

Removes .npmrc creation from the github workflows

## Testing

- all CIs are passing

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
