### PR TITLE
feat:CP-9655 handle more digits in fee usd value

### DIFF
--- a/src/contexts/utils/getCurrencyFormatter.ts
+++ b/src/contexts/utils/getCurrencyFormatter.ts
@@ -6,6 +6,7 @@ export const getCurrencyFormatter = (currency = 'USD') => {
     style: 'currency',
     currency: currency,
     currencyDisplay: 'narrowSymbol',
+    maximumSignificantDigits: 6,
   });
 
   return (amount: number) => {

--- a/src/utils/calculateGasAndFees.ts
+++ b/src/utils/calculateGasAndFees.ts
@@ -48,7 +48,7 @@ export function calculateGasAndFees({
     fee: fee.toDisplay(),
     bnFee,
     feeUSD: price
-      ? price.mul(fee).toDisplay({ fixedDp: 2, asNumber: true })
+      ? price.mul(fee).toDisplay({ fixedDp: 6, asNumber: true })
       : null,
     tipUSD:
       price && tip


### PR DESCRIPTION
## Description

Due to the lower gas prices we show the user $0.00 as a fee amount which is not correct (maybe itt will in the future).

## Changes

DIsplay more digits (up to 6)

## Testing

Go to send or an other tx -> populate everiything and go to the approval screen -> check the fee amount in currency at the bottom of the approval screen

## Screenshots:

![image](https://github.com/user-attachments/assets/0ae00c98-505c-4dd7-828a-ca5f3ed1590a)


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
