### PR TITLE
fix(ext): remove large ext files causing errors in smoke tests

### DIFF
--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -52,7 +52,7 @@ jobs:
         run: yarn setup
       - name: Build library
         run: yarn build:alpha
-      - name: Remove onboarding video
+      - name: Remove large extension files
         run: |
           rm -fv ./dist/images/core-ext-hero-hq.webm
 					rm -fv ./dist/images/onboarding-background.svg

--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Remove large extension files
         run: |
           rm -fv ./dist/images/core-ext-hero-hq.webm
-					rm -fv ./dist/images/onboarding-background.svg
+          rm -fv ./dist/images/onboarding-background.svg
           rm -fv ./dist/images/onboarding-background.png
       - name: Add extension key to manifest file
         run: |

--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -55,6 +55,8 @@ jobs:
       - name: Remove onboarding video
         run: |
           rm -fv ./dist/images/core-ext-hero-hq.webm
+					rm -fv ./dist/images/onboarding-background.svg
+          rm -fv ./dist/images/onboarding-background.png
       - name: Add extension key to manifest file
         run: |
           echo $(cat ./dist/manifest.json | jq '.key = "${{ secrets.EXTENSION_PUBLIC_KEY }}"') > ./dist/manifest.json


### PR DESCRIPTION
## Description

- It appears that any time automation tests are kicked off with an extension file larger than approximately ~37mb, it causes problems loading the extension into the browser at the start of the tests. Removing the two largest files before running the tests fixes.
