### PR TITLE
fix: collectible contact dropdown size

### DIFF
--- a/src/pages/Collectibles/SendEVMCollectible.tsx
+++ b/src/pages/Collectibles/SendEVMCollectible.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   Tooltip,
   Typography,
+  styled,
 } from '@avalabs/core-k2-components';
 
 import { useQueryParams } from '@src/hooks/useQueryParams';
@@ -35,6 +36,12 @@ type Props = SendPageProps<
   NetworkTokenWithBalance,
   [NftTokenWithBalance]
 >;
+
+const FlexScrollbars = styled(Scrollbars)`
+	> div {
+		display: flex;
+	}
+}`;
 
 export const SendEVMCollectible = ({
   network,
@@ -114,8 +121,15 @@ export const SendEVMCollectible = ({
 
   return (
     <Stack sx={{ flexGrow: 1, alignItems: 'center', width: '100%', pt: 1 }}>
-      <Scrollbars style={{ flexGrow: 1, maxHeight: 'unset', height: '100%' }}>
-        <Stack ref={formRef}>
+      <FlexScrollbars
+        style={{
+          flexGrow: 1,
+          maxHeight: 'unset',
+          height: '100%',
+          display: 'flex',
+        }}
+      >
+        <Stack ref={formRef} sx={{ display: 'flex', flexGrow: 1, mb: 2 }}>
           <ContactInput
             contact={contact}
             onChange={(newContact) => {
@@ -171,7 +185,7 @@ export const SendEVMCollectible = ({
             </Card>
           </Stack>
         </Stack>
-      </Scrollbars>
+      </FlexScrollbars>
       {!isContactsOpen && (
         <Stack
           sx={{


### PR DESCRIPTION
## Description

Ticket: https://ava-labs.atlassian.net/browse/CP-9816

- Fixes a UI bug found during regression testing of the latest blue. Applied @meeh0w's same exact fix for the send token contact dropdown to the collectible form which had the same issue. Previous fix here: https://github.com/ava-labs/core-extension/pull/107

## Testing

- Have many accounts/contacts
- Click on the collectibles tab
- Select a collectible to send
- Click contacts button in address input
- Verify the dropdown is of proper size

## Screenshots:

Before (Blue build) vs After video (Dev build):

https://github.com/user-attachments/assets/cb5f731f-bad7-4fbe-b0f9-eec1e4a2bfe9


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [X] I've tested the changes myself before sending it to code review and QA.
