### PR TITLE
feat: CP-9655 check the fraction numebr and transform

### DIFF
--- a/src/contexts/utils/getCurrencyFormatter.test.ts
+++ b/src/contexts/utils/getCurrencyFormatter.test.ts
@@ -1,0 +1,43 @@
+import { getCurrencyFormatter } from './getCurrencyFormatter';
+
+describe('contexts/utils/getCurrencyFormatter', () => {
+  const formatter = getCurrencyFormatter();
+  it('should return with the dollar sign and two fraction numbers', () => {
+    const value = formatter(12);
+    expect(value).toBe('$12.00');
+
+    const value2 = formatter(12.1);
+    expect(value2).toBe('$12.10');
+
+    const value3 = formatter(12.01);
+    expect(value3).toBe('$12.01');
+
+    const value4 = formatter(12.011);
+    expect(value4).toBe('$12.01');
+  });
+  it('should return with the dollar sign and the first two fraction numbers when the integer is a zero', () => {
+    const value = formatter(0.123);
+    expect(value).toBe('$0.12');
+
+    const value2 = formatter(0.02);
+    expect(value2).toBe('$0.02');
+
+    const value3 = formatter(0.0234);
+    expect(value3).toBe('$0.02');
+  });
+  it('should return with the dollar sign and look for the first non-zero fraction number', () => {
+    const value = formatter(0.00023);
+    expect(value).toBe('$0.0002');
+
+    const value2 = formatter(0.000023);
+    expect(value2).toBe('$0.00002');
+
+    // NOTE: this is the last point (in terms of the number of the fraction part) we handle, below that the scientific notation is not something we deal with at the moment
+    const value3 = formatter(0.0000023);
+    expect(value3).toBe('$0.000002');
+
+    // this is with scientific notation
+    const value4 = formatter(0.00000023);
+    expect(value4).not.toBe('$0.0000002');
+  });
+});

--- a/src/contexts/utils/getCurrencyFormatter.ts
+++ b/src/contexts/utils/getCurrencyFormatter.ts
@@ -6,11 +6,13 @@ export const getCurrencyFormatter = (currency = 'USD') => {
     style: 'currency',
     currency: currency,
     currencyDisplay: 'narrowSymbol',
-    maximumSignificantDigits: 6,
+    maximumFractionDigits: 6,
   });
 
   return (amount: number) => {
-    const parts = formatter.formatToParts(amount);
+    const transformedAmount = modifyFractionNumber(amount);
+    const parts = formatter.formatToParts(transformedAmount);
+
     /**
      *  This formats the currency to return
      *  <symbol><amount>
@@ -26,6 +28,19 @@ export const getCurrencyFormatter = (currency = 'USD') => {
       return flatArray.join('').trim();
     }
 
-    return formatter.format(amount);
+    return formatter.format(transformedAmount);
   };
+};
+
+const modifyFractionNumber = (amount: number) => {
+  const [integer, fraction] = amount.toString().split('.');
+  const indexOfNonZero = fraction?.search(/[1-9]/);
+
+  if (!indexOfNonZero || indexOfNonZero < 2 || integer !== '0') {
+    return parseFloat(`${integer}.${fraction?.slice(0, 2)}`);
+  }
+  if (indexOfNonZero && indexOfNonZero >= 2 && integer === '0') {
+    return parseFloat(`${integer}.${fraction?.slice(0, indexOfNonZero + 1)}`);
+  }
+  return amount;
 };


### PR DESCRIPTION
## Description

The fraction number display was not the AC.

## Changes

If the fraction has zeros the first non-zero value will be displayed (when the integer is 0, otherwise we will show two digits).

## Testing

Go the the portfolio and a transaction (e.g. send) and see the value has the right fraction numbers.

## Screenshots:

![image](https://github.com/user-attachments/assets/54257f68-0939-462f-a437-7e5345372dc1)


## Checklist for the author

Tick each of them when done or if not applicable.

- [x] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
