### PR TITLE
feat: scroll to the active account

### DIFF
--- a/src/pages/Accounts/components/AccountItem.tsx
+++ b/src/pages/Accounts/components/AccountItem.tsx
@@ -13,6 +13,7 @@ import {
   ForwardedRef,
   forwardRef,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -79,6 +80,18 @@ export const AccountItem = forwardRef(
     const address = network ? getAddressForChain(network.chainId, account) : '';
     const [cardHovered, setCardHovered] = useState(false);
     const itemRef = useRef<HTMLDivElement>(null);
+    const firstPageload = useRef(true);
+
+    useEffect(() => {
+      if (isActive) {
+        const behavior = firstPageload.current ? 'instant' : 'smooth';
+        itemRef?.current?.scrollIntoView({
+          block: 'center',
+          behavior,
+        });
+      }
+      firstPageload.current = false;
+    }, [isActive]);
 
     const toggle = useCallback(
       (accountId: string) => {


### PR DESCRIPTION
## Description

[https://ava-labs.atlassian.net/jira/software/c/projects/CP/boards/72?selectedIssue=CP-9842](url)

## Changes

Check the active account and scroll there. When the page has been loaded first time we don't need an animation for scrolling.

## Testing

Go to the account page and play around the accounts a bit. Select a new one to be the active, add another, go back to the portfolio and visit the accounts page again etc.

## Screenshots:


https://github.com/user-attachments/assets/bf10795f-1ea3-4137-af44-4c5111ef0044


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
