### PR TITLE
feat: add balance polling to two other pages

### DIFF
--- a/src/pages/Home/components/Portfolio/Assets.tsx
+++ b/src/pages/Home/components/Portfolio/Assets.tsx
@@ -28,11 +28,15 @@ import { isBitcoinNetwork } from '@src/background/services/network/utils/isBitco
 import { useAnalyticsContext } from '@src/contexts/AnalyticsProvider';
 import { useTokenPriceMissing } from '@src/hooks/useTokenPriceIsMissing';
 import { PAndL } from '@src/components/common/ProfitAndLoss';
+import { useLiveBalance } from '@src/hooks/useLiveBalance';
+import { TokenType } from '@avalabs/vm-module-types';
 
 enum AssetsTabs {
   TOKENS,
   ACTIVITY,
 }
+
+const POLLED_BALANCES = [TokenType.NATIVE, TokenType.ERC20];
 
 export function Assets() {
   const { t } = useTranslation();
@@ -69,6 +73,8 @@ export function Assets() {
     }
     return isPriceMissingFromNetwork(network?.chainId);
   }, [isPriceMissingFromNetwork, network]);
+
+  useLiveBalance(POLLED_BALANCES);
 
   return (
     <Stack sx={{ flexGrow: 1 }}>

--- a/src/pages/Wallet/TokenFlow.tsx
+++ b/src/pages/Wallet/TokenFlow.tsx
@@ -38,6 +38,10 @@ import { isXchainNetwork } from '@src/background/services/network/utils/isAvalan
 import { getUnconfirmedBalanceInCurrency } from '@src/background/services/balances/models';
 import { isTokenMalicious } from '@src/utils/isTokenMalicious';
 import { MaliciousTokenWarningBox } from '@src/components/common/MaliciousTokenWarning';
+import { useLiveBalance } from '@src/hooks/useLiveBalance';
+import { TokenType } from '@avalabs/vm-module-types';
+
+const POLLED_BALANCES = [TokenType.NATIVE, TokenType.ERC20];
 
 export function TokenFlow() {
   const { t } = useTranslation();
@@ -96,6 +100,8 @@ export function TokenFlow() {
       setTokensWithBalancesAreReady(!!tokensWithBalances.length);
     }
   }, [activeAccount, hasAccessToActiveNetwork, tokensWithBalances]);
+
+  useLiveBalance(POLLED_BALANCES);
 
   if (!hasAccessToActiveNetwork) {
     return (


### PR DESCRIPTION
## Description

[https://ava-labs.atlassian.net/browse/CP-9871](url)

## Changes

Add `useLiveBalance` to two new pages 

## Testing

Go to Send in the core web app -> send something -> the balance changes should appear in the Assets and Token pages as well not just in Portfolio

## Screenshots:

https://github.com/user-attachments/assets/f53a8e1e-af4c-4c94-995c-af0c6e33a4f1


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
