### PR TITLE
fix: remove more files to fix ci automation

### DIFF
--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -59,6 +59,9 @@ jobs:
           rm -fv ./dist/images/core-ext-hero-hq.webm
           rm -fv ./dist/images/onboarding-background.svg
           rm -fv ./dist/images/onboarding-background.png
+          rm -fv ./dist/images/keystone/keystone_onboarding_step_1.png
+          rm -fv ./dist/images/keystone/keystone_onboarding_step_2.png
+          rm -fv ./dist/images/keystone/keystone_onboarding_step_3.png
       - name: Add extension key to manifest file
         run: |
           echo $(cat ./dist/manifest.json | jq '.key = "${{ secrets.EXTENSION_PUBLIC_KEY }}"') > ./dist/manifest.json


### PR DESCRIPTION
## Description

- Any time automation tests are kicked off with an extension file larger than approximately ~37mb, it causes problems loading the extension into the browser at the start of the tests. Removing the more large files in the CI extension build before running the tests fixes.
