### PR TITLE
feat: CP-9247 add toast to swap status

### DIFF
--- a/src/contexts/SwapProvider/SwapProvider.test.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.test.tsx
@@ -93,6 +93,8 @@ jest.mock('ethers');
 jest.mock('@avalabs/core-k2-components', () => ({
   toast: {
     success: jest.fn(),
+    loading: jest.fn(),
+    dismiss: jest.fn(),
   },
 }));
 

--- a/src/contexts/SwapProvider/SwapProvider.test.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.test.tsx
@@ -90,6 +90,11 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('ethers');
+jest.mock('@avalabs/core-k2-components', () => ({
+  toast: {
+    success: jest.fn(),
+  },
+}));
 
 describe('contexts/SwapProvider', () => {
   const connectionContext = {

--- a/src/contexts/SwapProvider/SwapProvider.test.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.test.tsx
@@ -95,6 +95,7 @@ jest.mock('@avalabs/core-k2-components', () => ({
     success: jest.fn(),
     loading: jest.fn(),
     dismiss: jest.fn(),
+    error: jest.fn(),
   },
 }));
 

--- a/src/contexts/SwapProvider/SwapProvider.test.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.test.tsx
@@ -96,6 +96,8 @@ jest.mock('@avalabs/core-k2-components', () => ({
     loading: jest.fn(),
     dismiss: jest.fn(),
     error: jest.fn(),
+    custom: jest.fn(),
+    remove: jest.fn(),
   },
 }));
 

--- a/src/contexts/SwapProvider/SwapProvider.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.tsx
@@ -46,6 +46,7 @@ import { CommonError } from '@src/utils/errors';
 import { useWalletContext } from '../WalletProvider';
 import { SecretType } from '@src/background/services/secrets/models';
 import { toast } from '@avalabs/core-k2-components';
+import { SwapPendingToast } from '@src/pages/Swap/components/SwapPendingToast';
 
 export const SwapContext = createContext<SwapContextAPI>({} as any);
 
@@ -279,7 +280,8 @@ export function SwapContextProvider({ children }: { children: any }) {
           ? t('Swap transaction succeeded! 🎉')
           : t('Swap transaction failed! ❌');
 
-        toast.dismiss(pendingToastIdRef.current);
+        toast.remove(pendingToastIdRef.current);
+
         if (isSuccessful) {
           toast.success(notificationText);
         }
@@ -470,9 +472,16 @@ export function SwapContextProvider({ children }: { children: any }) {
         swapTxHash = txHash;
       }
 
-      pendingToastIdRef.current = toast.loading(t('Swap pending...'), {
-        duration: Infinity,
-      });
+      const toastId = toast.custom(
+        <SwapPendingToast onDismiss={() => toast.remove(toastId)}>
+          {t('Swap pending...')}
+        </SwapPendingToast>,
+
+        {
+          duration: Infinity,
+        },
+      );
+      pendingToastIdRef.current = toastId;
 
       notifyOnSwapResult({
         provider: avaxProviderC,
@@ -587,9 +596,16 @@ export function SwapContextProvider({ children }: { children: any }) {
         }),
       );
 
-      pendingToastIdRef.current = toast.loading(t('Swap pending...'), {
-        duration: Infinity,
-      });
+      const toastId = toast.custom(
+        <SwapPendingToast onDismiss={() => toast.remove(toastId)}>
+          {t('Swap pending...')}
+        </SwapPendingToast>,
+
+        {
+          duration: Infinity,
+        },
+      );
+      pendingToastIdRef.current = toastId;
 
       if (signError || !swapTxHash) {
         return throwError(signError);

--- a/src/contexts/SwapProvider/SwapProvider.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.tsx
@@ -280,7 +280,13 @@ export function SwapContextProvider({ children }: { children: any }) {
           : t('Swap transaction failed! ❌');
 
         toast.dismiss(pendingToastIdRef.current);
-        toast.success(notificationText);
+        if (isSuccessful) {
+          toast.success(notificationText);
+        }
+
+        if (!isSuccessful) {
+          toast.error(notificationText);
+        }
 
         browser.notifications.create({
           type: 'basic',
@@ -464,7 +470,9 @@ export function SwapContextProvider({ children }: { children: any }) {
         swapTxHash = txHash;
       }
 
-      pendingToastIdRef.current = toast.loading(t('Swap pending...'));
+      pendingToastIdRef.current = toast.loading(t('Swap pending...'), {
+        duration: Infinity,
+      });
 
       notifyOnSwapResult({
         provider: avaxProviderC,
@@ -579,7 +587,9 @@ export function SwapContextProvider({ children }: { children: any }) {
         }),
       );
 
-      pendingToastIdRef.current = toast.loading(t('Swap pending...'));
+      pendingToastIdRef.current = toast.loading(t('Swap pending...'), {
+        duration: Infinity,
+      });
 
       if (signError || !swapTxHash) {
         return throwError(signError);

--- a/src/contexts/SwapProvider/SwapProvider.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo } from 'react';
+import { createContext, useCallback, useContext, useMemo, useRef } from 'react';
 import type { JsonRpcBatchInternal } from '@avalabs/core-wallets-sdk';
 import { TransactionParams } from '@avalabs/evm-module';
 import { resolve } from '@avalabs/core-utils-sdk';
@@ -64,6 +64,7 @@ export function SwapContextProvider({ children }: { children: any }) {
     forceShowTokensWithoutBalances: true,
     disallowedAssets: DISALLOWED_SWAP_ASSETS,
   });
+  const pendingToastIdRef = useRef('');
 
   const paraswap = useMemo(
     () => new ParaSwap(ChainId.AVALANCHE_MAINNET_ID, undefined, new Web3()),
@@ -278,6 +279,7 @@ export function SwapContextProvider({ children }: { children: any }) {
           ? t('Swap transaction succeeded! 🎉')
           : t('Swap transaction failed! ❌');
 
+        toast.dismiss(pendingToastIdRef.current);
         toast.success(notificationText);
 
         browser.notifications.create({
@@ -462,6 +464,8 @@ export function SwapContextProvider({ children }: { children: any }) {
         swapTxHash = txHash;
       }
 
+      pendingToastIdRef.current = toast.loading(t('Swap pending...'));
+
       notifyOnSwapResult({
         provider: avaxProviderC,
         txHash: swapTxHash,
@@ -475,15 +479,16 @@ export function SwapContextProvider({ children }: { children: any }) {
       });
     },
     [
-      activeAccount,
-      activeNetwork,
-      avaxProviderC,
-      buildTx,
-      networkFee,
-      request,
-      notifyOnSwapResult,
-      getSwapTxProps,
       isFlagEnabled,
+      activeNetwork,
+      networkFee,
+      activeAccount,
+      avaxProviderC,
+      getSwapTxProps,
+      buildTx,
+      t,
+      notifyOnSwapResult,
+      request,
     ],
   );
 
@@ -574,6 +579,8 @@ export function SwapContextProvider({ children }: { children: any }) {
         }),
       );
 
+      pendingToastIdRef.current = toast.loading(t('Swap pending...'));
+
       if (signError || !swapTxHash) {
         return throwError(signError);
       }
@@ -591,14 +598,15 @@ export function SwapContextProvider({ children }: { children: any }) {
       });
     },
     [
-      activeAccount,
       activeNetwork,
-      avaxProviderC,
-      buildTx,
       networkFee,
-      request,
-      notifyOnSwapResult,
+      activeAccount,
+      avaxProviderC,
       getSwapTxProps,
+      request,
+      t,
+      notifyOnSwapResult,
+      buildTx,
     ],
   );
 

--- a/src/contexts/SwapProvider/SwapProvider.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.tsx
@@ -45,6 +45,7 @@ import { assert, assertPresent } from '@src/utils/assertions';
 import { CommonError } from '@src/utils/errors';
 import { useWalletContext } from '../WalletProvider';
 import { SecretType } from '@src/background/services/secrets/models';
+import { toast } from '@avalabs/core-k2-components';
 
 export const SwapContext = createContext<SwapContextAPI>({} as any);
 
@@ -273,11 +274,15 @@ export function SwapContextProvider({ children }: { children: any }) {
           .div(10 ** destDecimals)
           .toString();
 
+        const notificationText = isSuccessful
+          ? t('Swap transaction succeeded! 🎉')
+          : t('Swap transaction failed! ❌');
+
+        toast.success(notificationText);
+
         browser.notifications.create({
           type: 'basic',
-          title: isSuccessful
-            ? t('Swap transaction succeeded! 🎉')
-            : t('Swap transaction failed! ❌'),
+          title: notificationText,
           iconUrl: '../../../../images/icon-256.png',
           priority: 2,
           message: isSuccessful

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -184,7 +184,6 @@ export function Swap() {
     }
 
     if (!error) {
-      toast.loading(t('Swap pending...'));
       history.push('/home');
     }
   }

--- a/src/pages/Swap/components/SwapPendingToast.tsx
+++ b/src/pages/Swap/components/SwapPendingToast.tsx
@@ -1,0 +1,26 @@
+import {
+  Card,
+  CircularProgress,
+  Grow,
+  IconButton,
+  Stack,
+  Typography,
+  XIcon,
+} from '@avalabs/core-k2-components';
+
+export const SwapPendingToast = ({ onDismiss, children }) => (
+  <Grow in>
+    <Card sx={{ width: 250, position: 'relative', p: 2 }}>
+      <IconButton
+        sx={{ position: 'absolute', top: 4, right: 4 }}
+        onClick={onDismiss}
+      >
+        <XIcon size={16} />
+      </IconButton>
+      <Stack sx={{ flexDirection: 'row', alignItems: 'center' }}>
+        <Typography variant="h6">{children}</Typography>
+        <CircularProgress size={12} sx={{ ml: 1 }} color="primary" />
+      </Stack>
+    </Card>
+  </Grow>
+);


### PR DESCRIPTION
## Description

[https://ava-labs.atlassian.net/browse/CP-9247](url)

## Changes

Move the toasters to the swap provider to handle the notifications.

## Testing

Go to swap -> approve a transaction and watch the toasters, it should be pending after the failed ir success message

## Screenshots:


https://github.com/user-attachments/assets/55d1866f-0c25-41ea-92f5-762be99cdd96




## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
