### PR TITLE
chore: remove devnet p-chain references

### DIFF
--- a/src/background/services/accounts/AccountsService.ts
+++ b/src/background/services/accounts/AccountsService.ts
@@ -26,8 +26,6 @@ import getAllAddressesForAccount from '@src/utils/getAllAddressesForAccount';
 import { SecretsService } from '../secrets/SecretsService';
 import { LedgerService } from '../ledger/LedgerService';
 import { WalletConnectService } from '../walletConnect/WalletConnectService';
-import { Network } from '../network/models';
-import { isDevnet } from '@src/utils/isDevnet';
 
 type AddAccountParams = {
   walletId: string;
@@ -100,26 +98,7 @@ export class AccountsService implements OnLock, OnUnlock {
     // refresh addresses so in case the user switches to testnet mode,
     // as the BTC address needs to be updated
     this.networkService.developerModeChanged.add(this.onDeveloperModeChanged);
-
-    // TODO(@meeh0w):
-    // Remove this listener after E-upgrade activation on Fuji. It will be no longer needed.
-    this.networkService.uiActiveNetworkChanged.add(
-      this.#onActiveNetworkChanged,
-    );
   }
-
-  #wasDevnet = false;
-
-  #onActiveNetworkChanged = async (network?: Network) => {
-    if (!network) {
-      return;
-    }
-
-    if (isDevnet(network) !== this.#wasDevnet) {
-      this.#wasDevnet = isDevnet(network);
-      await this.onDeveloperModeChanged(network?.isTestnet);
-    }
-  };
 
   onLock() {
     this.accounts = {
@@ -130,9 +109,6 @@ export class AccountsService implements OnLock, OnUnlock {
 
     this.networkService.developerModeChanged.remove(
       this.onDeveloperModeChanged,
-    );
-    this.networkService.uiActiveNetworkChanged.remove(
-      this.#onActiveNetworkChanged,
     );
   }
 

--- a/src/background/services/network/NetworkService.ts
+++ b/src/background/services/network/NetworkService.ts
@@ -18,7 +18,6 @@ import {
   NetworkWithCaipId,
 } from './models';
 import {
-  AVALANCHE_P_DEV_NETWORK,
   AVALANCHE_XP_NETWORK,
   AVALANCHE_XP_TEST_NETWORK,
   BITCOIN_NETWORK,
@@ -53,7 +52,6 @@ import {
   decorateWithCaipId,
 } from '@src/utils/caipConversion';
 import { getSyncDomain, isSyncDomain } from './utils/getSyncDomain';
-import { isDevnet } from '@src/utils/isDevnet';
 
 @singleton()
 export class NetworkService implements OnLock, OnStorageReady {
@@ -377,9 +375,6 @@ export class NetworkService implements OnLock, OnStorageReady {
 
     return networkList;
   }
-  private _getPchainDevnet(): Network {
-    return decorateWithCaipId(AVALANCHE_P_DEV_NETWORK);
-  }
 
   private _getPchainNetwork(isTestnet: boolean): Network {
     const network = isTestnet
@@ -449,7 +444,6 @@ export class NetworkService implements OnLock, OnStorageReady {
           [ChainId.AVALANCHE_P]: this._getPchainNetwork(false),
           [ChainId.AVALANCHE_TEST_X]: this._getXchainNetwork(true),
           [ChainId.AVALANCHE_X]: this._getXchainNetwork(false),
-          [ChainId.AVALANCHE_DEVNET_P]: this._getPchainDevnet(),
         };
       } else {
         attempt += 1;
@@ -486,13 +480,7 @@ export class NetworkService implements OnLock, OnStorageReady {
    * Returns the network object for Avalanche X/P Chains
    */
   getAvalancheNetworkXP() {
-    // TODO(@meeh0w): clean up after E-upgrade activation on Fuji
-    const isDevnetActive =
-      this.uiActiveNetwork && isDevnet(this.uiActiveNetwork);
-
-    return isDevnetActive
-      ? this._getPchainDevnet()
-      : this._getXchainNetwork(!this.isMainnet());
+    return this._getXchainNetwork(!this.isMainnet());
   }
 
   async getAvalancheNetwork() {

--- a/src/background/services/network/utils/isAvalanchePchainNetwork.ts
+++ b/src/background/services/network/utils/isAvalanchePchainNetwork.ts
@@ -9,8 +9,6 @@ export function isPchainNetwork(network?: Network) {
 
 export function isPchainNetworkId(chainId: number) {
   return (
-    ChainId.AVALANCHE_P === chainId ||
-    ChainId.AVALANCHE_TEST_P === chainId ||
-    ChainId.AVALANCHE_DEVNET_P === chainId // TODO: to remove this.
+    ChainId.AVALANCHE_P === chainId || ChainId.AVALANCHE_TEST_P === chainId
   );
 }

--- a/src/background/services/network/utils/isAvalancheXchainNetwork.ts
+++ b/src/background/services/network/utils/isAvalancheXchainNetwork.ts
@@ -10,8 +10,6 @@ export function isXchainNetwork(network?: Network) {
 //TODO: Fix this once we figure out how to separate between x and p chain ID
 export function isXchainNetworkId(chainId: number) {
   return (
-    ChainId.AVALANCHE_X === chainId ||
-    ChainId.AVALANCHE_TEST_X === chainId ||
-    ChainId.AVALANCHE_DEVNET_X === chainId // TODO: to remove this.
+    ChainId.AVALANCHE_X === chainId || ChainId.AVALANCHE_TEST_X === chainId
   );
 }

--- a/src/background/services/wallet/handlers/avalanche_sendTransaction.ts
+++ b/src/background/services/wallet/handlers/avalanche_sendTransaction.ts
@@ -27,7 +27,6 @@ import { ChainId } from '@avalabs/core-chains-sdk';
 import { openApprovalWindow } from '@src/background/runtime/openApprovalWindow';
 import { measureDuration } from '@src/utils/measureDuration';
 import { HEADERS } from '../../glacier/glacierConfig';
-import { isDevnet } from '@src/utils/isDevnet';
 
 type TxParams = {
   transactionHex: string;
@@ -110,11 +109,7 @@ export class AvalancheSendTransactionHandler extends DAppRequestHandler<
       : await Avalanche.getUtxosByTxFromGlacier({
           transactionHex,
           chainAlias,
-          network: isDevnet(network)
-            ? Network.DEVNET
-            : network.isTestnet
-              ? Network.FUJI
-              : Network.MAINNET,
+          network: network.isTestnet ? Network.FUJI : Network.MAINNET,
           url: process.env.GLACIER_URL as string,
           token: process.env.GLACIER_API_KEY,
           headers: HEADERS,

--- a/src/background/services/wallet/handlers/avalanche_signTransaction.ts
+++ b/src/background/services/wallet/handlers/avalanche_signTransaction.ts
@@ -22,7 +22,6 @@ import { Network } from '@avalabs/glacier-sdk';
 import getProvidedUtxos from '../utils/getProvidedUtxos';
 import { openApprovalWindow } from '@src/background/runtime/openApprovalWindow';
 import { HEADERS } from '../../glacier/glacierConfig';
-import { isDevnet } from '@src/utils/isDevnet';
 
 type TxParams = {
   transactionHex: string;
@@ -92,11 +91,7 @@ export class AvalancheSignTransactionHandler extends DAppRequestHandler<TxParams
       : await Avalanche.getUtxosByTxFromGlacier({
           transactionHex,
           chainAlias,
-          network: isDevnet(network)
-            ? Network.DEVNET
-            : network.isTestnet
-              ? Network.FUJI
-              : Network.MAINNET,
+          network: network.isTestnet ? Network.FUJI : Network.MAINNET,
           url: process.env.GLACIER_URL as string,
           token: process.env.GLACIER_API_KEY,
           headers: HEADERS,

--- a/src/utils/caipConversion.ts
+++ b/src/utils/caipConversion.ts
@@ -20,7 +20,6 @@ export const AvaxCaipId = {
   [ChainId.AVALANCHE_X]: `${CaipNamespace.AVAX}:${Avalanche.MainnetContext.xBlockchainID}`,
   [ChainId.AVALANCHE_TEST_P]: `${CaipNamespace.AVAX}:fuji${Avalanche.FujiContext.pBlockchainID}`,
   [ChainId.AVALANCHE_TEST_X]: `${CaipNamespace.AVAX}:fuji${Avalanche.FujiContext.xBlockchainID}`,
-  [ChainId.AVALANCHE_DEVNET_P]: `${CaipNamespace.AVAX}:custom11111111111111111111111111111111LpoYY`,
 } as const;
 
 export const getNetworkCaipId = (network: PartialBy<Network, 'caipId'>) => {

--- a/src/utils/isDevnet.ts
+++ b/src/utils/isDevnet.ts
@@ -1,5 +1,0 @@
-import { ChainId } from '@avalabs/core-chains-sdk';
-import { Network } from '@src/background/services/network/models';
-
-export const isDevnet = (network: Network) =>
-  network.chainId === ChainId.AVALANCHE_DEVNET_P || network.chainId === 43117;

--- a/src/utils/network/getProviderForNetwork.ts
+++ b/src/utils/network/getProviderForNetwork.ts
@@ -9,7 +9,6 @@ import { info } from '@avalabs/avalanchejs';
 
 import { Network } from '@src/background/services/network/models';
 
-import { isDevnet } from '../isDevnet';
 import { addGlacierAPIKeyIfNeeded } from './addGlacierAPIKeyIfNeeded';
 
 export type SupportedProvider =
@@ -68,11 +67,9 @@ export const getProviderForNetwork = async (
       .getUpgradesInfo()
       .catch(() => undefined);
 
-    return isDevnet(network)
-      ? Avalanche.JsonRpcProvider.getDefaultDevnetProvider(upgradesInfo)
-      : network.isTestnet
-        ? Avalanche.JsonRpcProvider.getDefaultFujiProvider(upgradesInfo)
-        : Avalanche.JsonRpcProvider.getDefaultMainnetProvider(upgradesInfo);
+    return network.isTestnet
+      ? Avalanche.JsonRpcProvider.getDefaultFujiProvider(upgradesInfo)
+      : Avalanche.JsonRpcProvider.getDefaultMainnetProvider(upgradesInfo);
   } else {
     throw new Error('unsupported network');
   }


### PR DESCRIPTION
## Description
_no ticket_


## TODOs
- [x] Update SDKs and VM modules: https://github.com/ava-labs/vm-modules/pull/237

## Changes
Platform team deprecated the P-Chain Etna devnet, we can remove the references from our codebase now.

## Testing
Everything works as before.

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
