### PR TITLE
fix: swapping AVAX/wAVAX

### DIFF
--- a/src/contexts/SwapProvider/SwapProvider.test.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.test.tsx
@@ -1,4 +1,4 @@
-import { SwapSide } from 'paraswap';
+import { ETHER_ADDRESS, SwapSide } from 'paraswap';
 import { createRef, forwardRef, useImperativeHandle } from 'react';
 
 import { matchingPayload, render } from '@src/tests/test-utils';
@@ -272,6 +272,60 @@ describe('contexts/SwapProvider', () => {
           },
         });
       });
+    });
+
+    it('maps srcToken to 0xEeEe... when its the native token', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        json: async () => ({
+          priceRoute: {
+            address: ROUTE_ADDRESS,
+            destAmount: 1000,
+          },
+        }),
+        ok: true,
+      } as any);
+
+      const { getRate } = getSwapProvider();
+      const params = buildGetRateParams({
+        srcToken: networkContext.network.networkToken.symbol,
+      });
+
+      await getRate(params);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        getExpectedURL('prices', {
+          ...params,
+          srcToken: ETHER_ADDRESS,
+          srcDecimals: 18,
+        }),
+      );
+    });
+
+    it('maps destToken to 0xEeEe... when its the native token', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        json: async () => ({
+          priceRoute: {
+            address: ROUTE_ADDRESS,
+            destAmount: 1000,
+          },
+        }),
+        ok: true,
+      } as any);
+
+      const { getRate } = getSwapProvider();
+      const params = buildGetRateParams({
+        destToken: networkContext.network.networkToken.symbol,
+      });
+
+      await getRate(params);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        getExpectedURL('prices', {
+          ...params,
+          destToken: ETHER_ADDRESS,
+          destDecimals: 18,
+        }),
+      );
     });
 
     describe('when a server times out', () => {

--- a/src/contexts/SwapProvider/SwapProvider.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.tsx
@@ -105,18 +105,17 @@ export function SwapContextProvider({ children }: { children: any }) {
         throw new Error(`Feature (SWAP) is currently unavailable`);
       }
 
+      const isFromTokenNative = activeNetwork.networkToken.symbol === srcToken;
+      const isDestTokenNative = activeNetwork.networkToken.symbol === destToken;
+
       const query = new URLSearchParams({
-        srcToken,
-        destToken,
+        srcToken: isFromTokenNative ? ETHER_ADDRESS : srcToken,
+        destToken: isDestTokenNative ? ETHER_ADDRESS : destToken,
         amount: srcAmount,
         side: swapSide || SwapSide.SELL,
         network: ChainId.AVALANCHE_MAINNET_ID.toString(),
-        srcDecimals: `${
-          activeNetwork.networkToken.symbol === srcToken ? 18 : srcDecimals
-        }`,
-        destDecimals: `${
-          activeNetwork.networkToken.symbol === destToken ? 18 : destDecimals
-        }`,
+        srcDecimals: `${isFromTokenNative ? 18 : srcDecimals}`,
+        destDecimals: `${isDestTokenNative ? 18 : destDecimals}`,
         userAddress: activeAccount.addressC,
       });
 


### PR DESCRIPTION
_no ticket_

## Changes
* Maps `srcToken` / `destToken` from `AVAX` to Ether address (`0xEeeEeeeEe....`). It seems Paraswap changed how they interpret it -- or it's been broken for months on our end now. ¯\\\_(ツ)_/¯ 

## Testing
* Attempt to swap AVAX -> WAVAX. It should work, and the exchange rate should be ~`1:1`

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [X] I've tested the changes myself before sending it to code review and QA.
