### PR TITLE
fix: reset error state when erc20 data is fetched

### DIFF
--- a/src/pages/ManageTokens/AddToken.tsx
+++ b/src/pages/ManageTokens/AddToken.tsx
@@ -97,6 +97,7 @@ export function AddToken() {
         setNewTokenData(undefined);
         return;
       }
+      setError('');
       setNewTokenData(data);
     };
 


### PR DESCRIPTION
## Description
* [CP-9948](https://ava-labs.atlassian.net/browse/CP-9948)

## Changes
* Error state was not being reset after successfully fetching the ERC-20's data

## Testing
Add a custom token (e.g. Willy - `0x403b78f9f817a55b66030c7b2ddab063d28c2c0c`), but type it by hand.

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
