### PR TITLE
fix: balance polling when closed

### DIFF
--- a/src/background/services/balances/BalancePollingService.ts
+++ b/src/background/services/balances/BalancePollingService.ts
@@ -15,10 +15,7 @@ export class BalancePollingService implements OnLock, OnAllExtensionClosed {
   #timer: NodeJS.Timeout | null = null;
   #pollingIteration = 0;
   #lastPollingStartedAt?: number;
-
-  get isPollingActive() {
-    return this.#timer !== null;
-  }
+  #isPollingActive = false;
 
   constructor(private balanceAggregator: BalanceAggregatorService) {}
 
@@ -35,6 +32,7 @@ export class BalancePollingService implements OnLock, OnAllExtensionClosed {
     // Stop any polling that may be occurring already
     this.stopPolling();
     // Start a new interval
+    this.#isPollingActive = true;
     return this.pollBalances(
       account,
       activeChainId,
@@ -48,6 +46,7 @@ export class BalancePollingService implements OnLock, OnAllExtensionClosed {
   }
 
   stopPolling() {
+    this.#isPollingActive = false;
     if (this.#timer) {
       clearTimeout(this.#timer);
       this.#timer = null;
@@ -85,7 +84,10 @@ export class BalancePollingService implements OnLock, OnAllExtensionClosed {
 
     // Only schedule the next update if another polling was not started
     // while we were waiting for balance results.
-    if (thisPollingStartedAt === this.#lastPollingStartedAt) {
+    if (
+      this.#isPollingActive &&
+      thisPollingStartedAt === this.#lastPollingStartedAt
+    ) {
       this.scheduleNextUpdate(
         account,
         activeChainId,

--- a/src/background/services/balances/BalancePollingService.ts
+++ b/src/background/services/balances/BalancePollingService.ts
@@ -19,6 +19,10 @@ export class BalancePollingService implements OnLock, OnAllExtensionClosed {
 
   constructor(private balanceAggregator: BalanceAggregatorService) {}
 
+  get isPollingActive() {
+    return this.#isPollingActive;
+  }
+
   onLock() {
     this.stopPolling();
   }


### PR DESCRIPTION
* [CP-9902](https://ava-labs.atlassian.net/browse/CP-9902)

## Description
* If extension was closed while one of the balance requests was still in-flight, polling would not stop.

## Changes
* Add an additional indicator when polling is requested and stopped.

## Testing
* See the videos attached. Timing is key.

## Screenshots:

### Before

https://github.com/user-attachments/assets/859b82dd-eed8-4444-baf0-bd24c280421b


### After

https://github.com/user-attachments/assets/f49b80a0-cf25-4d71-b958-72ced83e9f34


## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
