### PR TITLE
[CP-9976] fix spend page stuck in pending state

### DIFF
--- a/src/hooks/useTokensWithBalances.ts
+++ b/src/hooks/useTokensWithBalances.ts
@@ -191,7 +191,7 @@ export const useTokensWithBalances = (
     const defaultResult = nativeToken ? [nativeToken] : [];
 
     const filteredTokens = unfilteredTokens.filter((token) => {
-      return token.balance > 0n;
+      return token.type === TokenType.NATIVE || token.balance > 0n;
     });
 
     return visibleTokens(


### PR DESCRIPTION
## Description
Accounts with some ERC20 balances, but without native asset balance got stuck in a pending state on the `Send` page.
<!--- Describe your changes -->
<!--- Link and relevant resources e.g JIRA ticket, Figma Designs, PRs -->

## Changes
Modify tokenlist so it always contains the native asset
<!--- What types of changes does your code introduce? -->

## Testing
- send some ERC20s to an account that does not have native asset on any EVM chain
- switch to that account
- go to the `Spend` page
- confirm the page loads correctly
<!--- Describe in detail how your changes were tested. -->
<!--- Repeatable Steps to derive the desired output -->

## Screenshots:
[CP-9976](https://ava-labs.atlassian.net/browse/CP-9976)
<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
