### PR TITLE
feat: set gasless turn off by default

### DIFF
--- a/src/contexts/NetworkFeeProvider.tsx
+++ b/src/contexts/NetworkFeeProvider.tsx
@@ -209,6 +209,7 @@ export function NetworkFeeContextProvider({ children }: { children: any }) {
           setGaslessPhase(GaslessPhase.FUNDING_IN_PROGRESS);
         }
         if (values.fundTxHex) {
+          setIsGaslessOn(false);
           setGaslessPhase(GaslessPhase.FUNDED);
         }
         if (values.fundTxDoNotRetryError) {

--- a/src/pages/ApproveAction/GenericApprovalScreen.tsx
+++ b/src/pages/ApproveAction/GenericApprovalScreen.tsx
@@ -79,7 +79,6 @@ export function GenericApprovalScreen() {
   const {
     isGaslessOn,
     gaslessFundTx,
-    setIsGaslessOn,
     fundTxHex,
     setGaslessDefaultValues,
     gaslessPhase,
@@ -117,10 +116,6 @@ export function GenericApprovalScreen() {
     setGaslessEligibility,
     signingData,
   ]);
-
-  useEffect(() => {
-    setIsGaslessOn(isGaslessEligible);
-  }, [isGaslessEligible, setIsGaslessOn]);
 
   useEffect(() => {
     fetchAndSolveGaslessChallange();


### PR DESCRIPTION
## Description

We want to turn off gasless feature by default.

## Changes

Does not turn it on.

## Testing

Go to an approval screen (c-chain tx) -> the gasless witch should be turned off in the beginning

## Screenshots:


https://github.com/user-attachments/assets/487926cc-b023-4a1b-93cd-b6e1fd001e7e



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
