### PR TITLE
fix: eligibility state

### DIFF
--- a/src/components/common/CustomFees.tsx
+++ b/src/components/common/CustomFees.tsx
@@ -215,7 +215,8 @@ export function CustomFees({
       : selectedGasFeeModifier || GasFeeModifier.SLOW,
   );
 
-  const { isGaslessOn, setIsGaslessOn, gaslessPhase } = useNetworkFeeContext();
+  const { isGaslessOn, setIsGaslessOn, gaslessPhase, isGaslessEligible } =
+    useNetworkFeeContext();
 
   useLiveBalance(POLLED_BALANCES); // Make sure we always use the latest native balance.
 
@@ -418,7 +419,7 @@ export function CustomFees({
           unmountOnExit
         >
           {!isBatchApprovalScreen &&
-            gaslessPhase !== GaslessPhase.NOT_ELIGIBLE &&
+            isGaslessEligible &&
             gaslessPhase !== GaslessPhase.ERROR && (
               <GaslessFee
                 onSwitch={() => {
@@ -428,7 +429,11 @@ export function CustomFees({
                 disabled={gaslessPhase === GaslessPhase.FUNDING_IN_PROGRESS}
               />
             )}
-          <Collapse in={!isGaslessOn} mountOnEnter unmountOnExit>
+          <Collapse
+            in={!isGaslessOn || !isGaslessEligible}
+            mountOnEnter
+            unmountOnExit
+          >
             <Stack
               sx={{
                 flexDirection: 'row',

--- a/src/components/common/header/NetworkSwitcher/NetworkSwitcher.tsx
+++ b/src/components/common/header/NetworkSwitcher/NetworkSwitcher.tsx
@@ -95,6 +95,7 @@ export function NetworkSwitcher() {
           anchorEl={selectButtonRef.current}
           placement="bottom-end"
           transition
+          sx={{ zIndex: 1 }}
         >
           {({ TransitionProps }) => (
             <Grow {...TransitionProps} timeout={250}>

--- a/src/contexts/NetworkFeeProvider.tsx
+++ b/src/contexts/NetworkFeeProvider.tsx
@@ -42,6 +42,7 @@ const NetworkFeeContext = createContext<{
     fromAddress?: AddressLike | null,
     nonce?: number | null,
   ) => Promise<void>;
+  isGaslessEligible: boolean;
 }>({
   networkFee: null,
   async getNetworkFee() {
@@ -69,6 +70,7 @@ const NetworkFeeContext = createContext<{
   async setGaslessEligibility() {
     return;
   },
+  isGaslessEligible: false,
 });
 
 export function NetworkFeeContextProvider({ children }: { children: any }) {
@@ -84,6 +86,7 @@ export function NetworkFeeContextProvider({ children }: { children: any }) {
   const [gaslessPhase, setGaslessPhase] = useState<GaslessPhase>(
     GaslessPhase.NOT_READY,
   );
+  const [isGaslessEligible, setIsGaslessEligible] = useState(false);
 
   const getNetworkFee = useCallback(
     async (caipId: string) =>
@@ -100,8 +103,11 @@ export function NetworkFeeContextProvider({ children }: { children: any }) {
       fromAddress?: AddressLike | null,
       nonce?: number | null,
     ) => {
+      if (gaslessPhase === GaslessPhase.READY) {
+        return;
+      }
       if (!featureFlags[FeatureGates.GASLESS]) {
-        setGaslessPhase(GaslessPhase.NOT_ELIGIBLE);
+        setIsGaslessEligible(false);
         return;
       }
       try {
@@ -109,16 +115,18 @@ export function NetworkFeeContextProvider({ children }: { children: any }) {
           method: ExtensionRequest.GASLESS_GET_ELIGIBILITY,
           params: [chainId, fromAddress?.toString(), nonce ?? undefined],
         });
-        if (!result) {
-          setGaslessPhase(GaslessPhase.NOT_ELIGIBLE);
+        if (result) {
+          setIsGaslessEligible(true);
+          return;
         }
+        setIsGaslessEligible(false);
       } catch (e: any) {
         console.error(e);
-        setGaslessPhase(GaslessPhase.NOT_ELIGIBLE);
+        setIsGaslessEligible(false);
       }
     },
 
-    [featureFlags, request],
+    [featureFlags, gaslessPhase, request],
   );
 
   useEffect(() => {
@@ -181,6 +189,7 @@ export function NetworkFeeContextProvider({ children }: { children: any }) {
 
   const setGaslessDefaultValues = useCallback(async () => {
     setGaslessPhase(GaslessPhase.NOT_READY);
+    setIsGaslessEligible(false);
     return request<SetDefaultStateValuesHandler>({
       method: ExtensionRequest.GASLESS_SET_DEFAUlT_STATE_VALUES,
     });
@@ -236,6 +245,7 @@ export function NetworkFeeContextProvider({ children }: { children: any }) {
         fundTxHex,
         setGaslessDefaultValues,
         gaslessPhase,
+        isGaslessEligible,
       }}
     >
       {children}

--- a/src/contexts/NetworkFeeProvider.tsx
+++ b/src/contexts/NetworkFeeProvider.tsx
@@ -190,6 +190,7 @@ export function NetworkFeeContextProvider({ children }: { children: any }) {
   const setGaslessDefaultValues = useCallback(async () => {
     setGaslessPhase(GaslessPhase.NOT_READY);
     setIsGaslessEligible(false);
+    setIsGaslessOn(false);
     return request<SetDefaultStateValuesHandler>({
       method: ExtensionRequest.GASLESS_SET_DEFAUlT_STATE_VALUES,
     });

--- a/src/localization/locales/en/translation.json
+++ b/src/localization/locales/en/translation.json
@@ -377,7 +377,6 @@
   "From Wallet Connect": "From Wallet Connect",
   "From {{start}} to {{end}}": "From {{start}} to {{end}}",
   "From:": "From:",
-  "Gas Fund Successful": "Gas Fund Successful",
   "Gas Limit": "Gas Limit",
   "Gas Limit is too much": "Gas Limit is too much",
   "Gas Limit too low": "Gas Limit too low",

--- a/src/pages/ApproveAction/GenericApprovalScreen.tsx
+++ b/src/pages/ApproveAction/GenericApprovalScreen.tsx
@@ -131,7 +131,7 @@ export function GenericApprovalScreen() {
   }, [cancelHandler, setGaslessDefaultValues]);
 
   const signTx = useCallback(async () => {
-    if (isGaslessOn) {
+    if (isGaslessOn && isGaslessEligible) {
       return await gaslessFundTx(action?.signingData);
     }
     updateAction(
@@ -144,6 +144,7 @@ export function GenericApprovalScreen() {
   }, [
     action?.signingData,
     gaslessFundTx,
+    isGaslessEligible,
     isGaslessOn,
     isUsingKeystoneWallet,
     isUsingLedgerWallet,


### PR DESCRIPTION
## Description

There are multiple tickets live in this PR.
[CP-10087](https://ava-labs.atlassian.net/browse/CP-10087)
[CP-10089](https://ava-labs.atlassian.net/browse/CP-10089)
[CP-10091](https://ava-labs.atlassian.net/browse/CP-10091)
[CP-10092](https://ava-labs.atlassian.net/browse/CP-10092)

## Changes

Bring back the eligibility state, we cannot rely only on the phase unfortunately. If we are in a ready or not ready (which means we have not had the solution and challenge hexes) we will need the eligibility because of the asynchronous behaviour of the states.
The Success toast has been removed.
The networks list got a default z-index.

## Testing

Play through the gasless in multiple networks.

## Screenshots:

**Overlapping issue:** 

https://github.com/user-attachments/assets/e598197e-76f7-43be-a435-61a116419f4d

**Gasless Feature Eligibility:**


https://github.com/user-attachments/assets/6b8e5b9f-329e-494d-9bfb-c2fb0c21fe01


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
