### PR TITLE
[CP-10099] make wallet_getEthereumChain public

### DIFF
--- a/src/background/connections/middlewares/PermissionMiddleware.ts
+++ b/src/background/connections/middlewares/PermissionMiddleware.ts
@@ -97,6 +97,7 @@ export const UNRESTRICTED_METHODS = Object.freeze([
   DAppProviderRequest.AVALANCHE_SIGN_MESSAGE,
   DAppProviderRequest.AVALANCHE_GET_ACCOUNT_PUB_KEY,
   DAppProviderRequest.WALLET_ADD_NETWORK,
+  DAppProviderRequest.WALLET_GET_CHAIN,
   DAppProviderRequest.WALLET_GET_PUBKEY,
   DAppProviderRequest.WALLET_CONNECT,
   RpcMethod.HVM_SIGN_TRANSACTION,
@@ -115,7 +116,6 @@ const CORE_METHODS = Object.freeze([
   DAppProviderRequest.ACCOUNT_RENAME,
   DAppProviderRequest.ACCOUNTS_DELETE,
   DAppProviderRequest.BITCOIN_SEND_TRANSACTION,
-  DAppProviderRequest.WALLET_GET_CHAIN,
   DAppProviderRequest.WALLET_RENAME,
 ]);
 

--- a/src/background/services/network/handlers/wallet_getEthereumChain.ts
+++ b/src/background/services/network/handlers/wallet_getEthereumChain.ts
@@ -48,7 +48,7 @@ export class WalletGetEthereumChainHandler extends DAppRequestHandler {
     };
   };
 
-  handleUnauthenticated = ({ request }) => {
+  handleUnauthenticated = async ({ request }) => {
     return {
       ...request,
       error: ethErrors.rpc.invalidRequest({


### PR DESCRIPTION
## Description
Make `wallet_getEthereumChain` available to non-Core dApps
<!--- Describe your changes -->
<!--- Link and relevant resources e.g JIRA ticket, Figma Designs, PRs -->

## Changes

<!--- What types of changes does your code introduce? -->

## Testing
- go to a dApp and connect your wallet (eg.: [lfj](https://lfj.gg/swap))
- send a `wallet_getEthereumChain` request in the developer console via `await window.ethereum.request({method: 'wallet_getEthereumChain', params: []})`
- confirm that the chan info is returned correctly
<!--- Describe in detail how your changes were tested. -->
<!--- Repeatable Steps to derive the desired output -->

## Screenshots:

<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
