### PR TITLE
refactor: add feature flag check to UI

### DIFF
--- a/src/components/common/CustomFees.tsx
+++ b/src/components/common/CustomFees.tsx
@@ -34,6 +34,8 @@ import { CustomGasSettings } from './CustomGasSettings';
 import { useNetworkFeeContext } from '@src/contexts/NetworkFeeProvider';
 import GaslessFee from './GaslessFee';
 import { GaslessPhase } from '@src/background/services/gasless/model';
+import { FeatureGates } from '@src/background/services/featureFlags/models';
+import { useFeatureFlagContext } from '@src/contexts/FeatureFlagsProvider';
 
 export interface CustomGasFeesProps {
   maxFeePerGas: bigint;
@@ -207,6 +209,7 @@ export function CustomFees({
     }),
   );
   const [isCollapsed, setIsCollapsed] = useState(isCollapsible);
+  const { featureFlags } = useFeatureFlagContext();
   const customInputRef = useRef<HTMLInputElement>(null);
   const [showEditGasLimit, setShowEditGasLimit] = useState(false);
   const [selectedFee, setSelectedFee] = useState<GasFeeModifier>(
@@ -419,7 +422,8 @@ export function CustomFees({
         >
           {!isBatchApprovalScreen &&
             gaslessPhase !== GaslessPhase.NOT_ELIGIBLE &&
-            gaslessPhase !== GaslessPhase.ERROR && (
+            gaslessPhase !== GaslessPhase.ERROR &&
+            featureFlags[FeatureGates.GASLESS] && (
               <GaslessFee
                 onSwitch={() => {
                   onGaslessSwitch();


### PR DESCRIPTION
## Description

The feature was turned on for a moment despite we turned it off in Posthog 

## Changes

The UI got a feature flag check as well, although we have a check in the provider which is still required because of the Collectibles sending flow.

## Testing

Play around send.

## Screenshots:

### **_THE UNBEATABLE EVIDENCE:_**


https://github.com/user-attachments/assets/d9808353-7add-456b-8bb7-538929ae82aa



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
