### PR TITLE
fix: switch size

### DIFF
--- a/src/components/common/GaslessFee.tsx
+++ b/src/components/common/GaslessFee.tsx
@@ -40,7 +40,12 @@ export default function GaslessFee({
           <InfoCircleIcon sx={{ mx: 0.5, cursor: 'pointer' }} />
         </Tooltip>
       </Stack>
-      <Switch onChange={onSwitch} checked={isTurnedOn} disabled={disabled} />
+      <Switch
+        onChange={onSwitch}
+        checked={isTurnedOn}
+        disabled={disabled}
+        size="small"
+      />
     </Stack>
   );
 }


### PR DESCRIPTION
## Description

The Gasless switch size should be smaller.

## Changes

Using the small switch size

## Testing

Go to gasless and turn on and off it to check the switch size

## Screenshots:

![image](https://github.com/user-attachments/assets/34efeb2e-b0af-492c-8ae4-2268078b6293)

![image](https://github.com/user-attachments/assets/3593bcbd-1962-4904-a08d-515b60b8d97c)


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
