### PR TITLE
fix: swap render loop

### DIFF
--- a/src/pages/Swap/hooks/useSwapStateFunctions.ts
+++ b/src/pages/Swap/hooks/useSwapStateFunctions.ts
@@ -143,8 +143,8 @@ export function useSwapStateFunctions() {
       setDestinationInputField('');
 
       if (clearTokens) {
-        setSelectedFromToken(undefined);
-        setSelectedToToken(undefined);
+        setSelectedFromToken($NATIVE);
+        setSelectedToToken(USDC);
       }
 
       setValuesDebouncedSubject.next({
@@ -153,7 +153,7 @@ export function useSwapStateFunctions() {
         destinationInputField: undefined,
       });
     },
-    [setValuesDebouncedSubject],
+    [setValuesDebouncedSubject, $NATIVE, USDC],
   );
 
   const calculateSwapValue = ({


### PR DESCRIPTION
## Description
* [CP-10131](https://ava-labs.atlassian.net/browse/CP-10131)


## Changes
When switching network on the swap screen, it now sets the token pair to native -> USDC.
Previously it would set them to `undefined`, which would trigger a `useEffect` and try to use the values from history:

https://github.com/ava-labs/core-extension/blob/9e92da0308e0cccf30937c8c00d06e9503e9bb5f/src/pages/Swap/hooks/useSwapStateFunctions.ts#L89-L108

It would then also recalculate the from/to values, populate them, which would trigger a change event and another render loop...at least that's my understanding, as it was not 100% reproducible for me and probably depends on some timings/race conditions.

This change seems to fix it, though, as I tried many times and with this fix I could not reproduce it even once anymore.

## Testing
Follow the 1st and 2nd videos below.

## Screenshots:

### 1st way to reproduce
https://github.com/user-attachments/assets/c446c483-7375-4750-80f5-966354774c16

### 2nd way to reproduce
https://github.com/user-attachments/assets/e9dcaf78-0f62-4e93-bfa5-c484ca9047b7

### Fixed, I think ™ ?
https://github.com/user-attachments/assets/dc8d4f82-6326-473e-a0f3-a2f500f417ed


## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.


