### PR TITLE
feat: CP-10042 gas widget

### DIFF
--- a/src/components/common/CustomGasSettings.tsx
+++ b/src/components/common/CustomGasSettings.tsx
@@ -18,6 +18,7 @@ import {
 } from '@avalabs/core-k2-components';
 import { useSettingsContext } from '@src/contexts/SettingsProvider';
 import { TextFieldLabel } from './TextFieldLabel';
+import { TruncateFeeAmount } from './TruncateFeeAmount';
 
 type GasSettings = {
   customGasLimit: number;
@@ -66,15 +67,10 @@ const FeeAmount = ({ decimals, value, fiatValue, tokenSymbol }) => {
             alignItems: 'center',
           }}
         >
-          <Typography variant="h5" color="text.secondary">
-            ~
-          </Typography>
           <Tooltip title={unit.toString()}>
-            <Typography variant="h5" component="span" color="text.primary">
-              {unit.toDisplay()}
-            </Typography>
+            <TruncateFeeAmount amount={unit.toDisplay()} />
           </Tooltip>
-          <Typography variant="h6" component="span" color="text.secondary">
+          <Typography variant="subtitle2" component="span" color="text.primary">
             {tokenSymbol}
           </Typography>
         </Stack>

--- a/src/components/common/TruncateFeeAmount.tsx
+++ b/src/components/common/TruncateFeeAmount.tsx
@@ -16,7 +16,7 @@ export function TruncateFeeAmount({ amount }: { amount: string }) {
   }
 
   const indexOfNonZero = fraction?.search(/[1-9]/);
-  const zeroCount = fraction.slice(1, indexOfNonZero).length;
+  const zeroCount = fraction.slice(0, indexOfNonZero).length;
   if (fraction && indexOfNonZero) {
     return (
       <>

--- a/src/components/common/TruncateFeeAmount.tsx
+++ b/src/components/common/TruncateFeeAmount.tsx
@@ -42,7 +42,7 @@ export function TruncateFeeAmount({ amount }: { amount: string }) {
           color="text.primary"
           sx={{ fontWeight: 'fontWeightSemibold' }}
         >
-          {fraction.slice(indexOfNonZero, fraction.length)}
+          {fraction.slice(indexOfNonZero, indexOfNonZero + 2)}
         </Typography>
       </>
     );

--- a/src/components/common/TruncateFeeAmount.tsx
+++ b/src/components/common/TruncateFeeAmount.tsx
@@ -1,0 +1,60 @@
+import { Typography } from '@avalabs/core-k2-components';
+
+export function TruncateFeeAmount({ amount }: { amount: string }) {
+  const [integer, fraction] = amount.split('.');
+  if (!fraction || (fraction && fraction.length <= 4)) {
+    return (
+      <Typography
+        variant="body2"
+        component="span"
+        color="text.primary"
+        sx={{ fontWeight: 'fontWeightSemibold' }}
+      >
+        {amount}
+      </Typography>
+    );
+  }
+
+  const indexOfNonZero = fraction?.search(/[1-9]/);
+  const zeroCount = fraction.slice(1, indexOfNonZero).length;
+  if (fraction && indexOfNonZero) {
+    return (
+      <>
+        <Typography
+          variant="body2"
+          component="span"
+          color="text.primary"
+          sx={{ fontWeight: 'fontWeightSemibold' }}
+        >
+          {integer}.0
+        </Typography>
+        <Typography
+          variant="overline"
+          component="span"
+          color="text.primary"
+          sx={{ mt: 1, fontWeight: 'fontWeightSemibold' }}
+        >
+          {zeroCount}
+        </Typography>
+        <Typography
+          variant="body2"
+          component="span"
+          color="text.primary"
+          sx={{ fontWeight: 'fontWeightSemibold' }}
+        >
+          {fraction.slice(indexOfNonZero, fraction.length)}
+        </Typography>
+      </>
+    );
+  }
+  return (
+    <Typography
+      variant="body2"
+      component="span"
+      color="text.primary"
+      sx={{ fontWeight: 'fontWeightSemibold' }}
+    >
+      {amount}
+    </Typography>
+  );
+}

--- a/src/contexts/utils/getCurrencyFormatter.test.ts
+++ b/src/contexts/utils/getCurrencyFormatter.test.ts
@@ -2,48 +2,31 @@ import { getCurrencyFormatter } from './getCurrencyFormatter';
 
 describe('contexts/utils/getCurrencyFormatter', () => {
   const formatter = getCurrencyFormatter();
-  it('should return with the dollar sign and two fraction numbers', () => {
-    const value = formatter(12);
-    expect(value).toBe('$12.00');
-
-    const value2 = formatter(12.1);
-    expect(value2).toBe('$12.10');
-
-    const value3 = formatter(12.01);
-    expect(value3).toBe('$12.01');
-
-    const value4 = formatter(12.011);
-    expect(value4).toBe('$12.01');
-  });
   it('should return with the dollar sign and the first two fraction numbers when the integer is a zero', () => {
     const value = formatter(0.123);
-    expect(value).toBe('$0.12');
+    expect(value).toBe('$0.123');
 
     const value2 = formatter(0.02);
     expect(value2).toBe('$0.02');
 
     const value3 = formatter(0.0234);
-    expect(value3).toBe('$0.02');
+    expect(value3).toBe('$0.023');
   });
-  it('should return with the dollar sign and look for the first non-zero fraction number', () => {
-    const value = formatter(0.00023);
-    expect(value).toBe('$0.0002');
+  it('should return with the dollar sign and look for the last non-zero fraction number', () => {
+    const value = formatter(0.23);
+    expect(value).toBe('$0.23');
 
-    const value2 = formatter(0.000023);
-    expect(value2).toBe('$0.00002');
+    const value2 = formatter(0.023);
+    expect(value2).toBe('$0.023');
 
     // NOTE: this is the last point (in terms of the number of the fraction part) we handle, below that the scientific notation is not something we deal with at the moment
-    const value3 = formatter(0.0000023);
-    expect(value3).toBe('$0.000002');
-
-    // this is with scientific notation
-    const value4 = formatter(0.00000023);
-    expect(value4).not.toBe('$0.0000002');
+    const value3 = formatter(0.0023);
+    expect(value3).toBe('$0.002');
   });
 
-  it('should transform a small number to `0.00` or a big number to `∞` from scientific notation', () => {
+  it('should transform a small number to `0.001` or a big number to `∞` from scientific notation', () => {
     const value = formatter(0.0000000001);
-    expect(value).toBe('$0.00');
+    expect(value).toBe('<$0.001');
 
     // eslint-disable-next-line no-loss-of-precision
     const value2 = formatter(999999999999999999999);

--- a/src/contexts/utils/getCurrencyFormatter.ts
+++ b/src/contexts/utils/getCurrencyFormatter.ts
@@ -10,7 +10,14 @@ export const getCurrencyFormatter = (currency = 'USD') => {
   });
 
   return (amount: number) => {
-    const transformedAmount = modifyFractionNumber(amount);
+    const minAmount = 0.001;
+    const isTooSmall = amount < minAmount ? true : false;
+    const prefixString = isTooSmall ? '<' : '';
+
+    const transformedAmount = isTooSmall
+      ? minAmount
+      : modifyFractionNumber(amount);
+
     const parts = formatter.formatToParts(transformedAmount);
 
     /**
@@ -28,27 +35,33 @@ export const getCurrencyFormatter = (currency = 'USD') => {
       return flatArray.join('').trim();
     }
 
-    return formatter.format(transformedAmount);
+    return `${prefixString}${formatter.format(transformedAmount)}`;
   };
 };
 
 const modifyFractionNumber = (amount: number) => {
-  const [integer, fraction] = parseScientificNotation(amount.toString());
-  const indexOfNonZero = fraction?.search(/[1-9]/);
+  const maxFractionLengt = 3;
 
-  if (!indexOfNonZero || indexOfNonZero < 2 || integer !== '0') {
-    return parseFloat(`${integer}.${fraction?.slice(0, 2)}`);
+  const [integer, fraction] = parseScientificNotation(amount.toString());
+  if (!fraction) {
+    return amount;
   }
-  if (indexOfNonZero && indexOfNonZero >= 2 && integer === '0') {
-    return parseFloat(`${integer}.${fraction?.slice(0, indexOfNonZero + 1)}`);
-  }
-  return amount;
+  const lastNonZeroFractionIndex =
+    maxFractionLengt -
+    (fraction
+      ?.split('')
+      .reverse()
+      .findIndex((value) => value !== '0') || 0);
+
+  return parseFloat(
+    `${integer}.${fraction?.slice(0, lastNonZeroFractionIndex)}`,
+  );
 };
 
 const parseScientificNotation = (amount: string) => {
   // When the number is extremely small or big we don't want to take care of it at the moment
   if (amount.toString().includes('e') && amount.toString().includes('-')) {
-    return ['0', '00'];
+    return ['0', '001'];
   }
   if (amount.toString().includes('e') && amount.toString().includes('+')) {
     return ['Infinity', 'Infinity'];


### PR DESCRIPTION
## Description

Handle the small numbers differently because we are having the Fortuna upgrade soon.
Modifications for the gas widget (amount are gone, custom behaviours differently the cog icon has gone)

## Changes

A component which truncates the numbers and the getCurrencyFormatter modifications.

## Testing

Go to send -> play around on main and on Fuji as well.

## Screenshots:

**Mainnet:**

https://github.com/user-attachments/assets/f2970595-2722-4ab5-9ebd-87e223ade79c


**Fuji:**

https://github.com/user-attachments/assets/4ad84948-bd54-4cb5-a2fc-56b52c7f6945



## Checklist for the author

Tick each of them when done or if not applicable.

- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
