### PR TITLE
feat: restart extension via context menu

### DIFF
--- a/src/background/runtime/BackgroundRuntime.ts
+++ b/src/background/runtime/BackgroundRuntime.ts
@@ -60,10 +60,22 @@ export class BackgroundRuntime {
         title: '🔒 Lock wallet',
         contexts: ['action'],
       });
+      browser.contextMenus.create({
+        id: 'lock-restart-separator',
+        type: 'separator',
+        contexts: ['action'],
+      });
+      browser.contextMenus.create({
+        id: 'restart-wallet',
+        title: '🔄 Restart',
+        contexts: ['action'],
+      });
 
       browser.contextMenus.onClicked.addListener((info) => {
         if (info.menuItemId === 'lock-wallet') {
           this.lockService.lock();
+        } else if (info.menuItemId === 'restart-wallet') {
+          browser.runtime.reload();
         }
       });
     });


### PR DESCRIPTION
## Description
Adds a `Restart` item in the context menu that allows the user to easily restart the extension.

## Testing
Click and see it restart

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
