### PR TITLE
fix: version replacement count

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -73,8 +73,8 @@ const releaseReplaceSetting = [
           {
             file: 'dist/js/inpage.js',
             hasChanged: true,
-            numMatches: 1,
-            numReplacements: 1,
+            numMatches: 2,
+            numReplacements: 2,
           },
         ],
         countMatches: true,


### PR DESCRIPTION
## Changes
With Solana dApp provider, there are now 2 places where `semantic-release` must replace the `CORE_EXTENSION_VERSION` string.

## Testing
`Release Main Branch` build must pass. [It failed recently](https://github.com/ava-labs/core-extension/actions/runs/14107156962/job/39516243362).

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
