### PR TITLE
fix: CP-10042 display amounts

### DIFF
--- a/src/contexts/utils/getCurrencyFormatter.ts
+++ b/src/contexts/utils/getCurrencyFormatter.ts
@@ -11,7 +11,7 @@ export const getCurrencyFormatter = (currency = 'USD') => {
 
   return (amount: number) => {
     const minAmount = 0.001;
-    const isTooSmall = amount < minAmount ? true : false;
+    const isTooSmall = amount < minAmount && amount > 0 ? true : false;
     const prefixString = isTooSmall ? '<' : '';
 
     const transformedAmount = isTooSmall

--- a/src/pages/Wallet/components/History/components/ActivityCard/ActivityCard.tsx
+++ b/src/pages/Wallet/components/History/components/ActivityCard/ActivityCard.tsx
@@ -25,6 +25,7 @@ import { ActivityCardDetails } from './ActivityCardDetails';
 import { ActivityCardIcon } from './ActivityCardIcon';
 import { ActivityCardSummary } from './ActivityCardSummary';
 import { TransactionType } from '@avalabs/vm-module-types';
+import { TruncateFeeAmount } from '@src/components/common/TruncateFeeAmount';
 
 export interface ActivityCardProp {
   historyItem: TxHistoryItem;
@@ -231,7 +232,8 @@ export function ActivityCard({ historyItem }: ActivityCardProp) {
               }}
               data-testid="explorer-link"
             >
-              <Typography>{gasDisplayAmount}</Typography>
+              <TruncateFeeAmount amount={gasDisplayAmount} />
+
               <Typography>{network?.networkToken.symbol}</Typography>
               <ExternalLinkIcon
                 size={16}

--- a/src/pages/Wallet/components/History/components/ActivityCard/ActivityCardAmount.tsx
+++ b/src/pages/Wallet/components/History/components/ActivityCard/ActivityCardAmount.tsx
@@ -1,9 +1,10 @@
-import { Stack, Typography } from '@avalabs/core-k2-components';
+import { Stack, Tooltip, Typography } from '@avalabs/core-k2-components';
 import { isNftTokenType } from '@src/background/services/balances/nft/utils/isNFT';
 import { TxHistoryItem } from '@src/background/services/history/models';
 import { useAccountsContext } from '@src/contexts/AccountsProvider';
 import { ActivityCardProp } from './ActivityCard';
 import { TransactionType } from '@avalabs/vm-module-types';
+import { TruncateFeeAmount } from '@src/components/common/TruncateFeeAmount';
 
 export function ActivityCardAmount({ historyItem }: ActivityCardProp) {
   const {
@@ -65,9 +66,11 @@ export function ActivityCardAmount({ historyItem }: ActivityCardProp) {
   const symbol = historyItem.tokens?.[0]?.symbol;
   return (
     <Stack sx={{ flexDirection: 'row', columnGap: 0.5 }}>
-      <Typography variant="body2" sx={{ fontWeight: 'fontWeightSemibold' }}>
-        {amount}
-      </Typography>
+      {amount && (
+        <Tooltip title={amount}>
+          <TruncateFeeAmount amount={amount} />
+        </Tooltip>
+      )}
       <Typography
         variant="body2"
         sx={(theme) => ({ color: theme.palette.primary.dark })}


### PR DESCRIPTION
## Description

The porfolio page had broken prices.

## Changes

Fix the portfolio and improve the activity page which contained a lot of small numbers

## Testing

Go to the portfolio page -> go to the activity page and check the prices, gas amounts etc.

## Screenshots:

<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
