### PR TITLE
chore: update @avalabs/bridge-unified to v4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@avalabs/avalanche-module": "1.6.0",
     "@avalabs/avalanchejs": "4.2.0-alpha.1",
     "@avalabs/bitcoin-module": "1.6.0",
-    "@avalabs/bridge-unified": "4.0.1",
+    "@avalabs/bridge-unified": "4.0.2",
     "@avalabs/core-bridge-sdk": "3.1.0-alpha.44",
     "@avalabs/core-chains-sdk": "3.1.0-alpha.44",
     "@avalabs/core-coingecko-sdk": "3.1.0-alpha.44",

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,9 +100,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/bridge-unified@npm:4.0.1":
-  version: 4.0.1
-  resolution: "@avalabs/bridge-unified@npm:4.0.1"
+"@avalabs/bridge-unified@npm:4.0.2":
+  version: 4.0.2
+  resolution: "@avalabs/bridge-unified@npm:4.0.2"
   dependencies:
     "@noble/hashes": "npm:1.5.0"
     "@scure/base": "npm:1.1.9"
@@ -112,7 +112,7 @@ __metadata:
     lodash: "npm:4.17.21"
     viem: "npm:2.11.1"
     zod: "npm:3.23.8"
-  checksum: 10c0/f203dea76c33012d8dc5c7805895edc927c54f2ee9aaae95cc209202dec2b64889a2eb0226805a42f10b247e07d0d1d8b553b818ebc3e8164246e656cd4ed388
+  checksum: 10c0/3c33687e411c31699081e4178b33d1a963e672cf431b423e20d35fba6cd41cd51d24aa56d50059d2f8e7a6fb6595ebcfdb62ca680fbb908ce308b462ac82d1b1
   languageName: node
   linkType: hard
 
@@ -11911,7 +11911,7 @@ __metadata:
     "@avalabs/avalanche-module": "npm:1.6.0"
     "@avalabs/avalanchejs": "npm:4.2.0-alpha.1"
     "@avalabs/bitcoin-module": "npm:1.6.0"
-    "@avalabs/bridge-unified": "npm:4.0.1"
+    "@avalabs/bridge-unified": "npm:4.0.2"
     "@avalabs/core-bridge-sdk": "npm:3.1.0-alpha.44"
     "@avalabs/core-chains-sdk": "npm:3.1.0-alpha.44"
     "@avalabs/core-coingecko-sdk": "npm:3.1.0-alpha.44"


### PR DESCRIPTION
## Description

Bumps `@avalabs/bridge-unified` to v4.0.2, which updates some warden URLs.