### PR TITLE
refactor: addXPChainToFavoriteIfNeeded() support solana

### DIFF
--- a/src/background/services/onboarding/finalizeOnboarding.test.ts
+++ b/src/background/services/onboarding/finalizeOnboarding.test.ts
@@ -5,9 +5,9 @@ import { LockService } from '../lock/LockService';
 import { WalletService } from '../wallet/WalletService';
 import { AccountsService } from '../accounts/AccountsService';
 import { NetworkService } from '../network/NetworkService';
-import { addXPChainToFavoriteIfNeeded } from './utils/addXPChainsToFavoriteIfNeeded';
+import { addChainsToFavoriteIfNeeded } from './utils/addChainsToFavoriteIfNeeded';
 
-jest.mock('./utils/addXPChainsToFavoriteIfNeeded');
+jest.mock('./utils/addChainsToFavoriteIfNeeded');
 
 jest.mock('@avalabs/core-wallets-sdk', () => {
   const actual = jest.requireActual('@avalabs/core-wallets-sdk');
@@ -88,6 +88,6 @@ describe('src/background/services/onboarding/finalizeOnboarding.test.ts', () => 
     expect(onboardingServiceMock.setIsOnboarded).toHaveBeenCalledWith(true);
     expect(lockServiceMock.unlock).toHaveBeenCalledWith('password');
 
-    expect(addXPChainToFavoriteIfNeeded).toHaveBeenCalledWith([accountMock]);
+    expect(addChainsToFavoriteIfNeeded).toHaveBeenCalledWith([accountMock]);
   });
 });

--- a/src/background/services/onboarding/finalizeOnboarding.ts
+++ b/src/background/services/onboarding/finalizeOnboarding.ts
@@ -4,7 +4,7 @@ import { AccountsService } from '../accounts/AccountsService';
 import { OnboardingService } from './OnboardingService';
 import { LockService } from '../lock/LockService';
 import { runtime } from 'webextension-polyfill';
-import { addXPChainToFavoriteIfNeeded } from './utils/addXPChainsToFavoriteIfNeeded';
+import { addChainsToFavoriteIfNeeded } from './utils/addChainsToFavoriteIfNeeded';
 
 export interface FinalizeOnboardingParams {
   walletId: string;
@@ -33,7 +33,7 @@ export async function finalizeOnboarding({
   const addedAccounts = allAccounts.primary[walletId];
 
   if (addedAccounts) {
-    await addXPChainToFavoriteIfNeeded(addedAccounts);
+    await addChainsToFavoriteIfNeeded(addedAccounts);
   }
 
   const account = addedAccounts?.[0];

--- a/src/background/services/onboarding/handlers/keystoneOnboardingHandler.test.ts
+++ b/src/background/services/onboarding/handlers/keystoneOnboardingHandler.test.ts
@@ -15,10 +15,10 @@ import { SettingsService } from '../../settings/SettingsService';
 import { NetworkService } from '../../network/NetworkService';
 import { KeystoneOnboardingHandler } from './keystoneOnboardingHandler';
 import { buildRpcCall } from '@src/tests/test-utils';
-import { addXPChainToFavoriteIfNeeded } from '../utils/addXPChainsToFavoriteIfNeeded';
+import { addChainsToFavoriteIfNeeded } from '../utils/addChainsToFavoriteIfNeeded';
 import { buildExtendedPublicKey } from '../../secrets/utils';
 
-jest.mock('../utils/addXPChainsToFavoriteIfNeeded');
+jest.mock('../utils/addChainsToFavoriteIfNeeded');
 
 jest.mock('@avalabs/core-wallets-sdk', () => {
   const actual = jest.requireActual('@avalabs/core-wallets-sdk');
@@ -148,6 +148,6 @@ describe('src/background/services/onboarding/handlers/keystoneOnboardingHandler.
       analyticsServiceMock.saveTemporaryAnalyticsIds,
     ).not.toHaveBeenCalled();
 
-    expect(addXPChainToFavoriteIfNeeded).toHaveBeenCalledWith([accountMock]);
+    expect(addChainsToFavoriteIfNeeded).toHaveBeenCalledWith([accountMock]);
   });
 });

--- a/src/background/services/onboarding/handlers/ledgerOnboardingHandler.test.ts
+++ b/src/background/services/onboarding/handlers/ledgerOnboardingHandler.test.ts
@@ -20,10 +20,10 @@ import {
   SecretType,
 } from '../../secrets/models';
 import { buildRpcCall } from '@src/tests/test-utils';
-import { addXPChainToFavoriteIfNeeded } from '../utils/addXPChainsToFavoriteIfNeeded';
+import { addChainsToFavoriteIfNeeded } from '../utils/addChainsToFavoriteIfNeeded';
 import { buildExtendedPublicKey } from '../../secrets/utils';
 
-jest.mock('../utils/addXPChainsToFavoriteIfNeeded');
+jest.mock('../utils/addChainsToFavoriteIfNeeded');
 
 const WALLET_ID = 'wallet-id';
 
@@ -118,6 +118,7 @@ describe('src/background/services/onboarding/handlers/ledgerOnboardingHandler.ts
         password: 'password',
         walletName: 'wallet-name',
         analyticsConsent: false,
+        numberOfAccountsToCreate: 1,
       },
     ]);
 
@@ -248,6 +249,6 @@ describe('src/background/services/onboarding/handlers/ledgerOnboardingHandler.ts
       analyticsServiceMock.saveTemporaryAnalyticsIds,
     ).not.toHaveBeenCalled();
 
-    expect(addXPChainToFavoriteIfNeeded).toHaveBeenCalledWith([accountMock]);
+    expect(addChainsToFavoriteIfNeeded).toHaveBeenCalledWith([accountMock]);
   });
 });

--- a/src/background/services/onboarding/handlers/mnemonicOnboardingHandler.test.ts
+++ b/src/background/services/onboarding/handlers/mnemonicOnboardingHandler.test.ts
@@ -19,10 +19,10 @@ import { AccountsService } from '../../accounts/AccountsService';
 import { SettingsService } from '../../settings/SettingsService';
 import { NetworkService } from '../../network/NetworkService';
 import { buildRpcCall } from '@src/tests/test-utils';
-import { addXPChainToFavoriteIfNeeded } from '../utils/addXPChainsToFavoriteIfNeeded';
+import { addChainsToFavoriteIfNeeded } from '../utils/addChainsToFavoriteIfNeeded';
 import { buildExtendedPublicKey } from '../../secrets/utils';
 
-jest.mock('../utils/addXPChainsToFavoriteIfNeeded');
+jest.mock('../utils/addChainsToFavoriteIfNeeded');
 
 jest.mock('@avalabs/core-wallets-sdk', () => {
   const actual = jest.requireActual('@avalabs/core-wallets-sdk');
@@ -195,6 +195,6 @@ describe('src/background/services/onboarding/handlers/mnemonicOnboardingHandler.
       analyticsServiceMock.saveTemporaryAnalyticsIds,
     ).not.toHaveBeenCalled();
 
-    expect(addXPChainToFavoriteIfNeeded).toHaveBeenCalledWith([accountMock]);
+    expect(addChainsToFavoriteIfNeeded).toHaveBeenCalledWith([accountMock]);
   });
 });

--- a/src/background/services/onboarding/handlers/seedlessOnboardingHandler.test.ts
+++ b/src/background/services/onboarding/handlers/seedlessOnboardingHandler.test.ts
@@ -17,9 +17,9 @@ import {
   SignerSessionData,
 } from '@cubist-labs/cubesigner-sdk';
 import { buildRpcCall } from '@src/tests/test-utils';
-import { addXPChainToFavoriteIfNeeded } from '../utils/addXPChainsToFavoriteIfNeeded';
+import { addChainsToFavoriteIfNeeded } from '../utils/addChainsToFavoriteIfNeeded';
 
-jest.mock('../utils/addXPChainsToFavoriteIfNeeded');
+jest.mock('../utils/addChainsToFavoriteIfNeeded');
 
 jest.mock('@cubist-labs/cubesigner-sdk');
 const mockrMemorySession = {
@@ -196,6 +196,6 @@ describe('src/background/services/onboarding/handlers/seedlessOnboardingHandler.
 
     expect(settingsServiceMock.setAnalyticsConsent).toHaveBeenCalledWith(true);
 
-    expect(addXPChainToFavoriteIfNeeded).toHaveBeenCalledWith([accountMock]);
+    expect(addChainsToFavoriteIfNeeded).toHaveBeenCalledWith([accountMock]);
   });
 });

--- a/src/background/services/onboarding/utils/addChainsToFavoriteIfNeeded.test.ts
+++ b/src/background/services/onboarding/utils/addChainsToFavoriteIfNeeded.test.ts
@@ -2,7 +2,7 @@ import { BN } from 'bn.js';
 import { ChainId } from '@avalabs/core-chains-sdk';
 import { container } from 'tsyringe';
 
-import { addXPChainToFavoriteIfNeeded } from './addXPChainsToFavoriteIfNeeded';
+import { addChainsToFavoriteIfNeeded } from './addChainsToFavoriteIfNeeded';
 
 describe('src/background/services/onboarding/utils/addXPChainsToFavoriteIfNeeded.ts', () => {
   const accounts = [
@@ -46,7 +46,7 @@ describe('src/background/services/onboarding/utils/addXPChainsToFavoriteIfNeeded
       nfts: {},
     });
 
-    await addXPChainToFavoriteIfNeeded(accounts as any);
+    await addChainsToFavoriteIfNeeded(accounts as any);
 
     expect(addFavoriteNetwork).toHaveBeenCalledWith(ChainId.AVALANCHE_X);
   });
@@ -65,7 +65,7 @@ describe('src/background/services/onboarding/utils/addXPChainsToFavoriteIfNeeded
       nfts: {},
     });
 
-    await addXPChainToFavoriteIfNeeded(accounts as any);
+    await addChainsToFavoriteIfNeeded(accounts as any);
 
     expect(addFavoriteNetwork).toHaveBeenCalledWith(ChainId.AVALANCHE_P);
   });
@@ -81,7 +81,7 @@ describe('src/background/services/onboarding/utils/addXPChainsToFavoriteIfNeeded
 
     getTxHistory.mockResolvedValueOnce([{ anything: ':-)' } as any]); // P-chain info is fetched first
 
-    await addXPChainToFavoriteIfNeeded(accounts as any);
+    await addChainsToFavoriteIfNeeded(accounts as any);
 
     expect(addFavoriteNetwork).toHaveBeenCalledWith(ChainId.AVALANCHE_P);
   });
@@ -101,7 +101,7 @@ describe('src/background/services/onboarding/utils/addXPChainsToFavoriteIfNeeded
 
     getTxHistory.mockResolvedValueOnce([{ anything: ':-)' } as any]); // X-chain call for account 1
 
-    await addXPChainToFavoriteIfNeeded(accounts as any);
+    await addChainsToFavoriteIfNeeded(accounts as any);
 
     expect(addFavoriteNetwork).toHaveBeenCalledWith(ChainId.AVALANCHE_X);
   });
@@ -115,7 +115,7 @@ describe('src/background/services/onboarding/utils/addXPChainsToFavoriteIfNeeded
       nfts: {},
     });
 
-    await addXPChainToFavoriteIfNeeded(accounts as any);
+    await addChainsToFavoriteIfNeeded(accounts as any);
 
     expect(addFavoriteNetwork).not.toHaveBeenCalled();
   });

--- a/src/pages/Accounts/Accounts.tsx
+++ b/src/pages/Accounts/Accounts.tsx
@@ -82,7 +82,8 @@ export function Accounts() {
       if (walletDetails?.id) {
         fetchBalanceForWallet(walletDetails.id);
       }
-    } catch (_err) {
+    } catch (err) {
+      console.error(err);
       toast.error(t('An error occurred, please try again later'));
     }
 

--- a/src/pages/Accounts/components/AccountItem.tsx
+++ b/src/pages/Accounts/components/AccountItem.tsx
@@ -307,7 +307,7 @@ export const AccountItem = forwardRef(
                       {t('Active network is not supported')}
                     </Typography>
                   )}
-                  <Grow in={cardHovered || isActive}>
+                  <Grow in={Boolean(address) && (cardHovered || isActive)}>
                     <IconButton
                       color="primary"
                       size="small"


### PR DESCRIPTION
## Changes
* Renames `addXPChainsToFavoriteIfNeeded()` to `addChainsToFavoriteIfNeeded()` and makes it support Solana as well.

## Testing 
* Onboard and make sure XP chains are still made your favorite chains (as long as your account has some X- or P-Chain balance/activity)
* Logs the error when adding an account fails
* Stops `Copy` icon from being displayed when there is no address to copy in the account manager.


## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
