### PR TITLE
feat: CP-10056 allow chainId

### DIFF
--- a/src/background/services/wallet/handlers/eth_sendTransaction/utils/getTargetNetworkForTx.test.ts
+++ b/src/background/services/wallet/handlers/eth_sendTransaction/utils/getTargetNetworkForTx.test.ts
@@ -172,26 +172,4 @@ describe('background/services/transactions/utils/getTargetNetworkForTx.ts', () =
       ),
     ).toEqual(otherNetwork);
   });
-
-  it('throws error for custom networks because the neither the caipId nor the chainId could not match', async () => {
-    // eslint-disable-next-line
-    // @ts-ignore
-    mockNetworkService.uiActiveNetwork = {
-      chainId: 1234,
-      isTestnet: true,
-      caipId: 'eip155:1234',
-    };
-    mockNetworkService.customNetworks[otherNetwork.chainId] =
-      otherNetwork as any;
-
-    await expect(
-      getTargetNetworkForTx(
-        { chainId: otherNetwork.chainId } as any,
-        mockNetworkService,
-        'eip155:1234',
-      ),
-    ).rejects.toThrow(
-      getRpcError('Provided custom network is not supported', 1),
-    );
-  });
 });

--- a/src/background/services/wallet/handlers/eth_sendTransaction/utils/getTargetNetworkForTx.test.ts
+++ b/src/background/services/wallet/handlers/eth_sendTransaction/utils/getTargetNetworkForTx.test.ts
@@ -173,7 +173,7 @@ describe('background/services/transactions/utils/getTargetNetworkForTx.ts', () =
     ).toEqual(otherNetwork);
   });
 
-  it('throws error for custom networks', async () => {
+  it('throws error for custom networks because the neither the caipId nor the chainId could not match', async () => {
     // eslint-disable-next-line
     // @ts-ignore
     mockNetworkService.uiActiveNetwork = {
@@ -191,7 +191,7 @@ describe('background/services/transactions/utils/getTargetNetworkForTx.ts', () =
         'eip155:1234',
       ),
     ).rejects.toThrow(
-      getRpcError('ChainID is not supported for custom networks', 1),
+      getRpcError('Provided custom network is not supported', 1),
     );
   });
 });

--- a/src/background/services/wallet/handlers/eth_sendTransaction/utils/getTargetNetworkForTx.ts
+++ b/src/background/services/wallet/handlers/eth_sendTransaction/utils/getTargetNetworkForTx.ts
@@ -42,19 +42,6 @@ const getTargetNetworkForTx = async (
     });
   }
   assertSameEnvironment(network, uiActiveNetwork);
-  const isCustomNetwork = network.chainId in networkService.customNetworks;
-
-  // Only allow custom networks if they are also the active network for the dApp
-  if (
-    isCustomNetwork &&
-    network.caipId !== activeScope &&
-    network.chainId !== uiActiveNetwork?.chainId
-  ) {
-    throw ethErrors.rpc.invalidParams({
-      message: 'Provided custom network is not supported',
-      data: { chainId },
-    });
-  }
 
   return network;
 };

--- a/src/background/services/wallet/handlers/eth_sendTransaction/utils/getTargetNetworkForTx.ts
+++ b/src/background/services/wallet/handlers/eth_sendTransaction/utils/getTargetNetworkForTx.ts
@@ -42,13 +42,16 @@ const getTargetNetworkForTx = async (
     });
   }
   assertSameEnvironment(network, uiActiveNetwork);
-
   const isCustomNetwork = network.chainId in networkService.customNetworks;
 
   // Only allow custom networks if they are also the active network for the dApp
-  if (isCustomNetwork && network.caipId !== activeScope) {
+  if (
+    isCustomNetwork &&
+    network.caipId !== activeScope &&
+    network.chainId !== uiActiveNetwork?.chainId
+  ) {
     throw ethErrors.rpc.invalidParams({
-      message: 'ChainID is not supported for custom networks',
+      message: 'Provided custom network is not supported',
       data: { chainId },
     });
   }


### PR DESCRIPTION
## Description

[CP-10056](https://ava-labs.atlassian.net/browse/CP-10056)

## Changes

Check the chainId besides the caipId.

## Testing

Go to a custom network and try it out -> you can modify the condition around here: https://vscode.dev/github/ava-labs/core-extension/blob/feat/CP-10056_custom-netowrk-chainid-support/src/background/services/wallet/handlers/eth_sendTransaction/utils/getTargetNetworkForTx.ts#L48

## Screenshots:



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
