### PR TITLE
fix: CP-10042 remove scientific, fraction if only zeros, 1 more digit

### DIFF
--- a/src/components/common/CustomGasSettings.tsx
+++ b/src/components/common/CustomGasSettings.tsx
@@ -217,7 +217,7 @@ export function CustomGasSettings({
           <TextField
             fullWidth
             type={'number'}
-            value={Number(customMaxFeePerGas) / 10 ** feeDisplayDecimals}
+            value={formatUnits(customMaxFeePerGas, feeDisplayDecimals)}
             onChange={(evt) => {
               setCustomMaxFeePerGas(
                 parseUnits(evt.currentTarget.value || '0', feeDisplayDecimals),

--- a/src/components/common/TruncateFeeAmount.tsx
+++ b/src/components/common/TruncateFeeAmount.tsx
@@ -2,7 +2,7 @@ import { Typography } from '@avalabs/core-k2-components';
 
 export function TruncateFeeAmount({ amount }: { amount: string }) {
   const [integer, fraction] = amount.split('.');
-  if (!fraction || (fraction && fraction.length <= 4)) {
+  if (!fraction || (fraction && fraction.length <= 5)) {
     return (
       <Typography
         variant="body2"
@@ -16,6 +16,18 @@ export function TruncateFeeAmount({ amount }: { amount: string }) {
   }
 
   const indexOfNonZero = fraction?.search(/[1-9]/);
+  if (indexOfNonZero == -1) {
+    return (
+      <Typography
+        variant="body2"
+        component="span"
+        color="text.primary"
+        sx={{ fontWeight: 'fontWeightSemibold' }}
+      >
+        {integer}
+      </Typography>
+    );
+  }
   const zeroCount = fraction.slice(0, indexOfNonZero).length;
   if (fraction && indexOfNonZero) {
     return (

--- a/src/components/common/TruncateFeeAmount.tsx
+++ b/src/components/common/TruncateFeeAmount.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@avalabs/core-k2-components';
+import { Stack, Typography } from '@avalabs/core-k2-components';
 
 export function TruncateFeeAmount({ amount }: { amount: string }) {
   const [integer, fraction] = amount.split('.');
@@ -31,7 +31,7 @@ export function TruncateFeeAmount({ amount }: { amount: string }) {
   const zeroCount = fraction.slice(0, indexOfNonZero).length;
   if (fraction && indexOfNonZero) {
     return (
-      <>
+      <Stack sx={{ flexDirection: 'row', columnGap: 0 }}>
         <Typography
           variant="body2"
           component="span"
@@ -56,7 +56,7 @@ export function TruncateFeeAmount({ amount }: { amount: string }) {
         >
           {fraction.slice(indexOfNonZero, indexOfNonZero + 2)}
         </Typography>
-      </>
+      </Stack>
     );
   }
   return (


### PR DESCRIPTION
## Description

[CP-10042](https://ava-labs.atlassian.net/browse/CP-10042)
Comments

## Changes

Let one more character to display.
Only show the integer when the fraction has only zero values.
Max Base Fee input formatting.

## Testing

Go to send or other tx -> click the custom button on the fee widget -> check the values

## Screenshots:

![image](https://github.com/user-attachments/assets/77b7d2f2-1a2d-4b65-9d99-a0e7d441b8aa)

![image](https://github.com/user-attachments/assets/00f787df-9ce8-4fab-9ec6-da150e9483ce)


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
