### PR TITLE
fix: seedless signing

### DIFF
--- a/src/background/services/wallet/WalletService.test.ts
+++ b/src/background/services/wallet/WalletService.test.ts
@@ -56,9 +56,11 @@ import { TransactionPayload, VMABI } from 'hypersdk-client';
 import { buildExtendedPublicKey } from '../secrets/utils';
 import { expectToThrowErrorCode } from '@src/tests/test-utils';
 import { SecretsError } from '@src/utils/errors';
+import { AddressResolver } from '../secrets/AddressResolver';
 
 jest.mock('../network/NetworkService');
 jest.mock('../secrets/SecretsService');
+jest.mock('../secrets/AddressResolver');
 jest.mock('../ledger/LedgerService');
 jest.mock('../keystone/KeystoneService');
 jest.mock('./utils/prepareBtcTxForLedger');
@@ -93,6 +95,7 @@ describe('background/services/wallet/WalletService.ts', () => {
   let keystoneService: KeystoneService;
   let walletConnectService: WalletConnectService;
   let fireblocksService: FireblocksService;
+  let addressResolver: AddressResolver;
   let secretsService: jest.Mocked<SecretsService>;
   const accountsService: jest.Mocked<AccountsService> = {
     activeAccount: {} as unknown as Account,
@@ -116,6 +119,8 @@ describe('background/services/wallet/WalletService.ts', () => {
   const walletConnectSignerMock = Object.create(WalletConnectSigner.prototype);
   const seedlessWalletMock = Object.create(SeedlessWallet.prototype);
   const mnemonic = 'mnemonic';
+
+  const getDerivationPathsByVM = jest.fn();
 
   let getDefaultFujiProviderMock: jest.Mock;
   let getAddressMock: jest.Mock;
@@ -309,6 +314,7 @@ describe('background/services/wallet/WalletService.ts', () => {
     fireblocksService = new FireblocksService({} as any);
 
     secretsService = jest.mocked(new SecretsService({} as any));
+    addressResolver = jest.mocked({ getDerivationPathsByVM } as any);
 
     secretsService.getPrimaryWalletsDetails = jest.fn().mockResolvedValue([]);
 
@@ -342,6 +348,7 @@ describe('background/services/wallet/WalletService.ts', () => {
       fireblocksService,
       secretsService,
       accountsService,
+      addressResolver,
     );
 
     (networkService.getAvalanceProviderXP as jest.Mock).mockReturnValue(

--- a/src/background/services/wallet/WalletService.ts
+++ b/src/background/services/wallet/WalletService.ts
@@ -30,7 +30,7 @@ import {
   SolanaSigner,
 } from '@avalabs/core-wallets-sdk';
 import { NetworkService } from '../network/NetworkService';
-import { NetworkVMType } from '@avalabs/core-chains-sdk';
+import { NetworkVMType } from '@avalabs/vm-module-types';
 import { OnUnlock } from '@src/background/runtime/lifecycleCallbacks';
 import {
   personalSign,
@@ -80,6 +80,9 @@ import {
 import { assertPresent } from '@src/utils/assertions';
 import { CommonError, LedgerError, SecretsError } from '@src/utils/errors';
 import { omitUndefined } from '@src/utils/object';
+import { AddressResolver } from '../secrets/AddressResolver';
+import { isXchainNetwork } from '../network/utils/isAvalancheXchainNetwork';
+import { isPchainNetwork } from '../network/utils/isAvalanchePchainNetwork';
 
 @singleton()
 export class WalletService implements OnUnlock {
@@ -93,6 +96,7 @@ export class WalletService implements OnUnlock {
     private fireblocksService: FireblocksService,
     private secretService: SecretsService,
     private accountsService: AccountsService,
+    private addressResolver: AddressResolver,
   ) {}
 
   async emitsWalletsInfo(wallets: WalletDetails[]) {
@@ -229,7 +233,23 @@ export class WalletService implements OnUnlock {
     if (secretType === SecretType.Seedless) {
       const accountIndexToUse =
         accountIndex === undefined ? secrets.account.index : accountIndex;
-      const addressPublicKey = secrets.publicKeys[accountIndexToUse];
+
+      const derivationPaths = await this.addressResolver.getDerivationPathsByVM(
+        accountIndexToUse,
+        secrets.derivationPathSpec,
+        [NetworkVMType.AVM, NetworkVMType.EVM],
+      );
+
+      const derivationPath =
+        isXchainNetwork(network) || isPchainNetwork(network)
+          ? derivationPaths[NetworkVMType.AVM]
+          : derivationPaths[NetworkVMType.EVM];
+
+      const addressPublicKey = getPublicKeyFor(
+        secrets,
+        derivationPath,
+        'secp256k1',
+      );
 
       if (!addressPublicKey) {
         throw new Error('Account public key not available');

--- a/src/pages/SeedlessPopups/SeedlessAuthPopup.tsx
+++ b/src/pages/SeedlessPopups/SeedlessAuthPopup.tsx
@@ -55,7 +55,10 @@ export const SeedlessAuthPopup = () => {
   );
 
   const getOidcToken = useMemo(
-    () => getOidcTokenProvider(walletDetails?.authProvider),
+    () =>
+      walletDetails?.authProvider
+        ? getOidcTokenProvider(walletDetails?.authProvider)
+        : () => Promise.reject(new Error('No auth provider')),
     [walletDetails],
   );
 


### PR DESCRIPTION
## Changes
* Actually finds the correct `publicKey` instead of relying on the `account.index` alone.

## Testing
* Attempt to sign a few transactions with seedless, using different accounts, possible both C-Chain and P-Chain.


## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
