### PR TITLE
fix: export from C with seedless

### DIFF
--- a/src/background/services/wallet/handlers/avalanche_sendTransaction.test.ts
+++ b/src/background/services/wallet/handlers/avalanche_sendTransaction.test.ts
@@ -57,6 +57,7 @@ describe('src/background/services/wallet/handlers/avalanche_sendTransaction.ts',
   const txBytes = new Uint8Array([0, 1, 2]);
 
   const getAvalanceProviderXPMock = jest.fn();
+  const getAvalancheNetworkMock = jest.fn();
   const getAvalancheNetworkXPMock = jest.fn();
   const signMock = jest.fn();
   const issueTxHexMock = jest.fn();
@@ -78,6 +79,7 @@ describe('src/background/services/wallet/handlers/avalanche_sendTransaction.ts',
   } as any;
   const networkServiceMock = {
     getAvalanceProviderXP: getAvalanceProviderXPMock,
+    getAvalancheNetwork: getAvalancheNetworkMock,
     getAvalancheNetworkXP: getAvalancheNetworkXPMock,
     isMainnet: jest.fn(),
   } as any;
@@ -130,7 +132,14 @@ describe('src/background/services/wallet/handlers/avalanche_sendTransaction.ts',
     (UnsignedTx.fromJSON as jest.Mock).mockReturnValue(unsignedTxMock);
     (EVMUnsignedTx.fromJSON as jest.Mock).mockReturnValue(unsignedTxMock);
     signMock.mockReturnValue({ signedTx: 'baz' });
-    getAvalancheNetworkXPMock.mockReturnValue({ rpcUrl: 'RPCURL' });
+    getAvalancheNetworkXPMock.mockReturnValue({
+      rpcUrl: 'RPCURL',
+      vmName: 'AVM',
+    });
+    getAvalancheNetworkMock.mockReturnValue({
+      rpcUrl: 'RPCURL',
+      vmName: 'EVM',
+    });
     issueTxHexMock.mockResolvedValue({ txID: 1 });
     getAvalanceProviderXPMock.mockResolvedValue(providerMock);
     getAddressesMock.mockReturnValue([]);
@@ -582,7 +591,7 @@ describe('src/background/services/wallet/handlers/avalanche_sendTransaction.ts',
           externalIndices: undefined,
           internalIndices: undefined,
         },
-        { rpcUrl: 'RPCURL' },
+        { rpcUrl: 'RPCURL', vmName: 'EVM' },
         frontendTabId,
         'avalanche_sendTransaction',
       );
@@ -627,7 +636,7 @@ describe('src/background/services/wallet/handlers/avalanche_sendTransaction.ts',
           externalIndices: undefined,
           internalIndices: undefined,
         },
-        { rpcUrl: 'RPCURL' },
+        { rpcUrl: 'RPCURL', vmName: 'AVM' },
         frontendTabId,
         'avalanche_sendTransaction',
       );
@@ -677,7 +686,7 @@ describe('src/background/services/wallet/handlers/avalanche_sendTransaction.ts',
           externalIndices: [0, 1],
           internalIndices: [2, 3],
         },
-        { rpcUrl: 'RPCURL' },
+        { rpcUrl: 'RPCURL', vmName: 'AVM' },
         frontendTabId,
         'avalanche_sendTransaction',
       );

--- a/src/background/services/wallet/handlers/avalanche_sendTransaction.ts
+++ b/src/background/services/wallet/handlers/avalanche_sendTransaction.ts
@@ -265,7 +265,11 @@ export class AvalancheSendTransactionHandler extends DAppRequestHandler<
         );
       }
 
-      const network = this.networkService.getAvalancheNetworkXP();
+      const network =
+        vm === EVM
+          ? await this.networkService.getAvalancheNetwork()
+          : await this.networkService.getAvalancheNetworkXP();
+
       const prov = await this.networkService.getAvalanceProviderXP();
       const { txHash, signedTx } = await this.walletService.sign(
         {


### PR DESCRIPTION
## Changes
* Passes the proper network from `avalanche_sendTransaction` to `WalletService.sign()`. Previously it was always an XP chain and it worked because the legacy `PubKeyType` had both EVM and XP public keys attached. Right now they are separated, so we need to pass the proper network, such that a matching public key is found.

## Testing
* Perform Cross-Chain Transfer with seedless wallets. **Make sure to do import/exports from and to all chains.**

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
