### PR TITLE
[CP-10261] check active account and network only when needed

### DIFF
--- a/src/hooks/useIsFunctionAvailable.ts
+++ b/src/hooks/useIsFunctionAvailable.ts
@@ -195,6 +195,7 @@ export const useIsFunctionAvailable = (
   const {
     accounts: { active },
   } = useAccountsContext();
+
   const isReady = Boolean(network && active);
 
   const checkIsFunctionAvailable = (functionToCheck: FunctionNames) => {
@@ -281,7 +282,7 @@ export const useIsFunctionAvailable = (
     return true;
   };
 
-  if (!network || !active || !functionName) {
+  if (!functionName) {
     return {
       isReady,
       isFunctionAvailable: false,


### PR DESCRIPTION
## Description
When we check for feature availability we should only care about correctly set `activeAccount` and `activeNetwork` when it's actually necessary for the feature.
<!--- Describe your changes -->
<!--- Link and relevant resources e.g JIRA ticket, Figma Designs, PRs -->

## Changes
`isFunctionAvailable` no longer defaults to `false` until `activeAccount` and `activeNetwork` are loaded. If any of them is required for the feature availability check `checkIsFunctionAvailable` will validate them.
<!--- What types of changes does your code introduce? -->

## Testing
- initiate any X/P transaction from Core web (e.g.: cross-chain transfer)
- verify the "This is currently unavailable" warning does not appear
<!--- Describe in detail how your changes were tested. -->
<!--- Repeatable Steps to derive the desired output -->

## Screenshots:

<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
