### PR TITLE
fix: caip lookup + improved sentry reports

### DIFF
--- a/src/background/services/storage/schemaMigrations/schemaMigrations.test.ts
+++ b/src/background/services/storage/schemaMigrations/schemaMigrations.test.ts
@@ -35,7 +35,17 @@ const MOCK_SCHEMA_MAP = {
         migration: {
           up: jest.fn(async (data) => ({ ...data, version: 2 })),
           previousSchema: {
-            validate: jest.fn(() => ({ error: 'invalid schema' })),
+            validate: jest.fn(() => ({
+              error: {
+                message: 'invalid schema',
+                details: [
+                  {
+                    path: ['foo'],
+                    type: 'string',
+                  },
+                ],
+              },
+            })),
           },
         },
       },

--- a/src/background/services/storage/schemaMigrations/schemaMigrations.ts
+++ b/src/background/services/storage/schemaMigrations/schemaMigrations.ts
@@ -42,8 +42,12 @@ export const migrateToLatest = async <T>(
         currentMigration.migration.previousSchema.validate(result);
 
       if (validationError) {
+        const mismatchingPaths = validationError.details
+          .map((d, i) => `${i + 1}: {${d.path}}`)
+          .join(' | ');
+
         throw new Error(
-          `Error while upgrading ${key} to version ${currentMigration.version}`,
+          `Error while upgrading ${key} to version ${currentMigration.version}. Unexpected data types in paths: ${mismatchingPaths}`,
         );
       }
 

--- a/src/background/vmModules/ModuleManager.ts
+++ b/src/background/vmModules/ModuleManager.ts
@@ -20,7 +20,11 @@ import { isDevelopment } from '@src/utils/environment';
 import { NetworkWithCaipId } from '../services/network/models';
 import { VMModuleError } from './models';
 import { ApprovalController } from './ApprovalController';
-import { AvaxCaipId, BitcoinCaipId } from '@src/utils/caipConversion';
+import {
+  AvaxCaipId,
+  AvaxLegacyCaipId,
+  BitcoinCaipId,
+} from '@src/utils/caipConversion';
 
 // https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md
 // Syntax for namespace is defined in CAIP-2
@@ -136,7 +140,9 @@ export class ModuleManager {
     const scopeConversion =
       BitcoinCaipId[chainIdOrScope] ??
       AvaxCaipId[chainIdOrScope] ??
+      AvaxLegacyCaipId[chainIdOrScope] ??
       chainIdOrScope;
+
     const [namespace] = scopeConversion.split(':');
     if (!namespace || !NAMESPACE_REGEX.test(namespace)) {
       throw ethErrors.rpc.invalidParams({

--- a/src/utils/caipConversion.ts
+++ b/src/utils/caipConversion.ts
@@ -3,6 +3,7 @@ import {
   BitcoinCaip2ChainId,
   ChainId,
 } from '@avalabs/core-chains-sdk';
+import { Avalanche } from '@avalabs/core-wallets-sdk';
 import { NetworkVMType } from '@avalabs/vm-module-types';
 import { EnsureDefined, PartialBy } from '@src/background/models';
 import { Network } from '@src/background/services/network/models';
@@ -24,6 +25,13 @@ export const SolanaCaipId = {
   [ChainId.SOLANA_MAINNET_ID]: `${CaipNamespace.SOLANA}:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`,
   [ChainId.SOLANA_DEVNET_ID]: `${CaipNamespace.SOLANA}:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`,
   [ChainId.SOLANA_TESTNET_ID]: `${CaipNamespace.SOLANA}:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z`,
+};
+
+export const AvaxLegacyCaipId = {
+  [ChainId.AVALANCHE_P]: `${CaipNamespace.AVAX}:${Avalanche.MainnetContext.pBlockchainID}`,
+  [ChainId.AVALANCHE_X]: `${CaipNamespace.AVAX}:${Avalanche.MainnetContext.xBlockchainID}`,
+  [ChainId.AVALANCHE_TEST_P]: `${CaipNamespace.AVAX}:fuji${Avalanche.FujiContext.pBlockchainID}`,
+  [ChainId.AVALANCHE_TEST_X]: `${CaipNamespace.AVAX}:fuji${Avalanche.FujiContext.xBlockchainID}`,
 };
 
 export const AvaxCaipId = {
@@ -104,7 +112,9 @@ export const caipToChainId = (identifier: string): number => {
 
   if (namespace === CaipNamespace.AVAX) {
     const chainId = Object.keys(AvaxCaipId).find(
-      (chainIdLookup) => AvaxCaipId[chainIdLookup] === identifier,
+      (chainIdLookup) =>
+        AvaxCaipId[chainIdLookup] === identifier ||
+        AvaxLegacyCaipId[chainIdLookup] === identifier,
     );
 
     if (!chainId) {


### PR DESCRIPTION
## Changes
* There is an issue reported in Sentry where an old CAIP-2 id for P-Chain is not found. This PR brings back handling of those old CAIP-2 ids. Later I'll prepare a migration to switch the users from old CAIP-2 ids to new ones, as it should've been done in the first place.

* Adds some additional logs to failed migrations error (no data, just schema paths so we at least get some hints as to where the problem is).

## Testing
-

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
