### PR TITLE
fix: use proper message for insufficient funds

### DIFF
--- a/src/pages/Send/hooks/useSend/models.ts
+++ b/src/pages/Send/hooks/useSend/models.ts
@@ -137,3 +137,17 @@ export type SendAdapterAVM = SendAdapter<
   AdapterOptionsX,
   TokenWithBalanceAVM
 >;
+
+export const isInsufficientBalanceError = (err: any) => {
+  if (!err || !err.message || typeof err.message !== 'string') {
+    return false;
+  }
+
+  const knownInsufficientBalanceSubstrings = [
+    'insufficient funds',
+    'exceeds balance',
+  ];
+  return knownInsufficientBalanceSubstrings.some((substr) =>
+    err.message.includes(substr),
+  );
+};

--- a/src/pages/Send/hooks/useSend/useEVMSend.ts
+++ b/src/pages/Send/hooks/useSend/useEVMSend.ts
@@ -16,7 +16,7 @@ import {
   NftSendOptions,
   SendOptions,
 } from '../../models';
-import { SendAdapterEVM } from './models';
+import { isInsufficientBalanceError, SendAdapterEVM } from './models';
 import { RpcMethod, TokenType } from '@avalabs/vm-module-types';
 import { stringToBigint } from '@src/utils/stringToBigint';
 
@@ -174,7 +174,7 @@ export const useEVMSend: SendAdapterEVM = ({
           setError(SendErrorMessage.UNSUPPORTED_TOKEN);
         }
       } catch (err: any) {
-        if (!!err?.message && err?.message.includes('insufficient funds')) {
+        if (isInsufficientBalanceError(err)) {
           setError(SendErrorMessage.INSUFFICIENT_BALANCE);
         } else {
           // We don't want to send those errors to Sentry,


### PR DESCRIPTION
* [CP-9910](https://ava-labs.atlassian.net/browse/CP-9910)

## Changes
* Recognizes one more error message as insufficient balance

## Testing
* Try to send more ERC-20 than you have
* You should see "Insufficient balance" instead of "Unknown error"

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
