### PR TITLE
feat: CP-10098 store results, handle multiple call

### DIFF
--- a/src/background/services/gasless/GasStationService.test.ts
+++ b/src/background/services/gasless/GasStationService.test.ts
@@ -103,11 +103,17 @@ describe('src/background/services/gasless/GasStationService', () => {
       networkFeeService,
     );
 
+    const serviceSpy = jest.spyOn(service, 'getEligibility');
     await service.getEligibility({ chainId: 'chainId' });
 
     expect(gaslessService.isEligibleForChain).toHaveBeenCalledWith({
       chainId: 'chainId',
     });
+    expect(serviceSpy).toHaveBeenCalledTimes(2);
+
+    await service.getEligibility({ chainId: 'chainId' });
+    expect(gaslessService.isEligibleForChain).toHaveBeenCalledTimes(1);
+    expect(serviceSpy).toHaveBeenCalledTimes(3);
   });
 
   it('should dispatch the modified state object', () => {

--- a/src/background/services/gasless/GasStationService.ts
+++ b/src/background/services/gasless/GasStationService.ts
@@ -86,7 +86,6 @@ export class GasStationService {
     if (!index && index !== 0) {
       const data = { chainId, fromAddress, nonce };
       this.#waitingForEligibilityList.push(data);
-      console.log('he');
       return await this.getEligibility({
         ...data,
         index: 0,


### PR DESCRIPTION
## Description

We had false result for eligibility checks.

## Changes

Store the result when the call only for the chainId (in this case we won't call the sdk for checking the eligibility all the time with only the chainId).
Store the data of the calls so we can return in the right order each of them.

## Testing

Test the eligibility is working on different chains.

## Screenshots:


https://github.com/user-attachments/assets/c7110dbb-8aa3-4aa3-b7a5-a29cb1f5ed02



## Checklist for the author

Tick each of them when done or if not applicable.

- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
