### PR TITLE
fix: catch error on provider fallback mechanism

### DIFF
--- a/src/background/providers/initializeInpageProvider.test.ts
+++ b/src/background/providers/initializeInpageProvider.test.ts
@@ -92,6 +92,21 @@ describe('src/background/providers/initializeInpageProvider', () => {
       expect(errorSpy).toHaveBeenCalledTimes(1);
     });
 
+    it(`catches error when setting window.ethereum on fallback`, () => {
+      const otherWalletMock = { isMetaMask: true };
+      Object.defineProperty(windowMock, 'ethereum', {
+        get: () => otherWalletMock,
+      });
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {
+        //do nothing
+      });
+      initializeProvider(connectionMock, 10, windowMock);
+
+      expect(windowMock.ethereum).toBe(otherWalletMock);
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+    });
+
     describe('legacy support: window.web3', () => {
       it('sets window.web3 object', () => {
         const provider = initializeProvider(connectionMock, 10, windowMock);

--- a/src/background/providers/initializeInpageProvider.ts
+++ b/src/background/providers/initializeInpageProvider.ts
@@ -136,8 +136,15 @@ function setGlobalProvider(
     // some browser was faster and defined the window.ethereum as non writable before us
     console.error('Cannot set Core window.ethereum provider', e);
 
-    // try to set the providerInstance in case it's a proxy like we are
-    globalObject.ethereum = providerInstance;
+    try {
+      // try to set the providerInstance in case it's a proxy like we are
+      globalObject.ethereum = providerInstance;
+    } catch (fallbackError) {
+      console.error(
+        'Cannot set Core window.ethereum provider as fallback',
+        fallbackError,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Catches potential error when setting `window.ethereum` in the fallback logic

## Changes

<!--- What types of changes does your code introduce? -->

## Testing

<!--- Describe in detail how your changes were tested. -->
<!--- Repeatable Steps to derive the desired output -->

## Screenshots:

<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
