### PR TITLE
fix: wallet_v5 migration

### DIFF
--- a/src/background/services/storage/schemaMigrations/migrations/wallet_v5/commonSchemas.ts
+++ b/src/background/services/storage/schemaMigrations/migrations/wallet_v5/commonSchemas.ts
@@ -1,12 +1,6 @@
 import Joi from 'joi';
 
-import {
-  BtcWalletPolicyDetails,
-  ImportedFireblocksSecrets,
-  ImportedPrivateKeySecrets,
-  ImportedWalletConnectSecrets,
-  PubKeyType,
-} from './commonModels';
+import { BtcWalletPolicyDetails, PubKeyType } from './commonModels';
 
 export const btcWalletPolicyDetailsSchema = Joi.object<
   BtcWalletPolicyDetails,
@@ -23,37 +17,4 @@ export const pubKeyTypeSchema = Joi.object<PubKeyType, true>({
   xp: Joi.string().optional(),
   ed25519: Joi.string().optional(),
   btcWalletPolicyDetails: btcWalletPolicyDetailsSchema.optional(),
-}).unknown();
-
-export const walletConnectSchema = Joi.object<
-  ImportedWalletConnectSecrets,
-  true
->({
-  secretType: Joi.string().valid('wallet-connect').required(),
-  pubKey: pubKeyTypeSchema.optional(),
-  addresses: Joi.object({
-    addressC: Joi.string().required(),
-    addressAVM: Joi.string().optional(),
-    addressBTC: Joi.string().optional(),
-    addressCoreEth: Joi.string().optional(),
-    addressPVM: Joi.string().optional(),
-  }).required(),
-}).unknown();
-
-export const fireblocksSchema = Joi.object<ImportedFireblocksSecrets>({
-  secretType: Joi.string().valid('fireblocks').required(),
-  addresses: Joi.object({
-    addressC: Joi.string().required(),
-    addressBTC: Joi.string().optional(),
-  }).required(),
-  api: Joi.object({
-    vaultAccountId: Joi.string().required(),
-    key: Joi.string().required(),
-    secret: Joi.string().required(),
-  }).optional(),
-}).unknown();
-
-export const privateKeySchema = Joi.object<ImportedPrivateKeySecrets, true>({
-  secretType: Joi.string().valid('private-key').required(),
-  secret: Joi.string().required(),
 }).unknown();

--- a/src/background/services/storage/schemaMigrations/migrations/wallet_v5/legacySchema.ts
+++ b/src/background/services/storage/schemaMigrations/migrations/wallet_v5/legacySchema.ts
@@ -3,10 +3,7 @@ import Joi from 'joi';
 import * as Legacy from './legacyModels';
 import {
   btcWalletPolicyDetailsSchema,
-  fireblocksSchema,
-  privateKeySchema,
   pubKeyTypeSchema,
-  walletConnectSchema,
 } from './commonSchemas';
 
 const seedlessSchema = Joi.object<Legacy.SeedlessSecrets, true>({
@@ -68,11 +65,8 @@ export const legacySecretsSchema = Joi.object<Legacy.LegacySchema, true>({
       seedlessSchema,
     )
     .required(),
-  importedAccounts: Joi.object()
-    .pattern(
-      Joi.string(),
-      Joi.alternatives(privateKeySchema, walletConnectSchema, fireblocksSchema),
-    )
-    .optional(),
+  // We don't really care about the contents of `importedAccounts`,
+  // as we don't modify it in any way.
+  importedAccounts: Joi.object().unknown().optional(),
   version: Joi.number().valid(4).required(),
 }).unknown();

--- a/src/background/services/storage/schemaMigrations/migrations/wallet_v5/newSchema.ts
+++ b/src/background/services/storage/schemaMigrations/migrations/wallet_v5/newSchema.ts
@@ -1,11 +1,6 @@
 import Joi from 'joi';
 
-import {
-  btcWalletPolicyDetailsSchema,
-  fireblocksSchema,
-  privateKeySchema,
-  walletConnectSchema,
-} from './commonSchemas';
+import { btcWalletPolicyDetailsSchema } from './commonSchemas';
 import * as New from './newModels';
 
 const addressPublicKeySchema = Joi.object<New.AddressPublicKey>({
@@ -83,11 +78,8 @@ export const newSecretsSchema = Joi.object({
       seedlessSchema,
     )
     .required(),
-  importedAccounts: Joi.object()
-    .pattern(
-      Joi.string(),
-      Joi.alternatives(privateKeySchema, walletConnectSchema, fireblocksSchema),
-    )
-    .optional(),
+  // We don't really care about the contents of `importedAccounts`,
+  // as we don't modify it in any way.
+  importedAccounts: Joi.object().unknown().optional(),
   version: Joi.number().valid(5).required(),
 }).unknown();


### PR DESCRIPTION
## Description
Fixes [a Sentry-reported issue](https://ava-labs.sentry.io/issues/6509729466/events/b1d11dcb5e1c4d308a95a882df9dffad/?project=6536095) where 3 users are not able to get through the secrets storage migration.

## Changes
It looses the schema requirements for `importedAccounts` in the secrets storage when migrating from Wallet v4 to v5. This migration does not change anything in the `importedAccounts` model, so we don't really need to validate its contents.

Meanwhile, 3 users are not able to get through this migration because of it.

I was not able to pinpoint the exact cause, all I know is something happened under `importedAccounts` key that made the users' storage out-of-sync with our current schemas.

## Testing
* Automated tests should still pass.

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
