### PR TITLE
fix: missing encryption key error

### DIFF
--- a/src/contexts/WalletProvider.tsx
+++ b/src/contexts/WalletProvider.tsx
@@ -81,17 +81,25 @@ export function WalletContextProvider({ children }: { children: any }) {
     }
   }, [activeAccount, wallets]);
 
+  useEffect(() => {
+    if (isWalletLocked) {
+      setWallets([]);
+      setWalletDetails(undefined);
+    } else {
+      request<GetWalletDetailsHandler>({
+        method: ExtensionRequest.WALLET_GET_DETAILS,
+      }).then((_wallets) => {
+        setWallets(_wallets);
+      });
+    }
+  }, [isWalletLocked, request]);
+
   // listen for wallet creation
   useEffect(() => {
     if (!request || !events) {
       return;
     }
     setIsWalletLoading(true);
-    request<GetWalletDetailsHandler>({
-      method: ExtensionRequest.WALLET_GET_DETAILS,
-    }).then((_wallets) => {
-      setWallets(_wallets);
-    });
 
     request<GetLockStateHandler>({
       method: ExtensionRequest.LOCK_GET_STATE,


### PR DESCRIPTION
## Description
We were attempting to load the wallet details as soon as `<WalletProvider>` was rendered, which also happens on the lock screen.

## Changes
* Only attempts to load the wallet details after extension gets unlocked.

## Testing
* Open dev tools
* Lock the extension
* You should not see the `Encryption key missing` error message anymore

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.