### PR TITLE
fix: disable solana dapp connection

### DIFF
--- a/src/background/providers/initializeInpageProvider.test.ts
+++ b/src/background/providers/initializeInpageProvider.test.ts
@@ -2,7 +2,7 @@ import AutoPairingPostMessageConnection from '../utils/messaging/AutoPairingPost
 import { createMultiWalletProxy } from './MultiWalletProviderProxy';
 import { initializeProvider } from './initializeInpageProvider';
 import { EVMProvider } from '@avalabs/evm-module/dist/provider';
-import { SolanaWalletProvider } from '@avalabs/svm-module/dist/provider';
+// import { SolanaWalletProvider } from '@avalabs/svm-module/dist/provider';
 
 jest.mock('../utils/messaging/AutoPairingPostMessageConnection', () => {
   const mocks = {
@@ -43,7 +43,7 @@ describe('src/background/providers/initializeInpageProvider', () => {
     expect(EVMProvider).toHaveBeenCalledWith(
       expect.objectContaining({ maxListeners: 10 }),
     );
-    expect(SolanaWalletProvider).toHaveBeenCalled();
+    // expect(SolanaWalletProvider).toHaveBeenCalled();
     expect(provider.isAvalanche).toBe(true);
   });
 

--- a/src/background/providers/initializeInpageProvider.ts
+++ b/src/background/providers/initializeInpageProvider.ts
@@ -71,13 +71,20 @@ export function initializeProvider(
   announceWalletProvider(evmProvider, globalObject);
   announceChainAgnosticProvider(chainAgnosticProvider, globalObject);
 
-  initializeSolanaProvider(
-    new SolanaWalletProvider(chainAgnosticProvider, {
-      icon: EVM_PROVIDER_INFO_ICON,
-      name: EVM_PROVIDER_INFO_NAME,
-      version: CORE_EXTENSION_VERSION,
-    }),
-  );
+  // TODO: remove prior to actual release and also uncomment the test
+  try {
+    if (localStorage.getItem('__core__solana__enabled') === 'true') {
+      initializeSolanaProvider(
+        new SolanaWalletProvider(chainAgnosticProvider, {
+          icon: EVM_PROVIDER_INFO_ICON,
+          name: EVM_PROVIDER_INFO_NAME,
+          version: CORE_EXTENSION_VERSION,
+        }),
+      );
+    }
+  } catch {
+    // Do nothing
+  }
 
   return evmProvider;
 }


### PR DESCRIPTION
Since Solana support will not be publicly released until it's also supported by Core Mobile, we need to disable the inpage provider (feature flags are not available in the inpage script).

When mobile will be near the release, we can add a feature flag check on the connection screen, but for now let's just not display `Core` as an option on the dapps at all to avoid confusion.