### PR TITLE
feat:  CP-10438 set default gas fee modifier to fast

### DIFF
--- a/src/components/common/CustomFees.tsx
+++ b/src/components/common/CustomFees.tsx
@@ -177,7 +177,7 @@ export function CustomFees({
   const [selectedFee, setSelectedFee] = useState<GasFeeModifier>(
     networkFee?.isFixedFee
       ? GasFeeModifier.SLOW
-      : selectedGasFeeModifier || GasFeeModifier.FAST,
+      : selectedGasFeeModifier || GasFeeModifier.SLOW,
   );
 
   const { isGaslessOn, setIsGaslessOn, gaslessPhase, isGaslessEligible } =

--- a/src/components/common/CustomFees.tsx
+++ b/src/components/common/CustomFees.tsx
@@ -177,7 +177,7 @@ export function CustomFees({
   const [selectedFee, setSelectedFee] = useState<GasFeeModifier>(
     networkFee?.isFixedFee
       ? GasFeeModifier.SLOW
-      : selectedGasFeeModifier || GasFeeModifier.SLOW,
+      : selectedGasFeeModifier || GasFeeModifier.FAST,
   );
 
   const { isGaslessOn, setIsGaslessOn, gaslessPhase, isGaslessEligible } =
@@ -308,7 +308,7 @@ export function CustomFees({
   }, [network?.networkToken, estimatedFee, newFees.feeUnit]);
 
   const onGaslessSwitch = useCallback(async () => {
-    handleModifierClick(GasFeeModifier.NORMAL);
+    handleModifierClick(GasFeeModifier.FAST);
     setIsGaslessOn(!isGaslessOn);
   }, [handleModifierClick, isGaslessOn, setIsGaslessOn]);
 

--- a/src/pages/ApproveAction/hooks/useFeeCustomizer.tsx
+++ b/src/pages/ApproveAction/hooks/useFeeCustomizer.tsx
@@ -28,7 +28,7 @@ import {
   MultiTxAction,
   isBatchApprovalAction,
 } from '@src/background/services/actions/models';
-import { ChainId } from '@avalabs/core-chains-sdk';
+import { isAvalancheNetwork } from '@src/background/services/network/utils/isAvalancheNetwork';
 
 const getInitialFeeRate = (
   data?: SigningData | MultiTxFeeData,
@@ -88,13 +88,10 @@ export function useFeeCustomizer({
   );
 
   useEffect(() => {
-    if (
-      network?.chainId === ChainId.AVALANCHE_MAINNET_ID ||
-      network?.chainId === ChainId.AVALANCHE_DEVNET_ID
-    ) {
+    if (network && isAvalancheNetwork(network)) {
       setGasFeeModifier(GasFeeModifier.FAST);
     }
-  }, [network?.chainId]);
+  }, [network]);
 
   const [isBatchApprovalScreen, setIsBatchApprovalScreen] = useState(false);
   const isFeeSelectorEnabled = Boolean(action?.displayData.networkFeeSelector);

--- a/src/pages/ApproveAction/hooks/useFeeCustomizer.tsx
+++ b/src/pages/ApproveAction/hooks/useFeeCustomizer.tsx
@@ -28,6 +28,7 @@ import {
   MultiTxAction,
   isBatchApprovalAction,
 } from '@src/background/services/actions/models';
+import { ChainId } from '@avalabs/core-chains-sdk';
 
 const getInitialFeeRate = (
   data?: SigningData | MultiTxFeeData,
@@ -83,8 +84,18 @@ export function useFeeCustomizer({
 
   const [isCalculatingFee, setIsCalculatingFee] = useState(false);
   const [gasFeeModifier, setGasFeeModifier] = useState<GasFeeModifier>(
-    GasFeeModifier.FAST,
+    GasFeeModifier.SLOW,
   );
+
+  useEffect(() => {
+    if (
+      network?.chainId === ChainId.AVALANCHE_MAINNET_ID ||
+      network?.chainId === ChainId.AVALANCHE_DEVNET_ID
+    ) {
+      setGasFeeModifier(GasFeeModifier.FAST);
+    }
+  }, [network?.chainId]);
+
   const [isBatchApprovalScreen, setIsBatchApprovalScreen] = useState(false);
   const isFeeSelectorEnabled = Boolean(action?.displayData.networkFeeSelector);
 

--- a/src/pages/ApproveAction/hooks/useFeeCustomizer.tsx
+++ b/src/pages/ApproveAction/hooks/useFeeCustomizer.tsx
@@ -83,7 +83,7 @@ export function useFeeCustomizer({
 
   const [isCalculatingFee, setIsCalculatingFee] = useState(false);
   const [gasFeeModifier, setGasFeeModifier] = useState<GasFeeModifier>(
-    GasFeeModifier.SLOW,
+    GasFeeModifier.FAST,
   );
   const [isBatchApprovalScreen, setIsBatchApprovalScreen] = useState(false);
   const isFeeSelectorEnabled = Boolean(action?.displayData.networkFeeSelector);


### PR DESCRIPTION
## Description



## Changes

Set the gas fee modifier to fast on c-chain and Fuji.

## Testing

e.g. Go to send and check the default modifier value -> try it on other networks

## Screenshots:

updated: 

https://github.com/user-attachments/assets/ba711c61-75be-4b17-b175-0e4371d64d2c



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
