### PR TITLE
fix: handle the error ai does not respond with text but status ok

### DIFF
--- a/src/monitoring/sentryCaptureException.ts
+++ b/src/monitoring/sentryCaptureException.ts
@@ -10,6 +10,8 @@ export enum SentryExceptionTypes {
 
   SWAP = 'swap',
 
+  AI_AGENT = 'aiAgent',
+
   // ledger
   LEDGER = 'ledger',
 


### PR DESCRIPTION
## Description

When the AI does not parse the function call correctly (or whatever the reason is) it responds with a status 200 but the text is empty.

## Changes

Let the user know something happened about the request.

## Testing

Go to AI -> the way I could see this error when I tried to get my balance with ```balance, token balance etc``` commands, try these

## Screenshots:

![image](https://github.com/user-attachments/assets/7e47203f-643f-4d77-af22-4797a0d3062b)


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
