### PR TITLE
feat: CP-10558 function param declaration

### DIFF
--- a/src/pages/Home/components/Portfolio/Prompt/models.ts
+++ b/src/pages/Home/components/Portfolio/Prompt/models.ts
@@ -32,7 +32,7 @@ export const functionDeclarations: FunctionDeclaration[] = [
       properties: {
         amount: {
           type: SchemaType.NUMBER,
-          description: `The amount of tokens to swap`,
+          description: `The amount of tokens to swap. The amount must not be greater than the user balance in that given token. E.g. if the user has .1 avax do not let swap a value which is greater than that.`,
         },
         fromTokenAddress: {
           type: SchemaType.STRING,


### PR DESCRIPTION
## Description

The AI did not care about the amount of a token that the user had and started the swap which caused an error in the background.

## Changes

Do not let the users to start the swap warn them instead.

## Testing

Go to AI -> try to swap a token with an amount you don't have

## Screenshots:


https://github.com/user-attachments/assets/599bdc0f-5a4d-4d15-86f2-9922985e5dbd



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
