### PR TITLE
feat: cp-10565 Core Assistant analytics

### DIFF
--- a/src/pages/Home/components/Portfolio/Prompt/Prompt.tsx
+++ b/src/pages/Home/components/Portfolio/Prompt/Prompt.tsx
@@ -430,8 +430,8 @@ export function Prompt() {
       } catch (e: any) {
         sentryCaptureException(e as Error, SentryExceptionTypes.AI_AGENT);
         capture('CoreAssistantFunctionCallError', {
-          errorName: e.name || '',
-          errorMessage: e.message || '',
+          errorName: e.name,
+          errorMessage: e.message,
           userMessage: message,
         });
         if (e.name === 'FirebaseError') {


### PR DESCRIPTION
## Description


## Changes

Added two events to get the opportunity to monitor the users' messages and the AI's behaviour after

## Testing

Go to AI -> call a swap send etc. -> check the console for the analytics_capture_event or check the posthog

## Screenshots:

![image](https://github.com/user-attachments/assets/be2b6f3f-24a3-42cd-86ee-716a0dbdffb1)

![image](https://github.com/user-attachments/assets/ff5e5c77-1f82-45e6-8d63-43a2b1121b2f)


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
