### PR TITLE
fix: assistant default state on

### DIFF
--- a/src/background/services/settings/SettingsService.ts
+++ b/src/background/services/settings/SettingsService.ts
@@ -29,7 +29,7 @@ const DEFAULT_SETTINGS_STATE: SettingsState = {
   collectiblesVisibility: {},
   analyticsConsent: AnalyticsConsent.Approved,
   language: Languages.EN,
-  coreAssistant: false,
+  coreAssistant: true,
 };
 
 @singleton()


### PR DESCRIPTION
## Description

We want to turn on the Core Assistant by default.

## Changes

It is on now when the user has no settings.

## Testing

Reset wallet -> do the onboarding -> check the core assistant is on by default in the settings

## Screenshots:

![image](https://github.com/user-attachments/assets/7476073f-0c6b-4b5c-a988-48f440c8538f)


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
