### PR TITLE
feat: CP-10608 && CP-10611 add open urls for open a dApp or buy a token

### DIFF
--- a/src/pages/Home/components/Portfolio/Prompt/Prompt.tsx
+++ b/src/pages/Home/components/Portfolio/Prompt/Prompt.tsx
@@ -44,6 +44,7 @@ import sentryCaptureException, {
   SentryExceptionTypes,
 } from '@src/monitoring/sentryCaptureException';
 import { useAnalyticsContext } from '@src/contexts/AnalyticsProvider';
+import browser from 'webextension-polyfill';
 
 export function Prompt() {
   const theme = useTheme();
@@ -173,6 +174,23 @@ export function Prompt() {
 
         return {
           content: `Success! New contact added!`,
+        };
+      },
+      goToDapp: async ({ url }) => {
+        const openUrl = url.includes('https://') ? url : `https://${url}`;
+        chrome.tabs.create({ url: openUrl, active: true }, () =>
+          browser.action.openPopup(),
+        );
+        return {
+          content: `${url} opened in a new tab!`,
+        };
+      },
+      buy: async () => {
+        chrome.tabs.create({ url: `https://core.app/buy/`, active: true }, () =>
+          browser.action.openPopup(),
+        );
+        return {
+          content: `You can buy tokens at https://core.app/buy/ !`,
         };
       },
       swap: async ({

--- a/src/pages/Home/components/Portfolio/Prompt/models.ts
+++ b/src/pages/Home/components/Portfolio/Prompt/models.ts
@@ -115,6 +115,10 @@ export const functionDeclarations: FunctionDeclaration[] = [
       required: ['name', 'address'],
     },
   },
+  {
+    name: 'buy',
+    description: `User can buy tokens in a new window at https://core.app/buy/ webpage.`,
+  },
 ];
 
 export const systemPromptTemplate = `
@@ -134,4 +138,5 @@ The user has the following tokens on the active account:
 __TOKENS__
 The tokens can be identified by their "symbol" property, as well as their "address" property. Both identifiers are case-insensitive.
 All known and available tokens for the current network are listed in the following array: __AVAILABLE_TOKENS__
+The user can open a dApp by name or by a given URL or if the user wants to buy a token you can open a new window where it can be done.
 `;


### PR DESCRIPTION
## Description

We want to open urls from AI

## Changes

Create new chrome tabs.
**NOTE: the reopening is not working for me at the moment. I have checked with the adding a new wallet with ledger and it won't work there neither. I guess the chrome is broken or modified something maybe? So I would kep the function call in the callback anyway.**

## Testing

Go to AI -> ask for open traderjoe or lfj or any other dApp -> check the buy as well it should open the core.app/buy

## Screenshots:



https://github.com/user-attachments/assets/d077f6e2-720c-4192-9c44-c1a6d964bdad


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
