### PR TITLE
feat: route AVAX<->WAVAX and ETH<->WETH through contracts

### DIFF
--- a/apps/legacy/src/pages/Swap/Swap.tsx
+++ b/apps/legacy/src/pages/Swap/Swap.tsx
@@ -2,7 +2,7 @@ import { FunctionIsOffline } from '@/components/common/FunctionIsOffline';
 import { FunctionIsUnavailable } from '@/components/common/FunctionIsUnavailable';
 import { PageTitle } from '@/components/common/PageTitle';
 import { TokenSelect } from '@/components/common/TokenSelect';
-import { useAccountsContext } from '@core/ui';
+import { isJupiterQuote, isParaswapQuote, useAccountsContext } from '@core/ui';
 import { useAnalyticsContext } from '@core/ui';
 import { useNetworkFeeContext } from '@core/ui';
 import { useNetworkContext } from '@core/ui';
@@ -254,6 +254,11 @@ export function Swap() {
     }
   }
 
+  const showEngineNotice = useMemo(
+    () => quote && (isParaswapQuote(quote) || isJupiterQuote(quote)),
+    [quote],
+  );
+
   if (!isSwapSupported) {
     return (
       <FunctionIsUnavailable
@@ -436,7 +441,7 @@ export function Swap() {
           <ReviewOrderButtonContainer
             isTransactionDetailsOpen={isTransactionDetailsOpen}
           >
-            <SwapEngineNotice quote={quote} />
+            {showEngineNotice && <SwapEngineNotice />}
             <Button
               data-testid="swap-review-order-button"
               sx={{

--- a/apps/legacy/src/pages/Swap/Swap.tsx
+++ b/apps/legacy/src/pages/Swap/Swap.tsx
@@ -420,6 +420,7 @@ export function Swap() {
 
           {isDetailsAvailable && (
             <TransactionDetails
+              quote={quote}
               fromTokenSymbol={selectedFromToken?.symbol}
               toTokenSymbol={selectedToToken?.symbol}
               rate={calculateRate(quote, {
@@ -435,7 +436,7 @@ export function Swap() {
           <ReviewOrderButtonContainer
             isTransactionDetailsOpen={isTransactionDetailsOpen}
           >
-            <SwapEngineNotice />
+            <SwapEngineNotice quote={quote} />
             <Button
               data-testid="swap-review-order-button"
               sx={{

--- a/apps/legacy/src/pages/Swap/components/SwapEngineNotice.tsx
+++ b/apps/legacy/src/pages/Swap/components/SwapEngineNotice.tsx
@@ -7,25 +7,16 @@ import {
 } from '@avalabs/core-k2-components';
 import { VeloraIcon } from '@/components/icons/VeloraIcon';
 import JupiterLogo from '@/images/logos/jupiter-logo.svg';
-import {
-  isUnwrapOperation,
-  isWrapOperation,
-  useNetworkContext,
-} from '@core/ui';
+import { useNetworkContext } from '@core/ui';
 import { useMemo } from 'react';
 import { NetworkVMType } from '@avalabs/vm-module-types';
-import { SwapQuote } from '@core/ui';
 
-export function SwapEngineNotice({ quote }: { quote: SwapQuote | null }) {
+export function SwapEngineNotice() {
   const { t } = useTranslation();
   const { network } = useNetworkContext();
 
   const engineInfo = useMemo(() => {
     if (!network) {
-      return null;
-    }
-
-    if (quote && (isUnwrapOperation(quote) || isWrapOperation(quote))) {
       return null;
     }
 
@@ -44,7 +35,7 @@ export function SwapEngineNotice({ quote }: { quote: SwapQuote | null }) {
     }
 
     return null;
-  }, [network, quote, t]);
+  }, [network, t]);
 
   if (!engineInfo) {
     return null;

--- a/apps/legacy/src/pages/Swap/components/SwapEngineNotice.tsx
+++ b/apps/legacy/src/pages/Swap/components/SwapEngineNotice.tsx
@@ -7,16 +7,25 @@ import {
 } from '@avalabs/core-k2-components';
 import { VeloraIcon } from '@/components/icons/VeloraIcon';
 import JupiterLogo from '@/images/logos/jupiter-logo.svg';
-import { useNetworkContext } from '@core/ui';
+import {
+  isUnwrapOperation,
+  isWrapOperation,
+  useNetworkContext,
+} from '@core/ui';
 import { useMemo } from 'react';
 import { NetworkVMType } from '@avalabs/vm-module-types';
+import { SwapQuote } from '@core/ui';
 
-export function SwapEngineNotice() {
+export function SwapEngineNotice({ quote }: { quote: SwapQuote | null }) {
   const { t } = useTranslation();
   const { network } = useNetworkContext();
 
   const engineInfo = useMemo(() => {
     if (!network) {
+      return null;
+    }
+
+    if (quote && (isUnwrapOperation(quote) || isWrapOperation(quote))) {
       return null;
     }
 
@@ -35,7 +44,7 @@ export function SwapEngineNotice() {
     }
 
     return null;
-  }, [network, t]);
+  }, [network, quote, t]);
 
   if (!engineInfo) {
     return null;

--- a/apps/legacy/src/pages/Swap/utils/calculateRate.ts
+++ b/apps/legacy/src/pages/Swap/utils/calculateRate.ts
@@ -1,0 +1,57 @@
+import { OptimalRate } from '@paraswap/sdk';
+import {
+  isJupiterQuote,
+  isParaswapQuote,
+  JupiterQuote,
+  UnwrapOperation,
+  WrapOperation,
+} from '@core/ui';
+
+type RateCalculationContext = { srcDecimals: number; destDecimals: number };
+type RateCalculationStrategy = {
+  calculate(
+    quote: OptimalRate | JupiterQuote | WrapOperation | UnwrapOperation,
+    context: RateCalculationContext,
+  ): number;
+};
+
+const ParaswapRateStrategy: RateCalculationStrategy = {
+  calculate(quote: OptimalRate): number {
+    const { destAmount, destDecimals, srcAmount, srcDecimals } = quote;
+    const destAmountNumber = parseInt(destAmount, 10) / 10 ** destDecimals;
+    const sourceAmountNumber = parseInt(srcAmount, 10) / 10 ** srcDecimals;
+    return destAmountNumber / sourceAmountNumber;
+  },
+};
+
+const JupiterRateStrategy: RateCalculationStrategy = {
+  calculate(quote: JupiterQuote, context): number {
+    const { inAmount, outAmount } = quote;
+    const realOutValue = parseInt(outAmount, 10) / 10 ** context.destDecimals;
+    const realInValue = parseInt(inAmount, 10) / 10 ** context.srcDecimals;
+    return realOutValue / realInValue;
+  },
+};
+
+const WrapUnwrapRateStrategy: RateCalculationStrategy = {
+  calculate(): number {
+    return 1; // wrap/unwrap always has 1:1 rate
+  },
+};
+
+export const calculateRate = (
+  quote: OptimalRate | JupiterQuote | WrapOperation | UnwrapOperation,
+  context: RateCalculationContext,
+) => {
+  let strategy: RateCalculationStrategy;
+
+  if (isParaswapQuote(quote)) {
+    strategy = ParaswapRateStrategy;
+  } else if (isJupiterQuote(quote)) {
+    strategy = JupiterRateStrategy;
+  } else {
+    strategy = WrapUnwrapRateStrategy;
+  }
+
+  return strategy.calculate(quote, context);
+};

--- a/apps/legacy/src/pages/Swap/utils/index.tsx
+++ b/apps/legacy/src/pages/Swap/utils/index.tsx
@@ -7,7 +7,13 @@ import {
 import { calculateGasAndFees, stringToBigint } from '@core/common';
 import { OptimalRate } from '@paraswap/sdk';
 import { SwappableToken } from '../models';
-import { isParaswapQuote, JupiterQuote } from '@core/ui';
+import {
+  isJupiterQuote,
+  isParaswapQuote,
+  JupiterQuote,
+  UnwrapOperation,
+  WrapOperation,
+} from '@core/ui';
 
 interface GetTokenIconProps {
   token?: TokenWithBalanceEVM;
@@ -87,7 +93,7 @@ export const getMaxValueWithGas = ({
 };
 
 export const calculateRate = (
-  quote: OptimalRate | JupiterQuote,
+  quote: OptimalRate | JupiterQuote | WrapOperation | UnwrapOperation,
   context: { srcDecimals: number; destDecimals: number },
 ) => {
   if (isParaswapQuote(quote)) {
@@ -97,14 +103,16 @@ export const calculateRate = (
     const sourceAmountNumber =
       parseInt(srcAmount, 10) / Math.pow(10, srcDecimals);
     return destAmountNumber / sourceAmountNumber;
+  } else if (isJupiterQuote(quote)) {
+    const { inAmount, outAmount } = quote;
+
+    const realOutValue = parseInt(outAmount, 10) / 10 ** context.destDecimals;
+    const realInValue = parseInt(inAmount, 10) / 10 ** context.srcDecimals;
+
+    return realOutValue / realInValue;
   }
 
-  const { inAmount, outAmount } = quote;
-
-  const realOutValue = parseInt(outAmount, 10) / 10 ** context.destDecimals;
-  const realInValue = parseInt(inAmount, 10) / 10 ** context.srcDecimals;
-
-  return realOutValue / realInValue;
+  return 1; // wrap/unwrap
 };
 
 export interface Token {

--- a/apps/legacy/src/pages/Swap/utils/index.tsx
+++ b/apps/legacy/src/pages/Swap/utils/index.tsx
@@ -7,17 +7,12 @@ import {
 import { calculateGasAndFees, stringToBigint } from '@core/common';
 import { OptimalRate } from '@paraswap/sdk';
 import { SwappableToken } from '../models';
-import {
-  isJupiterQuote,
-  isParaswapQuote,
-  JupiterQuote,
-  UnwrapOperation,
-  WrapOperation,
-} from '@core/ui';
 
 interface GetTokenIconProps {
   token?: TokenWithBalanceEVM;
 }
+
+export { calculateRate } from './calculateRate';
 
 export const MIN_SLIPPAGE = 0.1;
 
@@ -90,29 +85,6 @@ export const getMaxValueWithGas = ({
 
   const max = getMaxValue(selectedFromToken, newFees.fee);
   return max;
-};
-
-export const calculateRate = (
-  quote: OptimalRate | JupiterQuote | WrapOperation | UnwrapOperation,
-  context: { srcDecimals: number; destDecimals: number },
-) => {
-  if (isParaswapQuote(quote)) {
-    const { destAmount, destDecimals, srcAmount, srcDecimals } = quote;
-    const destAmountNumber =
-      parseInt(destAmount, 10) / Math.pow(10, destDecimals);
-    const sourceAmountNumber =
-      parseInt(srcAmount, 10) / Math.pow(10, srcDecimals);
-    return destAmountNumber / sourceAmountNumber;
-  } else if (isJupiterQuote(quote)) {
-    const { inAmount, outAmount } = quote;
-
-    const realOutValue = parseInt(outAmount, 10) / 10 ** context.destDecimals;
-    const realInValue = parseInt(inAmount, 10) / 10 ** context.srcDecimals;
-
-    return realOutValue / realInValue;
-  }
-
-  return 1; // wrap/unwrap
 };
 
 export interface Token {

--- a/packages/ui/src/contexts/SwapProvider/ABI_WAVAX.json
+++ b/packages/ui/src/contexts/SwapProvider/ABI_WAVAX.json
@@ -1,0 +1,153 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "guy", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "src", "type": "address" },
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "wad", "type": "uint256" }],
+    "name": "withdraw",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "deposit",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "", "type": "address" },
+      { "name": "", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "guy", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Withdrawal",
+    "type": "event"
+  }
+]

--- a/packages/ui/src/contexts/SwapProvider/ABI_WETH.json
+++ b/packages/ui/src/contexts/SwapProvider/ABI_WETH.json
@@ -1,0 +1,153 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "guy", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "src", "type": "address" },
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "wad", "type": "uint256" }],
+    "name": "withdraw",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "deposit",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "", "type": "address" },
+      { "name": "", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "guy", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Withdrawal",
+    "type": "event"
+  }
+]

--- a/packages/ui/src/contexts/SwapProvider/SwapProvider.tsx
+++ b/packages/ui/src/contexts/SwapProvider/SwapProvider.tsx
@@ -37,8 +37,13 @@ import {
   SwapError,
   SwapFormValues,
   SwapParams,
+  SwapQuote,
+  UnwrapOperation,
+  WrapOperation,
   isJupiterSwapParams,
   isParaswapSwapParams,
+  isUnwrapOperationParams,
+  isWrapOperationParams,
 } from './models';
 import { swapError } from './swap-utils';
 import { useEvmSwap } from './useEvmSwap';
@@ -76,7 +81,7 @@ export function SwapContextProvider({
     disallowedAssets: DISALLOWED_SWAP_ASSETS,
   });
 
-  const [quote, setQuote] = useState<OptimalRate | JupiterQuote | null>(null);
+  const [quote, setQuote] = useState<SwapQuote | null>(null);
   const [error, setError] = useState<SwapError>({ message: '' });
   const [destAmount, setDestAmount] = useState('');
   const [isSwapLoading, setIsSwapLoading] = useState<boolean>(false);
@@ -206,7 +211,13 @@ export function SwapContextProvider({
   );
 
   const swap = useCallback(
-    async (params: SwapParams<OptimalRate | JupiterQuote>) => {
+    async (
+      params:
+        | SwapParams<OptimalRate>
+        | SwapParams<WrapOperation>
+        | SwapParams<UnwrapOperation>
+        | SwapParams<JupiterQuote>,
+    ) => {
       if (isSolanaNetwork(activeNetwork)) {
         if (!isJupiterSwapParams(params)) {
           throw swapError(SwapErrorCode.InvalidParams);
@@ -215,7 +226,11 @@ export function SwapContextProvider({
         return svmSwap(params);
       }
 
-      if (!isParaswapSwapParams(params)) {
+      if (
+        !isParaswapSwapParams(params) &&
+        !isWrapOperationParams(params) &&
+        !isUnwrapOperationParams(params)
+      ) {
         throw swapError(SwapErrorCode.InvalidParams);
       }
 

--- a/packages/ui/src/contexts/SwapProvider/constants.ts
+++ b/packages/ui/src/contexts/SwapProvider/constants.ts
@@ -37,3 +37,6 @@ export const JUPITER_PARTNER_ADDRESS =
  * @example 85 -> 0.85%
  */
 export const JUPITER_PARTNER_FEE_BPS = 85 as const satisfies number;
+
+export const WAVAX_ADDRESS = '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7';
+export const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';

--- a/packages/ui/src/contexts/SwapProvider/models.ts
+++ b/packages/ui/src/contexts/SwapProvider/models.ts
@@ -75,9 +75,7 @@ export const isParaswapSwapParams = (
   return isParaswapQuote(swapParams.quote);
 };
 
-export function isWrapOperation(
-  quote: SwapQuote,
-): quote is WrapOperation | UnwrapOperation {
+export function isWrapOperation(quote: SwapQuote): quote is WrapOperation {
   return 'type' in quote && quote.type === 'WRAP';
 }
 

--- a/packages/ui/src/contexts/SwapProvider/swap-utils.ts
+++ b/packages/ui/src/contexts/SwapProvider/swap-utils.ts
@@ -188,6 +188,45 @@ export function validateJupiterParams(
   };
 }
 
+export async function buildWrapTx({
+  userAddress,
+  tokenAddress,
+  amount,
+  provider,
+  abi,
+}) {
+  const contract = new Contract(tokenAddress, abi, provider);
+
+  const { to, data } = await contract.deposit!.populateTransaction();
+
+  return {
+    to,
+    data,
+    from: userAddress,
+    value: `0x${BigInt(amount).toString(16)}`,
+  };
+}
+
+export async function buildUnwrapTx({
+  userAddress,
+  tokenAddress,
+  amount,
+  provider,
+  abi,
+}) {
+  const contract = new Contract(tokenAddress, abi, provider);
+
+  const { to, data } = await contract.withdraw!.populateTransaction(
+    `0x${BigInt(amount).toString(16)}`,
+  );
+
+  return {
+    to,
+    data,
+    from: userAddress,
+  };
+}
+
 export async function buildApprovalTx({
   userAddress,
   spenderAddress,

--- a/packages/ui/src/contexts/SwapProvider/useEvmSwap.test.tsx
+++ b/packages/ui/src/contexts/SwapProvider/useEvmSwap.test.tsx
@@ -18,12 +18,14 @@ import { matchingPayload } from '@shared/tests/test-utils';
 import { useConnectionContext } from '../ConnectionProvider';
 import { useFeatureFlagContext } from '../FeatureFlagsProvider';
 
-import { NATIVE_TOKEN_ADDRESS } from './constants';
+import { NATIVE_TOKEN_ADDRESS, WAVAX_ADDRESS } from './constants';
 import {
   GetRateParams,
   SwapAdapterMethods,
   SwapParams,
   SwapWalletState,
+  UnwrapOperation,
+  WrapOperation,
 } from './models';
 import * as swapUtils from './swap-utils';
 import { useEvmSwap } from './useEvmSwap';
@@ -353,10 +355,56 @@ describe('contexts/SwapProvider/useEvmSwap', () => {
         });
       });
     });
+
+    it('returns UNWRAP details when needed', async () => {
+      const { getRate } = await buildAdapter(buildWalletState());
+
+      const params = buildGetRateParams({
+        srcToken: WAVAX_ADDRESS,
+        destToken: 'AVAX',
+      });
+
+      await act(async () => {
+        expect(await getRate(params)).toStrictEqual({
+          destAmount: '1000',
+          error: undefined,
+          quote: {
+            type: 'UNWRAP',
+            source: WAVAX_ADDRESS,
+            amount: '1000',
+          },
+        });
+      });
+    });
+
+    it('returns WRAP details when needed', async () => {
+      const { getRate } = await buildAdapter(buildWalletState());
+
+      const params = buildGetRateParams({
+        srcToken: 'AVAX',
+        destToken: WAVAX_ADDRESS,
+      });
+
+      await act(async () => {
+        expect(await getRate(params)).toStrictEqual({
+          destAmount: '1000',
+          error: undefined,
+          quote: {
+            type: 'WRAP',
+            target: WAVAX_ADDRESS,
+            amount: '1000',
+          },
+        });
+      });
+    });
   });
 
   describe('swap() function', () => {
-    const getSwapParams = (overrides?: Partial<SwapParams<OptimalRate>>) =>
+    const getSwapParams = (
+      overrides?: Partial<
+        SwapParams<OptimalRate | WrapOperation | UnwrapOperation>
+      >,
+    ) =>
       ({
         srcToken: 'srcToken',
         srcDecimals: 10,
@@ -955,6 +1003,90 @@ describe('contexts/SwapProvider/useEvmSwap', () => {
             ),
           ).not.toThrow();
         });
+      });
+    });
+
+    it('performs a wrap when needed', async () => {
+      const requestMock = jest.fn().mockResolvedValueOnce('0xSWAP_HASH');
+
+      jest.mocked(Contract).mockReturnValue({
+        deposit: {
+          populateTransaction: jest.fn().mockResolvedValueOnce({
+            to: 'wrap_to',
+            data: 'wrap_data',
+          }),
+        },
+      } as any);
+
+      jest.mocked(useConnectionContext).mockReturnValue({
+        request: requestMock,
+        events: jest.fn(),
+      } as any);
+
+      const { swap } = await buildAdapter(buildWalletState());
+
+      await act(async () => {
+        await swap(
+          getSwapParams({
+            srcToken: 'AVAX',
+            destToken: WAVAX_ADDRESS,
+            quote: {
+              type: 'WRAP',
+              target: WAVAX_ADDRESS,
+              amount: '1000',
+            },
+          }),
+        );
+
+        expect(requestMock).toHaveBeenCalledWith(
+          matchingPayload({
+            method: RpcMethod.ETH_SEND_TRANSACTION,
+            params: [matchingPayload({ to: 'wrap_to', data: 'wrap_data' })],
+          }),
+        );
+      });
+    });
+
+    it('performs an unwrap when needed', async () => {
+      const requestMock = jest.fn().mockResolvedValueOnce('0xSWAP_HASH');
+
+      jest.mocked(Contract).mockReturnValue({
+        withdraw: {
+          populateTransaction: jest.fn().mockResolvedValueOnce({
+            to: 'unwrap_from',
+            data: 'unwrap_data',
+          }),
+        },
+      } as any);
+
+      jest.mocked(useConnectionContext).mockReturnValue({
+        request: requestMock,
+        events: jest.fn(),
+      } as any);
+
+      const { swap } = await buildAdapter(buildWalletState());
+
+      await act(async () => {
+        await swap(
+          getSwapParams({
+            destToken: 'AVAX',
+            srcToken: WAVAX_ADDRESS,
+            quote: {
+              type: 'UNWRAP',
+              source: WAVAX_ADDRESS,
+              amount: '1000',
+            },
+          }),
+        );
+
+        expect(requestMock).toHaveBeenCalledWith(
+          matchingPayload({
+            method: RpcMethod.ETH_SEND_TRANSACTION,
+            params: [
+              matchingPayload({ to: 'unwrap_from', data: 'unwrap_data' }),
+            ],
+          }),
+        );
       });
     });
   });

--- a/packages/ui/src/contexts/SwapProvider/useEvmSwap.test.tsx
+++ b/packages/ui/src/contexts/SwapProvider/useEvmSwap.test.tsx
@@ -1057,7 +1057,7 @@ describe('contexts/SwapProvider/useEvmSwap', () => {
             data: 'unwrap_data',
           }),
         },
-      } as any);
+      } as unknown as Contract);
 
       jest.mocked(useConnectionContext).mockReturnValue({
         request: requestMock,

--- a/packages/ui/src/contexts/SwapProvider/useEvmSwap.tsx
+++ b/packages/ui/src/contexts/SwapProvider/useEvmSwap.tsx
@@ -535,10 +535,9 @@ export const useEvmSwap: SwapAdapter<
 
       const { srcToken, destToken, srcDecimals, destDecimals } = params;
       const userAddress = account.addressC;
-      const tokenAddress =
-        params.quote.type === 'WRAP'
-          ? params.quote.target
-          : params.quote.source;
+      const tokenAddress = isWrapOperationParams(params)
+        ? params.quote.target
+        : params.quote.source;
       const amount = params.quote.amount;
 
       const abi = tokenAddress === WETH_ADDRESS ? WETH_ABI : WAVAX_ABI;
@@ -549,10 +548,9 @@ export const useEvmSwap: SwapAdapter<
         provider: rpcProvider,
         abi,
       };
-      const tx =
-        params.quote.type === 'WRAP'
-          ? await buildWrapTx(buildTxParams)
-          : await buildUnwrapTx(buildTxParams);
+      const tx = isWrapOperationParams(params)
+        ? await buildWrapTx(buildTxParams)
+        : await buildUnwrapTx(buildTxParams);
 
       const [txHash, signError] = await resolve(
         request({
@@ -570,7 +568,7 @@ export const useEvmSwap: SwapAdapter<
       const pendingToastId = showPendingToast();
 
       rpcProvider.waitForTransaction(txHash).then((receipt) => {
-        const isSuccessful = Boolean(receipt && receipt.status === 1);
+        const isSuccessful = Boolean(receipt?.status === 1);
 
         onTransactionReceipt({
           isSuccessful,

--- a/packages/ui/src/contexts/SwapProvider/useSolanaSwap.tsx
+++ b/packages/ui/src/contexts/SwapProvider/useSolanaSwap.tsx
@@ -26,10 +26,10 @@ import {
 import { JUPITER_QUOTE_SCHEMA, JUPITER_TX_SCHEMA } from './schemas';
 import { GetRateParams, JupiterQuote, SwapAdapter, SwapParams } from './models';
 
-export const useSolanaSwap: SwapAdapter<JupiterQuote> = (
-  { account, network },
-  { onTransactionReceipt, showPendingToast },
-) => {
+export const useSolanaSwap: SwapAdapter<
+  JupiterQuote,
+  SwapParams<JupiterQuote>
+> = ({ account, network }, { onTransactionReceipt, showPendingToast }) => {
   const { t } = useTranslation();
   const { request } = useConnectionContext();
   const { capture } = useAnalyticsContext();


### PR DESCRIPTION
⚠️ Based on #259 

* [CP-10281](https://ava-labs.atlassian.net/browse/CP-10281)

## Changes
* When swapping between AVAX <-> WAVAX or ETH <-> WETH, perform `deposit` or `withdraw` transactions directly on their respective contracts instead of going through Velora (Paraswap)

## Testing
* Swap between AVAX and WAVAX
    * Same for ETH <-> WETH
* "Powered by..." notice should be hidden
* Info about fees should be hidden
* Transactions should NOT go through Velora (Paraswap)

## Screenshots:

https://github.com/user-attachments/assets/052d3b1d-198d-4376-8650-c0ebae014ae1


## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
