### PR TITLE
feat: CP-10617 attach chat history to content creation

### DIFF
--- a/src/background/services/firebase/FirebaseService.ts
+++ b/src/background/services/firebase/FirebaseService.ts
@@ -13,6 +13,7 @@ import {
   FcmMessageListener,
   ChatConfig,
   ConfigParams,
+  ChatDialogHistory,
 } from './models';
 import sentryCaptureException, {
   SentryExceptionTypes,
@@ -151,10 +152,33 @@ export class FirebaseService {
     });
   }
 
-  async generateContent(message: string, parts?: Content[]) {
+  async generateContent({
+    message,
+    parts,
+    history,
+  }: {
+    message: string;
+    parts?: Content[];
+    history?: ChatDialogHistory[];
+  }) {
+    const chatHistory = history
+      ? history.map((messageItem) => {
+          return {
+            role: messageItem.role,
+            parts: [{ text: messageItem.content }],
+          };
+        })
+      : [];
     const contents = parts
-      ? ([{ role: 'user', parts: [{ text: message }] }, ...parts] as Content[])
-      : ([{ role: 'user', parts: [{ text: message }] }] as Content[]);
+      ? ([
+          ...chatHistory,
+          { role: 'user', parts: [{ text: message }] },
+          ...parts,
+        ] as Content[])
+      : ([
+          ...chatHistory,
+          { role: 'user', parts: [{ text: message }] },
+        ] as Content[]);
     const result = await this.#model?.generateContent({
       ...this.#config,
       contents,

--- a/src/background/services/firebase/handlers/sendMessage.ts
+++ b/src/background/services/firebase/handlers/sendMessage.ts
@@ -26,7 +26,6 @@ export class FirebaseSendMessageHandler implements HandlerType {
 
   handle: HandlerType['handle'] = async ({ request }) => {
     const { message, parts, history } = request.params;
-    console.log('history: ', history);
     if (!message) {
       return {
         ...request,

--- a/src/background/services/firebase/models.ts
+++ b/src/background/services/firebase/models.ts
@@ -24,3 +24,8 @@ export interface ConfigParams {
 export interface ChatConfig extends ConfigParams {
   generationConfig: GenerationConfig;
 }
+
+export interface ChatDialogHistory {
+  role: 'model' | 'user';
+  content: string;
+}

--- a/src/pages/Home/components/Portfolio/Prompt/Prompt.tsx
+++ b/src/pages/Home/components/Portfolio/Prompt/Prompt.tsx
@@ -383,7 +383,7 @@ export function Prompt() {
             throw new Error(e);
           });
 
-        const response = await sendMessage(message);
+        const response = await sendMessage({ message, history: prompts });
 
         // For simplicity, this uses the first function call found.
         const call = response?.functionCalls?.[0];
@@ -399,22 +399,25 @@ export function Prompt() {
             const apiResponse = await functions[call.name](call.args);
             // Send the API response back to the model so it can generate
             // a text response that can be displayed to the user.
-            const functionResult = await sendMessage(message, [
-              { role: 'model', parts: [{ functionCall: { ...call } }] },
-              {
-                role: 'function',
-                parts: [
-                  {
-                    functionResponse: {
-                      name: 'send',
-                      response: {
-                        content: apiResponse.content,
+            const functionResult = await sendMessage({
+              message,
+              parts: [
+                { role: 'model', parts: [{ functionCall: { ...call } }] },
+                {
+                  role: 'function',
+                  parts: [
+                    {
+                      functionResponse: {
+                        name: 'send',
+                        response: {
+                          content: apiResponse.content,
+                        },
                       },
                     },
-                  },
-                ],
-              },
-            ]);
+                  ],
+                },
+              ],
+            });
             // Log the text response.
             setPrompts((prev) => {
               return [...prev, { role: 'model', content: functionResult.text }];
@@ -427,22 +430,25 @@ export function Prompt() {
 
             // Send the API response back to the model so it can generate
             // a text response that can be displayed to the user.
-            const errorResult = await sendMessage(message, [
-              { role: 'model', parts: [{ functionCall: { ...call } }] },
-              {
-                role: 'function',
-                parts: [
-                  {
-                    functionResponse: {
-                      name: 'send',
-                      response: {
-                        content: `Send failed. ${errorMessage}`,
+            const errorResult = await sendMessage({
+              message,
+              parts: [
+                { role: 'model', parts: [{ functionCall: { ...call } }] },
+                {
+                  role: 'function',
+                  parts: [
+                    {
+                      functionResponse: {
+                        name: 'send',
+                        response: {
+                          content: `Send failed. ${errorMessage}`,
+                        },
                       },
                     },
-                  },
-                ],
-              },
-            ]);
+                  ],
+                },
+              ],
+            });
 
             // Log the text response.
             setPrompts((prev) => {
@@ -507,6 +513,7 @@ export function Prompt() {
       setModel,
       systemPrompt,
       sendMessage,
+      prompts,
       captureEncrypted,
       functions,
     ],

--- a/src/pages/Home/components/Portfolio/Prompt/models.ts
+++ b/src/pages/Home/components/Portfolio/Prompt/models.ts
@@ -13,7 +13,7 @@ export const functionDeclarations: FunctionDeclaration[] = [
         },
         recipient: {
           type: SchemaType.STRING,
-          description: `The wallet address of the recipient. It has to be a valid EVM address which is in a hexadecimal format and is 42 characters long. The recipient can be a contact or one of the user's accounts. The active account cannot be the recipient.`,
+          description: `The wallet address of the recipient. It has to be a valid EVM address which is in a hexadecimal format and is 42 characters long. The recipient can be a contact or one of the user's accounts. The active account cannot be the recipient but the user can use the other accounts as a recipient.`,
         },
         token: {
           type: SchemaType.STRING,


### PR DESCRIPTION
## Description

The AI can lose the context of the chat dialog.

## Changes

Improve the chat capabilities e.g. the user can continuously write commands and refer back to another command.

## Testing

Go to AI -> try to chat with it, give a command in pieces (e.g. what do you want after that the amount the token etc.)

## Screenshots:


https://github.com/user-attachments/assets/a015f1c7-19b0-444c-a3a4-b8bfaa0a6ef9



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
