### PR TITLE
feat: internally wrap/unwrap WAVAX & WETH

### DIFF
--- a/src/contexts/SwapProvider/ABI_WAVAX.json
+++ b/src/contexts/SwapProvider/ABI_WAVAX.json
@@ -1,0 +1,153 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "guy", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "src", "type": "address" },
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "wad", "type": "uint256" }],
+    "name": "withdraw",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "deposit",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "", "type": "address" },
+      { "name": "", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "guy", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Withdrawal",
+    "type": "event"
+  }
+]

--- a/src/contexts/SwapProvider/ABI_WETH.json
+++ b/src/contexts/SwapProvider/ABI_WETH.json
@@ -1,0 +1,153 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "guy", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "src", "type": "address" },
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "wad", "type": "uint256" }],
+    "name": "withdraw",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "deposit",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "", "type": "address" },
+      { "name": "", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "guy", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Withdrawal",
+    "type": "event"
+  }
+]

--- a/src/contexts/SwapProvider/SwapProvider.tsx
+++ b/src/contexts/SwapProvider/SwapProvider.tsx
@@ -41,6 +41,11 @@ import {
   DISALLOWED_SWAP_ASSETS,
   OnTransactionReceiptCallback,
   SwapErrorCode,
+  SwapQuote,
+  isUnwrapOperationParams,
+  isWrapOperationParams,
+  UnwrapOperation,
+  WrapOperation,
 } from './models';
 import { useEvmSwap } from './useEvmSwap';
 import { useSolanaSwap } from './useSolanaSwap';
@@ -61,7 +66,7 @@ export function SwapContextProvider({ children }: { children: any }) {
     disallowedAssets: DISALLOWED_SWAP_ASSETS,
   });
 
-  const [quote, setQuote] = useState<OptimalRate | JupiterQuote | null>(null);
+  const [quote, setQuote] = useState<SwapQuote | null>(null);
   const [error, setError] = useState<SwapError>({ message: '' });
   const [destAmount, setDestAmount] = useState('');
   const [isSwapLoading, setIsSwapLoading] = useState<boolean>(false);
@@ -196,7 +201,13 @@ export function SwapContextProvider({ children }: { children: any }) {
   );
 
   const swap = useCallback(
-    async (params: SwapParams<OptimalRate | JupiterQuote>) => {
+    async (
+      params:
+        | SwapParams<OptimalRate>
+        | SwapParams<WrapOperation>
+        | SwapParams<UnwrapOperation>
+        | SwapParams<JupiterQuote>,
+    ) => {
       if (isSolanaNetwork(activeNetwork)) {
         if (!isJupiterSwapParams(params)) {
           throw swapError(SwapErrorCode.InvalidParams);
@@ -205,7 +216,11 @@ export function SwapContextProvider({ children }: { children: any }) {
         return svmSwap(params);
       }
 
-      if (!isParaswapSwapParams(params)) {
+      if (
+        !isParaswapSwapParams(params) &&
+        !isWrapOperationParams(params) &&
+        !isUnwrapOperationParams(params)
+      ) {
         throw swapError(SwapErrorCode.InvalidParams);
       }
 

--- a/src/contexts/SwapProvider/constants.ts
+++ b/src/contexts/SwapProvider/constants.ts
@@ -37,3 +37,6 @@ export const JUPITER_PARTNER_ADDRESS =
  * @example 85 -> 0.85%
  */
 export const JUPITER_PARTNER_FEE_BPS = 85 as const satisfies number;
+
+export const WAVAX_ADDRESS = '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7';
+export const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';

--- a/src/contexts/SwapProvider/swap-utils.ts
+++ b/src/contexts/SwapProvider/swap-utils.ts
@@ -42,6 +42,8 @@ import {
   SOL_MINT,
 } from './constants';
 import { FetcherError, OptimalRate, TransactionParams } from '@paraswap/sdk';
+import type WAVAX_ABI from './ABI_WAVAX.json';
+import type WETH_ABI from './ABI_WETH.json';
 
 export function validateParaswapParams(
   params: Partial<SwapParams<OptimalRate>>,
@@ -563,3 +565,50 @@ export const getFeeAccountInfo = async (
     isInitialized: Boolean(feeAccountInfo.value),
   };
 };
+
+type WrapUnwrapTxParams = {
+  userAddress: string;
+  tokenAddress: string;
+  amount: string;
+  provider: JsonRpcBatchInternal;
+  abi: typeof WAVAX_ABI | typeof WETH_ABI;
+};
+
+export async function buildWrapTx({
+  userAddress,
+  tokenAddress,
+  amount,
+  provider,
+  abi,
+}: WrapUnwrapTxParams) {
+  const contract = new Contract(tokenAddress, abi, provider);
+
+  const { to, data } = await contract.deposit!.populateTransaction();
+
+  return {
+    to,
+    data,
+    from: userAddress,
+    value: `0x${BigInt(amount).toString(16)}`,
+  };
+}
+
+export async function buildUnwrapTx({
+  userAddress,
+  tokenAddress,
+  amount,
+  provider,
+  abi,
+}: WrapUnwrapTxParams) {
+  const contract = new Contract(tokenAddress, abi, provider);
+
+  const { to, data } = await contract.withdraw!.populateTransaction(
+    `0x${BigInt(amount).toString(16)}`,
+  );
+
+  return {
+    to,
+    data,
+    from: userAddress,
+  };
+}

--- a/src/contexts/SwapProvider/useEvmSwap.tsx
+++ b/src/contexts/SwapProvider/useEvmSwap.tsx
@@ -19,6 +19,10 @@ import {
   ValidTransactionResponse,
   SwapErrorCode,
   SwapAdapter,
+  isUnwrapOperationParams,
+  isWrapOperationParams,
+  UnwrapOperation,
+  WrapOperation,
 } from './models';
 import Joi from 'joi';
 import { isAPIError } from '@src/pages/Swap/utils';
@@ -32,6 +36,8 @@ import {
   paraswapErrorToSwapError,
   swapError,
   validateParaswapParams,
+  buildUnwrapTx,
+  buildWrapTx,
 } from './swap-utils';
 import { assert, assertPresent } from '@src/utils/assertions';
 import {
@@ -52,9 +58,16 @@ import {
   SwapSide,
   constructGetSpender,
 } from '@paraswap/sdk';
-import { NATIVE_TOKEN_ADDRESS } from './constants';
+import { NATIVE_TOKEN_ADDRESS, WAVAX_ADDRESS, WETH_ADDRESS } from './constants';
+import WAVAX_ABI from './ABI_WAVAX.json';
+import WETH_ABI from './ABI_WETH.json';
 
-export const useEvmSwap: SwapAdapter<OptimalRate> = (
+export const useEvmSwap: SwapAdapter<
+  OptimalRate | WrapOperation | UnwrapOperation,
+  | SwapParams<OptimalRate>
+  | SwapParams<WrapOperation>
+  | SwapParams<UnwrapOperation>
+> = (
   { account, network, walletDetails },
   { onTransactionReceipt, showPendingToast },
 ) => {
@@ -127,6 +140,35 @@ export const useEvmSwap: SwapAdapter<OptimalRate> = (
 
       const isFromTokenNative = network.networkToken.symbol === srcToken;
       const isDestTokenNative = network.networkToken.symbol === destToken;
+      const wrappableTokens = [WAVAX_ADDRESS, WETH_ADDRESS];
+
+      if (
+        isFromTokenNative &&
+        wrappableTokens.includes(destToken.toLowerCase())
+      ) {
+        return {
+          error: undefined,
+          quote: {
+            type: 'WRAP' as const,
+            target: destToken,
+            amount: srcAmount,
+          },
+          destAmount: srcAmount,
+        };
+      } else if (
+        isDestTokenNative &&
+        wrappableTokens.includes(srcToken.toLowerCase())
+      ) {
+        return {
+          error: undefined,
+          quote: {
+            type: 'UNWRAP' as const,
+            source: srcToken,
+            amount: srcAmount,
+          },
+          destAmount: srcAmount,
+        };
+      }
 
       const optimalRates = async () => {
         return await paraswap.getRate({
@@ -480,6 +522,74 @@ export const useEvmSwap: SwapAdapter<OptimalRate> = (
       showPendingToast,
     ],
   );
+  const performWrapOperation = useCallback(
+    async (params: SwapParams<WrapOperation> | SwapParams<UnwrapOperation>) => {
+      assertPresent(network, CommonError.NoActiveNetwork);
+      assertPresent(account, CommonError.NoActiveAccount);
+      assertPresent(rpcProvider, CommonError.Unknown);
+      assert(!network.isTestnet, CommonError.UnknownNetwork);
+
+      const { srcToken, destToken, srcDecimals, destDecimals } = params;
+      const userAddress = account.addressC;
+      const tokenAddress = isWrapOperationParams(params)
+        ? params.quote.target
+        : params.quote.source;
+      const amount = params.quote.amount;
+
+      const abi = tokenAddress === WETH_ADDRESS ? WETH_ABI : WAVAX_ABI;
+      const buildTxParams = {
+        userAddress,
+        tokenAddress,
+        amount,
+        provider: rpcProvider,
+        abi,
+      };
+      const tx = isWrapOperationParams(params)
+        ? await buildWrapTx(buildTxParams)
+        : await buildUnwrapTx(buildTxParams);
+
+      const [txHash, signError] = await resolve(
+        request({
+          method: RpcMethod.ETH_SEND_TRANSACTION,
+          params: [tx],
+        }),
+      );
+
+      if (isUserRejectionError(signError)) {
+        throw signError;
+      } else if (signError || !txHash) {
+        throw swapError(CommonError.UnableToSign, signError);
+      }
+
+      const pendingToastId = showPendingToast();
+
+      rpcProvider.waitForTransaction(txHash).then((receipt) => {
+        const isSuccessful = Boolean(receipt?.status === 1);
+
+        onTransactionReceipt({
+          isSuccessful,
+          pendingToastId,
+          txHash: txHash,
+          chainId: network.chainId,
+          userAddress,
+          srcToken,
+          destToken,
+          srcAmount: amount,
+          destAmount: amount,
+          srcDecimals,
+          destDecimals,
+        });
+      });
+    },
+    [
+      request,
+      account,
+      network,
+      rpcProvider,
+      showPendingToast,
+      onTransactionReceipt,
+    ],
+  );
 
   const regularSwap = useCallback(
     async (params: SwapParams<OptimalRate>) => {
@@ -608,7 +718,12 @@ export const useEvmSwap: SwapAdapter<OptimalRate> = (
   );
 
   const swap = useCallback(
-    async (params: SwapParams<OptimalRate>) => {
+    async (
+      params:
+        | SwapParams<OptimalRate>
+        | SwapParams<WrapOperation>
+        | SwapParams<UnwrapOperation>,
+    ) => {
       if (!isFlagEnabled(FeatureGates.SWAP)) {
         throw swapError(SwapErrorCode.FeatureDisabled);
       }
@@ -619,13 +734,23 @@ export const useEvmSwap: SwapAdapter<OptimalRate> = (
         walletDetails?.type === SecretType.Seedless ||
         walletDetails?.type === SecretType.PrivateKey;
 
+      if (isWrapOperationParams(params) || isUnwrapOperationParams(params)) {
+        return performWrapOperation(params);
+      }
+
       if (isOneClickSwapEnabled && isOneClickSwapSupported) {
         return oneClickSwap(params);
       }
 
       return regularSwap(params);
     },
-    [regularSwap, oneClickSwap, isFlagEnabled, walletDetails?.type],
+    [
+      regularSwap,
+      oneClickSwap,
+      isFlagEnabled,
+      walletDetails?.type,
+      performWrapOperation,
+    ],
   );
 
   return {

--- a/src/contexts/SwapProvider/useSolanaSwap.tsx
+++ b/src/contexts/SwapProvider/useSolanaSwap.tsx
@@ -32,10 +32,10 @@ import {
   SwapParams,
 } from './models';
 
-export const useSolanaSwap: SwapAdapter<JupiterQuote> = (
-  { account, network },
-  { onTransactionReceipt, showPendingToast },
-) => {
+export const useSolanaSwap: SwapAdapter<
+  JupiterQuote,
+  SwapParams<JupiterQuote>
+> = ({ account, network }, { onTransactionReceipt, showPendingToast }) => {
   const { t } = useTranslation();
   const { request } = useConnectionContext();
   const { capture } = useAnalyticsContext();

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -42,6 +42,8 @@ import { useLiveBalance } from '@src/hooks/useLiveBalance';
 import { useErrorMessage } from '@src/hooks/useErrorMessage';
 import { SwappableToken } from './models';
 import { useSwappableTokens } from './hooks/useSwapTokens';
+import { isParaswapQuote } from '@src/contexts/SwapProvider/models';
+import { isJupiterQuote } from '@src/contexts/SwapProvider/models';
 
 const ReviewOrderButtonContainer = styled('div')<{
   isTransactionDetailsOpen: boolean;
@@ -282,6 +284,9 @@ export function Swap() {
     setIsTransactionDetailsOpen(false);
   }
 
+  const showEngineNotice =
+    quote && (isParaswapQuote(quote) || isJupiterQuote(quote));
+
   return (
     <Stack
       sx={{
@@ -420,6 +425,7 @@ export function Swap() {
 
           {isDetailsAvailable && (
             <TransactionDetails
+              quote={quote}
               fromTokenSymbol={selectedFromToken?.symbol}
               toTokenSymbol={selectedToToken?.symbol}
               rate={calculateRate(quote, {
@@ -435,7 +441,7 @@ export function Swap() {
           <ReviewOrderButtonContainer
             isTransactionDetailsOpen={isTransactionDetailsOpen}
           >
-            <SwapEngineNotice />
+            {showEngineNotice && <SwapEngineNotice />}
             <Button
               data-testid="swap-review-order-button"
               sx={{

--- a/src/pages/Swap/utils/calculateRate.ts
+++ b/src/pages/Swap/utils/calculateRate.ts
@@ -1,0 +1,57 @@
+import { OptimalRate } from '@paraswap/sdk';
+import {
+  isJupiterQuote,
+  isParaswapQuote,
+  JupiterQuote,
+  UnwrapOperation,
+  WrapOperation,
+} from '@src/contexts/SwapProvider/models';
+
+type RateCalculationContext = { srcDecimals: number; destDecimals: number };
+type RateCalculationStrategy = {
+  calculate(
+    quote: OptimalRate | JupiterQuote | WrapOperation | UnwrapOperation,
+    context: RateCalculationContext,
+  ): number;
+};
+
+const ParaswapRateStrategy: RateCalculationStrategy = {
+  calculate(quote: OptimalRate): number {
+    const { destAmount, destDecimals, srcAmount, srcDecimals } = quote;
+    const destAmountNumber = parseInt(destAmount, 10) / 10 ** destDecimals;
+    const sourceAmountNumber = parseInt(srcAmount, 10) / 10 ** srcDecimals;
+    return destAmountNumber / sourceAmountNumber;
+  },
+};
+
+const JupiterRateStrategy: RateCalculationStrategy = {
+  calculate(quote: JupiterQuote, context): number {
+    const { inAmount, outAmount } = quote;
+    const realOutValue = parseInt(outAmount, 10) / 10 ** context.destDecimals;
+    const realInValue = parseInt(inAmount, 10) / 10 ** context.srcDecimals;
+    return realOutValue / realInValue;
+  },
+};
+
+const WrapUnwrapRateStrategy: RateCalculationStrategy = {
+  calculate(): number {
+    return 1; // wrap/unwrap always has 1:1 rate
+  },
+};
+
+export const calculateRate = (
+  quote: OptimalRate | JupiterQuote | WrapOperation | UnwrapOperation,
+  context: RateCalculationContext,
+) => {
+  let strategy: RateCalculationStrategy;
+
+  if (isParaswapQuote(quote)) {
+    strategy = ParaswapRateStrategy;
+  } else if (isJupiterQuote(quote)) {
+    strategy = JupiterRateStrategy;
+  } else {
+    strategy = WrapUnwrapRateStrategy;
+  }
+
+  return strategy.calculate(quote, context);
+};

--- a/src/pages/Swap/utils/index.tsx
+++ b/src/pages/Swap/utils/index.tsx
@@ -9,10 +9,6 @@ import { stringToBigint } from '@src/utils/stringToBigint';
 import { WrappedError } from '@src/utils/errors';
 import { OptimalRate } from '@paraswap/sdk';
 import { SwappableToken } from '../models';
-import {
-  isParaswapQuote,
-  JupiterQuote,
-} from '@src/contexts/SwapProvider/models';
 
 interface GetTokenIconProps {
   token?: TokenWithBalanceEVM;
@@ -95,27 +91,6 @@ export const getMaxValueWithGas = ({
   return max;
 };
 
-export const calculateRate = (
-  quote: OptimalRate | JupiterQuote,
-  context: { srcDecimals: number; destDecimals: number },
-) => {
-  if (isParaswapQuote(quote)) {
-    const { destAmount, destDecimals, srcAmount, srcDecimals } = quote;
-    const destAmountNumber =
-      parseInt(destAmount, 10) / Math.pow(10, destDecimals);
-    const sourceAmountNumber =
-      parseInt(srcAmount, 10) / Math.pow(10, srcDecimals);
-    return destAmountNumber / sourceAmountNumber;
-  }
-
-  const { inAmount, outAmount } = quote;
-
-  const realOutValue = parseInt(outAmount, 10) / 10 ** context.destDecimals;
-  const realInValue = parseInt(inAmount, 10) / 10 ** context.srcDecimals;
-
-  return realOutValue / realInValue;
-};
-
 export interface Token {
   icon?: JSX.Element;
   name?: string;
@@ -160,3 +135,5 @@ export const isSwappableToken = (
 
   return token.type === TokenType.ERC20 || token.type === TokenType.NATIVE;
 };
+
+export { calculateRate } from './calculateRate';


### PR DESCRIPTION
_(copy of https://github.com/ava-labs/core-extension/pull/263, targetting `main`)_

* [CP-10281](https://ava-labs.atlassian.net/browse/CP-10281)

## Changes
* When swapping between AVAX <-> WAVAX or ETH <-> WETH, perform `deposit` or `withdraw` transactions directly on their respective contracts instead of going through Velora (Paraswap)

## Testing
* Swap between AVAX and WAVAX
    * Same for ETH <-> WETH
* "Powered by..." notice should be hidden
* Info about fees should be hidden
* Transactions should NOT go through Velora (Paraswap)

## Screenshots:

https://github.com/user-attachments/assets/052d3b1d-198d-4376-8650-c0ebae014ae1


## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
