### PR TITLE
fix: CP-10715 handle the unsupprotd networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pids
 *.pid.lock
 .env
 .env.production
+.env.dev
 
 # Dependency directories
 node_modules/
@@ -43,12 +44,12 @@ typings/
 # IDE files
 .idea
 .idea/*
-
 __dist
 dist
 builds
 .DS_Store
 todo.*
+dist-next
 
 # snyk
 .dccache

--- a/src/pages/Home/components/Portfolio/Prompt/Prompt.tsx
+++ b/src/pages/Home/components/Portfolio/Prompt/Prompt.tsx
@@ -20,6 +20,7 @@ import { buildTx } from '@src/pages/Send/utils/buildSendTx';
 import { getProviderForNetwork } from '@src/utils/network/getProviderForNetwork';
 import { JsonRpcBatchInternal } from '@avalabs/core-wallets-sdk';
 import {
+  NetworkVMType,
   RpcMethod,
   TokenType,
   TokenWithBalanceERC20,
@@ -95,6 +96,10 @@ export function Prompt() {
         if (!network) {
           throw new Error(`No network`);
         }
+        if (network.vmName !== NetworkVMType.EVM) {
+          throw new Error('Only EVM networks supported at the moment');
+        }
+
         const provider = await getProviderForNetwork(network);
         if (!provider) {
           throw new Error(`No network`);
@@ -204,6 +209,9 @@ export function Prompt() {
         fromTokenAddress: string;
         toTokenAddress: string;
       }) => {
+        if (network && network.vmName !== NetworkVMType.EVM) {
+          throw new Error('Only EVM networks supported at the moment');
+        }
         const srcToken = tokens.find(
           (item) =>
             item.symbol === fromTokenAddress ||
@@ -387,6 +395,7 @@ export function Prompt() {
             id: n.caipId,
             name: n.chainName,
             isTestnet: n.isTestnet,
+            vmName: n.vmName,
           })),
         ),
       )

--- a/src/pages/Home/components/Portfolio/Prompt/models.ts
+++ b/src/pages/Home/components/Portfolio/Prompt/models.ts
@@ -169,4 +169,6 @@ All known and available tokens for the current network are listed in the followi
 Bridge must be only available the following tokens: __BRIDGE_DATA__ and the source network is always the actual "active" network.
 The user can open a dApp by name or by a given URL or if the user wants to buy a token you can open a new window where it can be done.
 The important words should be emphasised with bold formatting e.g.  token and network names and / or ids, command names and similar things. 
+The user can use the 'swap' and 'send' functions ONLY on EVM networks which means the 'vmName' (that is the short form of Virtual Machine) property of the active network MUST BE 'EVM'. There is a 'vmName' property in the data of each network in the available networks list. If that value is 'EVM' the user able to call those functions. When the user wants to start a 'send' or 'swap' transaction notify them with an emphasised message.
+Usually when the user wants to use the 'c-chain' network it means the Avalanche (C-Chain) network. This is similar than the 'x-chain' (Avalanche (X-Chain)) and 'p-chain' (Avalanche (P-Chain)) networks.
 `;


### PR DESCRIPTION
## Description

The AI does not support the non-evm specific transactions (send and swap) but it does not aware of that.

## Changes

The prompt has been modified and the functions should throw an error when the active network is a non-evm network.

## Testing

Go to AI -> try to send and/or swap from a non evm network.

## Screenshots:


https://github.com/user-attachments/assets/0803de9e-25ce-4fcb-892b-f1c10bc839c6



## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
