### PR TITLE
fix: enquote env file building

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -21,31 +21,31 @@ jobs:
         run: |
           touch .env.production
           echo RELEASE=production >> .env.production
-          echo POSTHOG_KEY=${{ secrets.POSTHOG_KEY }} >> .env.production
-          echo POSTHOG_URL=${{ secrets.POSTHOG_URL }} >> .env.production
-          echo ANALYTICS_ENCRYPTION_KEY=${{ secrets.ANALYTICS_ENCRYPTION_KEY }} >> .env.production
-          echo ANALYTICS_ENCRYPTION_KEY_ID=${{ secrets.ANALYTICS_ENCRYPTION_KEY_ID }} >> .env.production
-          echo COVALENT_API_KEY=${{ secrets.COVALENT_API_KEY }} >> .env.production
-          echo GLACIER_URL=${{ secrets.GLACIER_URL }} >> .env.production
-          echo PROXY_URL=${{ secrets.PROXY_URL }} >> .env.production
-          echo CORE_EXTENSION_LANDING_URL=${{ secrets.CORE_EXTENSION_LANDING_URL }} >> .env.production
-          echo SENTRY_DSN=${{ secrets.SENTRY_DSN }} >> .env.production
-          echo CORE_WEB_BASE_URL=${{ secrets.CORE_WEB_BASE_URL }} >> .env.production
-          echo WALLET_CONNECT_PROJECT_ID=${{ secrets.WALLET_CONNECT_PROJECT_ID }} >> .env.production
-          echo SEEDLESS_URL=${{ secrets.SEEDLESS_URL }} >> .env.production
-          echo SEEDLESS_ORG_ID=${{ secrets.SEEDLESS_ORG_ID }} >> .env.production
-          echo GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }} >> .env.production
-          echo APPLE_OAUTH_CLIENT_ID=${{ secrets.APPLE_OAUTH_CLIENT_ID }} >> .env.production
-          echo APPLE_OAUTH_REDIRECT_URL=${{ secrets.APPLE_OAUTH_REDIRECT_URL }} >> .env.production
-          echo CUBESIGNER_ENV=${{ secrets.CUBESIGNER_ENV }} >> .env.production
-          echo SEEDLESS_FIDO_IDENTITY_URL=${{ secrets.SEEDLESS_FIDO_IDENTITY_URL }} >> .env.production
-          echo NEWSLETTER_BASE_URL=${{ secrets.NEWSLETTER_BASE_URL }} >> .env.production
-          echo NEWSLETTER_PORTAL_ID=${{ secrets.NEWSLETTER_PORTAL_ID }} >> .env.production
-          echo NEWSLETTER_FORM_ID=${{ secrets.NEWSLETTER_FORM_ID }} >> .env.production
-          echo FIREBASE_CONFIG=${{ secrets.FIREBASE_CONFIG }} >> .env.production
-          echo ID_SERVICE_URL=${{ secrets.ID_SERVICE_URL }} >> .env.production
-          echo GASLESS_SERVICE_URL=${{ secrets.GASLESS_SERVICE_URL }} >> .env.production
-          echo NOTIFICATION_SENDER_SERVICE_URL=${{ secrets.NOTIFICATION_SENDER_SERVICE_URL }} >> .env.production
+          echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> .env.production
+          echo 'POSTHOG_URL="${{ secrets.POSTHOG_URL }}"' >> .env.production
+          echo 'ANALYTICS_ENCRYPTION_KEY="${{ secrets.ANALYTICS_ENCRYPTION_KEY }}"' >> .env.production
+          echo 'ANALYTICS_ENCRYPTION_KEY_ID="${{ secrets.ANALYTICS_ENCRYPTION_KEY_ID }}"' >> .env.production
+          echo 'COVALENT_API_KEY="${{ secrets.COVALENT_API_KEY }}"' >> .env.production
+          echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
+          echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
+          echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
+          echo 'SENTRY_DSN="${{ secrets.SENTRY_DSN }}"' >> .env.production
+          echo 'CORE_WEB_BASE_URL="${{ secrets.CORE_WEB_BASE_URL }}"' >> .env.production
+          echo 'WALLET_CONNECT_PROJECT_ID="${{ secrets.WALLET_CONNECT_PROJECT_ID }}"' >> .env.production
+          echo 'SEEDLESS_URL="${{ secrets.SEEDLESS_URL }}"' >> .env.production
+          echo 'SEEDLESS_ORG_ID="${{ secrets.SEEDLESS_ORG_ID }}"' >> .env.production
+          echo 'GOOGLE_OAUTH_CLIENT_ID="${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}"' >> .env.production
+          echo 'APPLE_OAUTH_CLIENT_ID="${{ secrets.APPLE_OAUTH_CLIENT_ID }}"' >> .env.production
+          echo 'APPLE_OAUTH_REDIRECT_URL="${{ secrets.APPLE_OAUTH_REDIRECT_URL }}"' >> .env.production
+          echo 'CUBESIGNER_ENV="${{ secrets.CUBESIGNER_ENV }}"' >> .env.production
+          echo 'SEEDLESS_FIDO_IDENTITY_URL="${{ secrets.SEEDLESS_FIDO_IDENTITY_URL }}"' >> .env.production
+          echo 'NEWSLETTER_BASE_URL="${{ secrets.NEWSLETTER_BASE_URL }}"' >> .env.production
+          echo 'NEWSLETTER_PORTAL_ID="${{ secrets.NEWSLETTER_PORTAL_ID }}"' >> .env.production
+          echo 'NEWSLETTER_FORM_ID="${{ secrets.NEWSLETTER_FORM_ID }}"' >> .env.production
+          echo 'FIREBASE_CONFIG="${{ secrets.FIREBASE_CONFIG }}"' >> .env.production
+          echo 'ID_SERVICE_URL="${{ secrets.ID_SERVICE_URL }}"' >> .env.production
+          echo 'GASLESS_SERVICE_URL="${{ secrets.GASLESS_SERVICE_URL }}"' >> .env.production
+          echo 'NOTIFICATION_SENDER_SERVICE_URL="${{ secrets.NOTIFICATION_SENDER_SERVICE_URL }}"' >> .env.production
       - name: Install dependencies
         run: |
           yarn install

--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -36,71 +36,67 @@ jobs:
 
           echo RELEASE=alpha >> .env.production
 
-          echo POSTHOG_KEY=${{ secrets.POSTHOG_KEY }} >> .env.production
+          echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> .env.production
 
-          echo POSTHOG_URL=${{ secrets.POSTHOG_URL }} >> .env.production
+          echo 'POSTHOG_URL="${{ secrets.POSTHOG_URL }}"' >> .env.production
 
-          echo ANALYTICS_ENCRYPTION_KEY=${{ secrets.ANALYTICS_ENCRYPTION_KEY }}
+          echo 'ANALYTICS_ENCRYPTION_KEY="${{ secrets.ANALYTICS_ENCRYPTION_KEY }}"'
           >> .env.production
 
-          echo ANALYTICS_ENCRYPTION_KEY_ID=${{
-          secrets.ANALYTICS_ENCRYPTION_KEY_ID }} >> .env.production
+          echo 'ANALYTICS_ENCRYPTION_KEY_ID="${{ secrets.ANALYTICS_ENCRYPTION_KEY_ID }}"' >> .env.production
 
-          echo COVALENT_API_KEY=${{ secrets.COVALENT_API_KEY }} >>
+          echo 'COVALENT_API_KEY="${{ secrets.COVALENT_API_KEY }}"' >>
           .env.production
 
-          echo GLACIER_URL=${{ secrets.GLACIER_URL }} >> .env.production
+          echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
 
-          echo PROXY_URL=${{ secrets.PROXY_URL }} >> .env.production
+          echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
 
-          echo CORE_EXTENSION_LANDING_URL=${{ secrets.CORE_EXTENSION_LANDING_URL
-          }} >> .env.production
+          echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
 
-          echo SENTRY_DSN=${{ secrets.SENTRY_DSN }} >> .env.production
+          echo 'SENTRY_DSN="${{ secrets.SENTRY_DSN }}"' >> .env.production
 
-          echo CORE_WEB_BASE_URL=${{ secrets.CORE_WEB_BASE_URL }} >>
+          echo 'CORE_WEB_BASE_URL="${{ secrets.CORE_WEB_BASE_URL }}"' >>
           .env.production
 
-          echo GLACIER_API_KEY=${{ secrets.GLACIER_API_KEY }} >> .env.production
+          echo 'GLACIER_API_KEY="${{ secrets.GLACIER_API_KEY }}"' >> .env.production
 
-          echo WALLET_CONNECT_PROJECT_ID=${{ secrets.WALLET_CONNECT_PROJECT_ID
-          }} >> .env.production
+          echo 'WALLET_CONNECT_PROJECT_ID="${{ secrets.WALLET_CONNECT_PROJECT_ID }}"' >> .env.production
 
-          echo SEEDLESS_URL=${{ secrets.SEEDLESS_URL }} >> .env.production
+          echo 'SEEDLESS_URL="${{ secrets.SEEDLESS_URL }}"' >> .env.production
 
-          echo SEEDLESS_ORG_ID=${{ secrets.SEEDLESS_ORG_ID }} >> .env.production
+          echo 'SEEDLESS_ORG_ID="${{ secrets.SEEDLESS_ORG_ID }}"' >> .env.production
 
-          echo GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }} >>
+          echo 'GOOGLE_OAUTH_CLIENT_ID="${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}"' >>
           .env.production
 
-          echo APPLE_OAUTH_CLIENT_ID=${{ secrets.APPLE_OAUTH_CLIENT_ID }} >>
+          echo 'APPLE_OAUTH_CLIENT_ID="${{ secrets.APPLE_OAUTH_CLIENT_ID }}"' >>
           .env.production
 
-          echo APPLE_OAUTH_REDIRECT_URL=${{ secrets.APPLE_OAUTH_REDIRECT_URL }}
+          echo 'APPLE_OAUTH_REDIRECT_URL="${{ secrets.APPLE_OAUTH_REDIRECT_URL }}"'
           >> .env.production
 
-          echo CUBESIGNER_ENV=${{ secrets.CUBESIGNER_ENV }} >> .env.production
+          echo 'CUBESIGNER_ENV="${{ secrets.CUBESIGNER_ENV }}"' >> .env.production
 
-          echo SEEDLESS_FIDO_IDENTITY_URL=${{ secrets.SEEDLESS_FIDO_IDENTITY_URL
-          }} >> .env.production
+          echo 'SEEDLESS_FIDO_IDENTITY_URL="${{ secrets.SEEDLESS_FIDO_IDENTITY_URL }}"' >> .env.production
 
-          echo NEWSLETTER_BASE_URL=${{ secrets.NEWSLETTER_BASE_URL }} >>
+          echo 'NEWSLETTER_BASE_URL="${{ secrets.NEWSLETTER_BASE_URL }}"' >>
           .env.production
 
-          echo NEWSLETTER_PORTAL_ID=${{ secrets.NEWSLETTER_PORTAL_ID }} >>
+          echo 'NEWSLETTER_PORTAL_ID="${{ secrets.NEWSLETTER_PORTAL_ID }}"' >>
           .env.production
 
-          echo NEWSLETTER_FORM_ID=${{ secrets.NEWSLETTER_FORM_ID }} >>
+          echo 'NEWSLETTER_FORM_ID="${{ secrets.NEWSLETTER_FORM_ID }}"' >>
           .env.production
 
-          echo FIREBASE_CONFIG=${{ secrets.FIREBASE_CONFIG }} >> .env.production
+          echo 'FIREBASE_CONFIG="${{ secrets.FIREBASE_CONFIG }}"' >> .env.production
 
-          echo ID_SERVICE_URL=${{ secrets.ID_SERVICE_URL }} >> .env.production
+          echo 'ID_SERVICE_URL="${{ secrets.ID_SERVICE_URL }}"' >> .env.production
 
-          echo GASLESS_SERVICE_URL=${{ secrets.GASLESS_SERVICE_URL }} >>
+          echo 'GASLESS_SERVICE_URL="${{ secrets.GASLESS_SERVICE_URL }}"' >>
           .env.production
 
-          echo NOTIFICATION_SENDER_SERVICE_URL=${{ secrets.NOTIFICATION_SENDER_SERVICE_URL }} >> .env.production
+          echo 'NOTIFICATION_SENDER_SERVICE_URL="${{ secrets.NOTIFICATION_SENDER_SERVICE_URL }}"' >> .env.production
       - name: Install dependencies
         run: |
           yarn install

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -24,31 +24,31 @@ jobs:
         run: |
           touch .env.production
           echo RELEASE=alpha >> .env.production
-          echo POSTHOG_KEY=${{ secrets.POSTHOG_KEY }} >> .env.production
-          echo POSTHOG_URL=${{ secrets.POSTHOG_URL }} >> .env.production
-          echo ANALYTICS_ENCRYPTION_KEY=${{ secrets.ANALYTICS_ENCRYPTION_KEY }} >> .env.production
-          echo ANALYTICS_ENCRYPTION_KEY_ID=${{ secrets.ANALYTICS_ENCRYPTION_KEY_ID }} >> .env.production
-          echo COVALENT_API_KEY=${{ secrets.COVALENT_API_KEY }} >> .env.production
-          echo GLACIER_URL=${{ secrets.GLACIER_URL }} >> .env.production
-          echo PROXY_URL=${{ secrets.PROXY_URL }} >> .env.production
-          echo CORE_EXTENSION_LANDING_URL=${{ secrets.CORE_EXTENSION_LANDING_URL }} >> .env.production
-          echo SENTRY_DSN=${{ secrets.SENTRY_DSN }} >> .env.production
-          echo CORE_WEB_BASE_URL=${{ secrets.CORE_WEB_BASE_URL }} >> .env.production
-          echo WALLET_CONNECT_PROJECT_ID=${{ secrets.WALLET_CONNECT_PROJECT_ID }} >> .env.production
-          echo SEEDLESS_URL=${{ secrets.SEEDLESS_URL }} >> .env.production
-          echo SEEDLESS_ORG_ID=${{ secrets.SEEDLESS_ORG_ID }} >> .env.production
-          echo GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }} >> .env.production
-          echo APPLE_OAUTH_CLIENT_ID=${{ secrets.APPLE_OAUTH_CLIENT_ID }} >> .env.production
-          echo APPLE_OAUTH_REDIRECT_URL=${{ secrets.APPLE_OAUTH_REDIRECT_URL }} >> .env.production
-          echo CUBESIGNER_ENV=${{ secrets.CUBESIGNER_ENV }} >> .env.production
-          echo SEEDLESS_FIDO_IDENTITY_URL=${{ secrets.SEEDLESS_FIDO_IDENTITY_URL }} >> .env.production
-          echo NEWSLETTER_BASE_URL=${{ secrets.NEWSLETTER_BASE_URL }} >> .env.production
-          echo NEWSLETTER_PORTAL_ID=${{ secrets.NEWSLETTER_PORTAL_ID }} >> .env.production
-          echo NEWSLETTER_FORM_ID=${{ secrets.NEWSLETTER_FORM_ID }} >> .env.production
-          echo FIREBASE_CONFIG=${{ secrets.FIREBASE_CONFIG }} >> .env.production
-          echo ID_SERVICE_URL=${{ secrets.ID_SERVICE_URL }} >> .env.production
-          echo GASLESS_SERVICE_URL=${{ secrets.GASLESS_SERVICE_URL }} >> .env.production
-          echo NOTIFICATION_SENDER_SERVICE_URL=${{ secrets.NOTIFICATION_SENDER_SERVICE_URL }} >> .env.production
+          echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> .env.production
+          echo 'POSTHOG_URL="${{ secrets.POSTHOG_URL }}"' >> .env.production
+          echo 'ANALYTICS_ENCRYPTION_KEY="${{ secrets.ANALYTICS_ENCRYPTION_KEY }}"' >> .env.production
+          echo 'ANALYTICS_ENCRYPTION_KEY_ID="${{ secrets.ANALYTICS_ENCRYPTION_KEY_ID }}"' >> .env.production
+          echo 'COVALENT_API_KEY="${{ secrets.COVALENT_API_KEY }}"' >> .env.production
+          echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
+          echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
+          echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
+          echo 'SENTRY_DSN="${{ secrets.SENTRY_DSN }}"' >> .env.production
+          echo 'CORE_WEB_BASE_URL="${{ secrets.CORE_WEB_BASE_URL }}"' >> .env.production
+          echo 'WALLET_CONNECT_PROJECT_ID="${{ secrets.WALLET_CONNECT_PROJECT_ID }}"' >> .env.production
+          echo 'SEEDLESS_URL="${{ secrets.SEEDLESS_URL }}"' >> .env.production
+          echo 'SEEDLESS_ORG_ID="${{ secrets.SEEDLESS_ORG_ID }}"' >> .env.production
+          echo 'GOOGLE_OAUTH_CLIENT_ID="${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}"' >> .env.production
+          echo 'APPLE_OAUTH_CLIENT_ID="${{ secrets.APPLE_OAUTH_CLIENT_ID }}"' >> .env.production
+          echo 'APPLE_OAUTH_REDIRECT_URL="${{ secrets.APPLE_OAUTH_REDIRECT_URL }}"' >> .env.production
+          echo 'CUBESIGNER_ENV="${{ secrets.CUBESIGNER_ENV }}"' >> .env.production
+          echo 'SEEDLESS_FIDO_IDENTITY_URL="${{ secrets.SEEDLESS_FIDO_IDENTITY_URL }}"' >> .env.production
+          echo 'NEWSLETTER_BASE_URL="${{ secrets.NEWSLETTER_BASE_URL }}"' >> .env.production
+          echo 'NEWSLETTER_PORTAL_ID="${{ secrets.NEWSLETTER_PORTAL_ID }}"' >> .env.production
+          echo 'NEWSLETTER_FORM_ID="${{ secrets.NEWSLETTER_FORM_ID }}"' >> .env.production
+          echo 'FIREBASE_CONFIG="${{ secrets.FIREBASE_CONFIG }}"' >> .env.production
+          echo 'ID_SERVICE_URL="${{ secrets.ID_SERVICE_URL }}"' >> .env.production
+          echo 'GASLESS_SERVICE_URL="${{ secrets.GASLESS_SERVICE_URL }}"' >> .env.production
+          echo 'NOTIFICATION_SENDER_SERVICE_URL="${{ secrets.NOTIFICATION_SENDER_SERVICE_URL }}"' >> .env.production
       - name: Install dependencies
         run: |
           yarn install

--- a/.github/workflows/pr-checks-nextgen.yml
+++ b/.github/workflows/pr-checks-nextgen.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Create env file
         run: |
           touch .env.production
-          echo POSTHOG_KEY=${{ secrets.POSTHOG_KEY }} >> .env.production
-          echo GLACIER_URL=${{ secrets.GLACIER_URL }} >> .env.production
-          echo PROXY_URL=${{ secrets.PROXY_URL }} >> .env.production
-          echo CORE_EXTENSION_LANDING_URL=${{ secrets.CORE_EXTENSION_LANDING_URL }} >> .env.production
+          echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> .env.production
+          echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
+          echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
+          echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
       - name: Install dependencies
         run: |
           yarn install

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -20,10 +20,10 @@ jobs:
       - name: Create env file
         run: |
           touch .env.production
-          echo POSTHOG_KEY=${{ secrets.POSTHOG_KEY }} >> .env.production
-          echo GLACIER_URL=${{ secrets.GLACIER_URL }} >> .env.production
-          echo PROXY_URL=${{ secrets.PROXY_URL }} >> .env.production
-          echo CORE_EXTENSION_LANDING_URL=${{ secrets.CORE_EXTENSION_LANDING_URL }} >> .env.production
+          echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> .env.production
+          echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
+          echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
+          echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
       - name: Install dependencies
         run: |
           yarn install


### PR DESCRIPTION
## Changes

RSBuild reads the `.env` files a bit different than webpack did, if it encounters a `#` character it stops.

This line:

```bash
echo SEEDLESS_ORG_ID={{ secrets.SEEDLESS_ORG_ID }} >> .env.production
```

results in this line in the file:

```.env
SEEDLESS_ORG_ID=Org#1234
```

RSBuild when parsing the file, stops with the `#` character, whereas webpack would have read the whole line.

Encapsulating the whole `echo` in quotes ensures the lines in the env file looks like this:

```.env
SEEDLESS_ORG_ID="Org#1234"
```

which lets the RSBuild read the proper values.