### PR TITLE
fix: serializer for Uint8Array

### DIFF
--- a/packages/messaging/src/serialization/deserialize.test.ts
+++ b/packages/messaging/src/serialization/deserialize.test.ts
@@ -12,6 +12,7 @@ describe('deserialize', () => {
   const bigString =
     '10000000000000000000000000000000000000000000000000000000000000';
   const buffer = Buffer.from('This is a text');
+  const uint8Array = Uint8Array.from(buffer);
   const serializableValues: [
     value: SerializableValue,
     serializedValue: DeserializableValue,
@@ -20,6 +21,7 @@ describe('deserialize', () => {
     [new BN(bigString), { type: 'BN', value: bigString }],
     [BigInt(bigString), { type: 'BigInt', value: bigString }],
     [buffer, { type: 'Buffer', value: Array.from(buffer) }],
+    [uint8Array, { type: 'Uint8Array', value: Array.from(uint8Array) }],
   ];
 
   // Primitives

--- a/packages/messaging/src/serialization/deserialize.ts
+++ b/packages/messaging/src/serialization/deserialize.ts
@@ -8,7 +8,7 @@ export type DeserializableValue =
       value: string;
     }
   | {
-      type: 'Buffer';
+      type: 'Buffer' | 'Uint8Array';
       value: number[];
     };
 
@@ -47,6 +47,8 @@ function deserializeValue({
       return BigInt(value);
     case 'Buffer':
       return Buffer.from(value);
+    case 'Uint8Array':
+      return Uint8Array.from(value);
     default:
       throw new Error('unhandled serialization');
   }

--- a/packages/messaging/src/serialization/serialize.test.ts
+++ b/packages/messaging/src/serialization/serialize.test.ts
@@ -12,6 +12,7 @@ describe('serialize', () => {
   const bigString =
     '10000000000000000000000000000000000000000000000000000000000000';
   const buffer = Buffer.from('This is a text');
+  const uint8Array = Uint8Array.from(buffer);
   const serializableValues: [
     value: SerializableValue,
     serializedValue: DeserializableValue,
@@ -20,6 +21,7 @@ describe('serialize', () => {
     [new BN(bigString), { type: 'BN', value: bigString }],
     [BigInt(bigString), { type: 'BigInt', value: bigString }],
     [buffer, { type: 'Buffer', value: Array.from(buffer) }],
+    [uint8Array, { type: 'Uint8Array', value: Array.from(uint8Array) }],
   ];
 
   // Primitives

--- a/packages/messaging/src/serialization/serialize.ts
+++ b/packages/messaging/src/serialization/serialize.ts
@@ -2,7 +2,7 @@ import Big from 'big.js';
 import BN from 'bn.js';
 import { DeserializableValue } from './deserialize';
 
-export type SerializableValue = Big | bigint | BN | Buffer;
+export type SerializableValue = Big | bigint | BN | Buffer | Uint8Array;
 
 /**
  * Prepare data for JSON serialization by converting complex numbers like `Big`,
@@ -33,6 +33,8 @@ function serializeValue(value: SerializableValue): DeserializableValue {
     return { type: 'BigInt', value: value.toString() };
   } else if (value instanceof Buffer) {
     return { type: 'Buffer', value: Array.from(value) };
+  } else if (value instanceof Uint8Array) {
+    return { type: 'Uint8Array', value: Array.from(value) };
   } else {
     throw new Error('unhandled serialization');
   }
@@ -43,6 +45,7 @@ function isSerializable(value: unknown): value is SerializableValue {
     value instanceof Big ||
     value instanceof BN ||
     typeof value === 'bigint' ||
-    value instanceof Buffer
+    value instanceof Buffer ||
+    value instanceof Uint8Array
   );
 }


### PR DESCRIPTION
## Description

With the repo restructuring, I was also updating the ts config, which resulted in typescript catching more errors than before (in some places it complained about us passing `Buffer` instead of `Uint8Array`).

So I fixed that and some values previously sent as `Buffer` between UI and the service worker are now sent as `Uint8Array`, but we didn't have a serializer for it.

This PR adds the serializer.

## Testing
1. Use an existing seedless account with a FIDO key configured (Yubikey / Passkey)
2. Attempt to perform any action that requires MFA: change recovery methods or initiate seedphrase export.
3. If you can confirm it with your FIDO key, it works 🎉 

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
