### PR TITLE
fix: chicken-egg problem with WalletProvider

### DIFF
--- a/packages/ui/src/contexts/WalletProvider.tsx
+++ b/packages/ui/src/contexts/WalletProvider.tsx
@@ -51,9 +51,9 @@ type WalletStateAndMethods = {
   renameWallet(id: string, name: string): Promise<any>;
 };
 
-const WalletContext = createContext<WalletStateAndMethods | undefined>(
-  undefined,
-);
+const WalletContext = createContext<WalletStateAndMethods>({
+  wallets: [],
+} as any);
 
 export type WalletContextProviderProps = PropsWithChildren<{
   LockedComponent: React.FC<{
@@ -229,11 +229,5 @@ export function WalletContextProvider({
 }
 
 export function useWalletContext() {
-  const context = useContext(WalletContext);
-  if (!context) {
-    throw new Error(
-      'useWalletContext must be used within a WalletContextProvider',
-    );
-  }
-  return context;
+  return useContext(WalletContext);
 }


### PR DESCRIPTION
## Description

@bartosz-the-coder-at-avalabs had a nice idea on making sure we're using contexts within their respective providers, but it seems it uncovered a scenario where it breaks the legacy app.

I have an idea on how to fix it, but making sure it doesn't break anything else will take me some time, so I'm reverting this small change for now.

## Changes
Revert some changes to `useWalletContext()`

## Testing
* Onboard with Ledger

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
