### PR TITLE
fix: build configs

### DIFF
--- a/apps/legacy/rsbuild.legacy.common.ts
+++ b/apps/legacy/rsbuild.legacy.common.ts
@@ -5,7 +5,7 @@ import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { CopyRspackPlugin } from '@rspack/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-export default defineConfig({
+export default defineConfig(() => ({
   environments: {
     web: {
       html: {
@@ -70,6 +70,12 @@ export default defineConfig({
       joi: path.resolve('../../node_modules/joi/lib/index.js'),
     },
     dedupe: ['bn.js'],
+    fallback: {
+      path: false,
+      fs: false,
+      Buffer: false,
+      process: false,
+    },
   },
   plugins: [
     pluginNodePolyfill(),
@@ -106,4 +112,4 @@ export default defineConfig({
       });
     },
   },
-});
+}));

--- a/apps/next/rsbuild.next.common.ts
+++ b/apps/next/rsbuild.next.common.ts
@@ -5,7 +5,7 @@ import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { CopyRspackPlugin } from '@rspack/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-export default defineConfig({
+export default defineConfig(() => ({
   environments: {
     web: {
       html: {
@@ -72,6 +72,12 @@ export default defineConfig({
       'react-dom': path.resolve('./node_modules/react-dom'),
       path: require.resolve('path-browserify'),
     },
+    fallback: {
+      path: false,
+      fs: false,
+      Buffer: false,
+      process: false,
+    },
   },
   plugins: [
     pluginNodePolyfill(),
@@ -108,4 +114,4 @@ export default defineConfig({
       });
     },
   },
-});
+}));

--- a/packages/content-script/rsbuild.content-script.common.ts
+++ b/packages/content-script/rsbuild.content-script.common.ts
@@ -37,6 +37,12 @@ export default defineConfig(() => {
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.js'],
+      fallback: {
+        path: false,
+        fs: false,
+        Buffer: false,
+        process: false,
+      },
     },
     plugins: [pluginNodePolyfill()],
     tools: {

--- a/packages/inpage/rsbuild.inpage.ts
+++ b/packages/inpage/rsbuild.inpage.ts
@@ -60,6 +60,12 @@ export default defineConfig(({ envMode }) => {
     resolve: {
       extensions: ['.ts', '.tsx', '.js'],
       alias: {},
+      fallback: {
+        path: false,
+        fs: false,
+        Buffer: false,
+        process: false,
+      },
     },
     plugins: [pluginNodePolyfill()],
     tools: {

--- a/packages/offscreen/rsbuild.offscreen.common.ts
+++ b/packages/offscreen/rsbuild.offscreen.common.ts
@@ -41,6 +41,12 @@ export default defineConfig(() => {
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.js'],
+      fallback: {
+        path: false,
+        fs: false,
+        Buffer: false,
+        process: false,
+      },
     },
     plugins: [pluginNodePolyfill()],
     tools: {

--- a/packages/service-worker/rsbuild.worker.common.ts
+++ b/packages/service-worker/rsbuild.worker.common.ts
@@ -50,6 +50,12 @@ export default defineConfig(() => {
         joi: require.resolve('joi/lib/index.js'),
       },
       dedupe: ['bn.js'],
+      fallback: {
+        path: false,
+        fs: false,
+        Buffer: false,
+        process: false,
+      },
     },
     plugins: [
       pluginNodePolyfill(),


### PR DESCRIPTION
## Description

The build process was replacing some APIs (e.g. `Buffer`) causing some serialization issues downstream.
I noticed it after rebasing [the Keystone PR](https://github.com/ava-labs/core-extension/pull/301), but it may have been causing issues in other places too.

The config I'm adding was already present in the legacy app (prior to the huge refactoring in #259), I just forgot to add it in the new build process.

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
