### PR TITLE
fix: remove unused tabs permissions

### DIFF
--- a/apps/next/manifest/manifest.json
+++ b/apps/next/manifest/manifest.json
@@ -41,7 +41,6 @@
     "activeTab",
     "contextMenus",
     "notifications",
-    "tabs",
     "scripting",
     "identity",
     "alarms",


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
<!--- Link and relevant resources e.g JIRA ticket, Figma Designs, PRs -->

## Changes
The `tabs` permission is only needed if we need to `chrome.tabs.query({ ... })` with some specific parameters, like `title` or `url`, which we never do.

## Testing

<!--- Describe in detail how your changes were tested. -->
<!--- Repeatable Steps to derive the desired output -->

## Screenshots:

<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author

Tick each of them when done or if not applicable.
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
