### PR TITLE
fix: display estimated fiat value when bridging

### DIFF
--- a/apps/legacy/src/pages/Bridge/components/BridgeForm.tsx
+++ b/apps/legacy/src/pages/Bridge/components/BridgeForm.tsx
@@ -57,8 +57,6 @@ export type BridgeFormProps = ReturnType<typeof useBridge> & {
   setIsAmountTooLow: Dispatch<SetStateAction<boolean>>;
   networkFee: NetworkFee;
 
-  price?: number;
-
   sourceBalance?: Exclude<TokenWithBalance, NftTokenWithBalance>;
   bridgeError: string;
   setBridgeError: Dispatch<SetStateAction<string>>;
@@ -82,7 +80,6 @@ export const BridgeForm = ({
   sourceBalance,
   targetChain,
   setTargetChain,
-  price,
   estimateGas,
   bridgeError,
   setBridgeError,
@@ -223,14 +220,18 @@ export const BridgeForm = ({
   }, [receiveAmount, asset]);
 
   const formattedReceiveAmountCurrency = useMemo(() => {
-    if (!price || typeof receiveAmount !== 'bigint' || !asset) {
+    if (
+      !sourceBalance?.priceInCurrency ||
+      typeof receiveAmount !== 'bigint' ||
+      !asset
+    ) {
       return '-';
     }
 
     const unit = new TokenUnit(receiveAmount, asset.decimals, asset.symbol);
 
-    return `~${formatCurrency(price * unit.toDisplay({ asNumber: true }))}`;
-  }, [formatCurrency, price, receiveAmount, asset]);
+    return `~${formatCurrency(sourceBalance.priceInCurrency * unit.toDisplay({ asNumber: true }))}`;
+  }, [formatCurrency, sourceBalance?.priceInCurrency, receiveAmount, asset]);
 
   const handleAmountChanged = useCallback(
     (value: { bigint: bigint; amount: string }) => {


### PR DESCRIPTION
## Description
* [CP-10352](https://ava-labs.atlassian.net/browse/CP-10352)

## Changes
We were using `price` prop, which was never passed. We can use `.priceInCurrency` prop of the token instead.

## Testing
Verify you see the estimated fiat value when attempting a bridge transaction.

## Screenshots:
![image](https://github.com/user-attachments/assets/d3aa1c23-ed78-4d43-ae51-0c6d194e69b2)

<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
