### PR TITLE
fix: hide chains not supported by active account

### DIFF
--- a/apps/legacy/src/components/common/header/NetworkSwitcher/NetworkSwitcher.tsx
+++ b/apps/legacy/src/components/common/header/NetworkSwitcher/NetworkSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useNetworkContext } from '@core/ui';
+import { useAccountsContext, useNetworkContext } from '@core/ui';
 import { useRef, useState } from 'react';
 import { ChainId } from '@avalabs/core-chains-sdk';
 import { useHistory } from 'react-router-dom';
@@ -20,6 +20,7 @@ import {
   Box,
 } from '@avalabs/core-k2-components';
 import { useAnalyticsContext } from '@core/ui';
+import { isChainSupportedByAccount } from '@core/common';
 
 const defaultNetworks = [
   ChainId.AVALANCHE_MAINNET_ID,
@@ -40,6 +41,9 @@ const NetworkSelectronMenuItem = styled(MenuItem)`
 `;
 
 export function NetworkSwitcher() {
+  const {
+    accounts: { active },
+  } = useAccountsContext();
   const { network, setNetwork, favoriteNetworks, networks } =
     useNetworkContext();
 
@@ -54,7 +58,7 @@ export function NetworkSwitcher() {
         !defaultNetworks.includes(networkItem.chainId) &&
         networkItem.chainId !== network?.chainId,
     ),
-  ];
+  ].filter((networkItem) => isChainSupportedByAccount(networkItem, active));
 
   const isActiveInList = networkList.find(
     (networkItem) => networkItem?.chainId === network?.chainId,

--- a/apps/legacy/src/localization/locales/en/translation.json
+++ b/apps/legacy/src/localization/locales/en/translation.json
@@ -973,6 +973,7 @@
   "This is taking longer than expected. Please try again later.": "This is taking longer than expected. Please try again later.",
   "This is your secret recovery phrase. Write it down, and store it in a secure location.": "This is your secret recovery phrase. Write it down, and store it in a secure location.",
   "This message contains non-standard elements.": "This message contains non-standard elements.",
+  "This network is not supported by your active account": "This network is not supported by your active account",
   "This network requires additional authentication to be fully functional.": "This network requires additional authentication to be fully functional.",
   "This operation requires {{total}} approvals.": "This operation requires {{total}} approvals.",
   "This password was set when you created the keystore file.": "This password was set when you created the keystore file.",

--- a/apps/legacy/src/pages/Home/components/Portfolio/NetworkWidget/NetworkList.tsx
+++ b/apps/legacy/src/pages/Home/components/Portfolio/NetworkWidget/NetworkList.tsx
@@ -32,7 +32,7 @@ const LogoContainer = styled('div')`
 `;
 
 const NetworkListContainer = styled(Stack)`
-  margin: 16px 0;
+  margin-bottom: 16px;
   flex-wrap: wrap;
 `;
 

--- a/apps/legacy/src/pages/Home/components/Portfolio/NetworkWidget/NetworksWidget.tsx
+++ b/apps/legacy/src/pages/Home/components/Portfolio/NetworkWidget/NetworksWidget.tsx
@@ -1,7 +1,12 @@
 import { Stack } from '@avalabs/core-k2-components';
 
 import { getUnconfirmedBalanceInCurrency } from '@core/types';
-import { useTokensWithBalances } from '@core/ui';
+import {
+  useAccountsContext,
+  useNetworkContext,
+  useTokensWithBalances,
+} from '@core/ui';
+import { isChainSupportedByAccount } from '@core/common';
 
 import { ActiveNetworkWidget } from './ActiveNetworkWidget';
 import { NetworkList } from './NetworkList';
@@ -52,6 +57,10 @@ export const getNetworkTokensPriceChanges = (assetList: TokenWithBalance[]) => {
 
 export function NetworksWidget() {
   const activeNetworkAssetList = useTokensWithBalances();
+  const { network } = useNetworkContext();
+  const {
+    accounts: { active },
+  } = useAccountsContext();
 
   const activeNetworkBalance = getNetworkBalance(activeNetworkAssetList);
   const activeNetworkPriceChanges = getNetworkTokensPriceChanges(
@@ -59,12 +68,14 @@ export function NetworksWidget() {
   );
 
   return (
-    <Stack sx={{ m: 2 }}>
-      <ActiveNetworkWidget
-        assetList={activeNetworkAssetList}
-        activeNetworkBalance={activeNetworkBalance}
-        activeNetworkPriceChanges={activeNetworkPriceChanges}
-      />
+    <Stack sx={{ m: 2, gap: 2 }}>
+      {isChainSupportedByAccount(network, active) && (
+        <ActiveNetworkWidget
+          assetList={activeNetworkAssetList}
+          activeNetworkBalance={activeNetworkBalance}
+          activeNetworkPriceChanges={activeNetworkPriceChanges}
+        />
+      )}
       <NetworkList />
     </Stack>
   );

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -22,6 +22,7 @@ export * from './object';
 export * from './hasAccountBalances';
 export * from './isAddressValid';
 export * from './isContactValid';
+export * from './isChainSupportedByAccount';
 export * from './logging';
 export * from './history';
 export * from './account';

--- a/packages/common/src/utils/isChainSupportedByAccount.ts
+++ b/packages/common/src/utils/isChainSupportedByAccount.ts
@@ -1,0 +1,11 @@
+import { Account, NetworkWithCaipId } from '@core/types';
+import { getAddressForChain } from './getAddressForChain';
+
+export const isChainSupportedByAccount = (
+  network?: NetworkWithCaipId,
+  account?: Account,
+) => {
+  const addressForNetwork = getAddressForChain(network, account);
+
+  return !!addressForNetwork;
+};


### PR DESCRIPTION
* [CP-10732](https://ava-labs.atlassian.net/browse/CP-10732)

## Changes
* Hides the active network widget on the home screen if the active chain is not supported by the current account.
* Hides the networks that are not supported by the active account from the network switcher dropdown (active network always visible).
* Fades the unsupported networks from the network list on the fullscreen network list

## Screenshots:

Uploading Screen Recording 2025-07-03 at 11.24.51.mov…

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
