### PR TITLE
feat(import): import private key

### DIFF
--- a/apps/next/src/pages/AccountManagement/AccountManagement.tsx
+++ b/apps/next/src/pages/AccountManagement/AccountManagement.tsx
@@ -23,6 +23,7 @@ import { QRCode } from './components/QRCode';
 import { RenamePage } from './components/RenamePage';
 import { ShowPrivateKey } from './components/ShowPrivateKey/ShowPrivateKey';
 import { Wallets } from './components/Wallets';
+import { ImportPrivateKey } from './components/ImportPrivateKey/Page';
 
 const dialogSlots: Pick<DialogProps, 'slots' | 'slotProps'> = {
   slots: {
@@ -74,6 +75,10 @@ const AccountManagement: FC = () => {
                     <Route
                       path="/account-management/add-wallet"
                       component={AddOrConnectWallet}
+                    />
+                    <Route
+                      path="/account-management/import-private-key"
+                      component={ImportPrivateKey}
                     />
                     <Route
                       path="/account-management/account"

--- a/apps/next/src/pages/AccountManagement/components/AddOrCreateWallet/AddOrConnectWallet.tsx
+++ b/apps/next/src/pages/AccountManagement/components/AddOrCreateWallet/AddOrConnectWallet.tsx
@@ -9,7 +9,7 @@ import {
 } from '@avalabs/k2-alpine';
 import { AccountType } from '@core/types';
 import { useAccountsContext } from '@core/ui';
-import { FC } from 'react';
+import { FC, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaSquareCaretUp } from 'react-icons/fa6';
 import { MdAdd, MdKey, MdList, MdTopic } from 'react-icons/md';
@@ -22,9 +22,14 @@ const underDevelopmentClick = () => toast.error('Under development');
 export const AddOrConnectWallet: FC = () => {
   const { t } = useTranslation();
   const { addAccount, accounts, selectAccount } = useAccountsContext();
-  const { goBack } = useHistory();
+  const { goBack, push } = useHistory();
 
   const isPrimaryAccount = accounts.active?.type === AccountType.PRIMARY;
+
+  const goToImportPrivateKey = useCallback(() => {
+    // capture('ImportPrivateKey_Clicked');
+    push('/account-management/import-private-key');
+  }, [push]);
 
   return (
     <Stack gap={2} height={1}>
@@ -53,7 +58,7 @@ export const AddOrConnectWallet: FC = () => {
             Icon={MdKey}
             primary={t('Import a private key')}
             secondary={t('Manually enter your private key to import')}
-            onClick={underDevelopmentClick}
+            onClick={goToImportPrivateKey}
           />
           <Divider />
           <AccountListItem

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/Page.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/Page.tsx
@@ -1,0 +1,6 @@
+import { FC } from 'react';
+import { ImportPrivateKeyForm } from './components/ImportPrivateKeyForm';
+
+export const ImportPrivateKey: FC = () => {
+  return <ImportPrivateKeyForm />;
+};

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressList.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressList.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@avalabs/k2-alpine';
+import { Card, Stack } from '@avalabs/k2-alpine';
 import { DerivedAddresses } from '../types';
 import { DerivedAddressListItem, NetworkType } from './DerivedAddressListItem';
 
@@ -12,21 +12,23 @@ export const DerivedAddressList = ({
   isLoading,
 }: DerivedAddressesProps) => {
   return (
-    <Stack>
-      {derivedAddresses && (
-        <>
-          <DerivedAddressListItem
-            networkType={NetworkType.AVALANCHE}
-            address={derivedAddresses.addressC}
-            isLoading={isLoading}
-          />
-          <DerivedAddressListItem
-            networkType={NetworkType.BITCOIN}
-            address={derivedAddresses.addressBTC}
-            isLoading={isLoading}
-          />
-        </>
-      )}
-    </Stack>
+    <Card>
+      <Stack>
+        {derivedAddresses && (
+          <>
+            <DerivedAddressListItem
+              networkType={NetworkType.AVALANCHE}
+              address={derivedAddresses.addressC}
+              isLoading={isLoading}
+            />
+            <DerivedAddressListItem
+              networkType={NetworkType.BITCOIN}
+              address={derivedAddresses.addressBTC}
+              isLoading={isLoading}
+            />
+          </>
+        )}
+      </Stack>
+    </Card>
   );
 };

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressList.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressList.tsx
@@ -1,4 +1,4 @@
-import { Card, Stack } from '@avalabs/k2-alpine';
+import { Card, Divider, Stack } from '@avalabs/k2-alpine';
 import { DerivedAddresses } from '../types';
 import { DerivedAddressListItem, NetworkType } from './DerivedAddressListItem';
 
@@ -21,6 +21,7 @@ export const DerivedAddressList = ({
               address={derivedAddresses.addressC}
               isLoading={isLoading}
             />
+            <Divider sx={{ mx: 2 }} />
             <DerivedAddressListItem
               networkType={NetworkType.BITCOIN}
               address={derivedAddresses.addressBTC}

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressList.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressList.tsx
@@ -1,0 +1,32 @@
+import { Stack } from '@avalabs/k2-alpine';
+import { DerivedAddresses } from '../types';
+import { DerivedAddressListItem, NetworkType } from './DerivedAddressListItem';
+
+type DerivedAddressesProps = {
+  derivedAddresses?: DerivedAddresses;
+  isLoading: boolean;
+};
+
+export const DerivedAddressList = ({
+  derivedAddresses,
+  isLoading,
+}: DerivedAddressesProps) => {
+  return (
+    <Stack>
+      {derivedAddresses && (
+        <>
+          <DerivedAddressListItem
+            networkType={NetworkType.AVALANCHE}
+            address={derivedAddresses.addressC}
+            isLoading={isLoading}
+          />
+          <DerivedAddressListItem
+            networkType={NetworkType.BITCOIN}
+            address={derivedAddresses.addressBTC}
+            isLoading={isLoading}
+          />
+        </>
+      )}
+    </Stack>
+  );
+};

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressListItem.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressListItem.tsx
@@ -6,6 +6,7 @@ import {
   Typography,
   useTheme,
 } from '@avalabs/core-k2-components';
+import { truncateAddress } from '@avalabs/k2-alpine';
 
 export enum NetworkType {
   AVALANCHE = 'avalanche',
@@ -52,8 +53,15 @@ export function DerivedAddressListItem({
           alignItems: 'center',
         }}
       >
+        <Typography
+          variant="body2"
+          sx={{ wordBreak: 'break-all', fontFamily: 'DejaVu Sans Mono' }}
+        >
+          {truncateAddress(address, 10)}
+        </Typography>
         <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
-          {address}
+          {/* TODO: Add balance and fix color */}
+          {'$123.45'}
         </Typography>
         {isLoading && <CircularProgress size={16} />}
       </Stack>

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressListItem.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressListItem.tsx
@@ -57,11 +57,7 @@ export function DerivedAddressListItem({
           variant="body2"
           sx={{ wordBreak: 'break-all', fontFamily: 'DejaVu Sans Mono' }}
         >
-          {truncateAddress(address, 10)}
-        </Typography>
-        <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
-          {/* TODO: Add balance and fix color */}
-          {'$123.45'}
+          {truncateAddress(address, 17)}
         </Typography>
         {isLoading && <CircularProgress size={16} />}
       </Stack>

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressListItem.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DerivedAddressListItem.tsx
@@ -1,0 +1,62 @@
+import {
+  AvalancheColorIcon,
+  BitcoinColorIcon,
+  CircularProgress,
+  Stack,
+  Typography,
+  useTheme,
+} from '@avalabs/core-k2-components';
+
+export enum NetworkType {
+  AVALANCHE = 'avalanche',
+  BITCOIN = 'bitcoin',
+}
+
+type DerivedAddressProps = {
+  networkType: NetworkType;
+  address: string;
+  isLoading: boolean;
+};
+
+export function DerivedAddressListItem({
+  networkType,
+  address,
+  isLoading,
+}: DerivedAddressProps) {
+  const theme = useTheme();
+  const iconStyles = { filter: address ? 'none' : 'grayscale(1)' };
+
+  return (
+    <Stack
+      direction="row"
+      sx={{
+        gap: 1,
+        py: 1,
+        px: 2,
+        alignItems: 'center',
+        background: theme.palette.grey[850],
+        borderRadius: 1,
+        height: 56,
+      }}
+    >
+      {networkType === NetworkType.AVALANCHE ? (
+        <AvalancheColorIcon size={18} sx={iconStyles} />
+      ) : (
+        <BitcoinColorIcon size={18} sx={iconStyles} />
+      )}
+      <Stack
+        direction="row"
+        sx={{
+          flex: 1,
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+          {address}
+        </Typography>
+        {isLoading && <CircularProgress size={16} />}
+      </Stack>
+    </Stack>
+  );
+}

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DuplicatedAccountConfirmation.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/DuplicatedAccountConfirmation.tsx
@@ -1,0 +1,36 @@
+import { Button, Stack, Typography } from '@avalabs/k2-alpine';
+import { useTranslation } from 'react-i18next';
+
+type DuplicatedAccountConfirmationProps = {
+  onImportDuplicate: () => void;
+  onCancel: () => void;
+};
+
+export const DuplicatedAccountConfirmation = ({
+  onImportDuplicate,
+  onCancel,
+}: DuplicatedAccountConfirmationProps) => {
+  const { t } = useTranslation();
+  return (
+    <Stack sx={{ height: '100%', mt: '23px' }}>
+      <Typography variant="h2" sx={{ textWrap: 'balance' }}>
+        {t('This account has already been imported')}
+      </Typography>
+
+      <Stack sx={{ rowGap: '10px', mt: 'auto' }}>
+        <Button
+          onClick={onImportDuplicate}
+          sx={{ backgroundColor: 'text.primary', color: 'background.default' }}
+        >
+          {t('Import duplicate')}
+        </Button>
+        <Button
+          onClick={onCancel}
+          sx={{ backgroundColor: 'glass.light2', color: 'text.primary' }}
+        >
+          {t('cancel')}
+        </Button>
+      </Stack>
+    </Stack>
+  );
+};

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/ImportPrivateKeyForm.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/ImportPrivateKeyForm.tsx
@@ -171,10 +171,15 @@ export const ImportPrivateKeyForm = () => {
 
       <Stack sx={{ rowGap: 2 }}>
         <TextField
+          variant="filled"
           onChange={keyInputHandler}
           type={showPassword ? 'text' : 'password'}
           slotProps={{
             input: {
+              disableUnderline: true,
+              sx: {
+                borderRadius: 2,
+              },
               endAdornment: (
                 <InputAdornment position="end">
                   <IconButton
@@ -227,7 +232,11 @@ export const ImportPrivateKeyForm = () => {
       <Button
         disabled={!readyToImport}
         onClick={handleImport}
-        sx={{ marginTop: 'auto' }}
+        sx={{
+          marginTop: 'auto',
+          backgroundColor: 'primary.main',
+          color: 'background.default',
+        }}
       >
         {t('Import')}
       </Button>

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/ImportPrivateKeyForm.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/ImportPrivateKeyForm.tsx
@@ -1,0 +1,143 @@
+import { utils } from '@avalabs/avalanchejs';
+import {
+  getBtcAddressFromPubKey,
+  getEvmAddressFromPubKey,
+  getPublicKeyFromPrivateKey,
+} from '@avalabs/core-wallets-sdk';
+import {
+  Button,
+  Stack,
+  TextField,
+  toast,
+  Typography,
+} from '@avalabs/k2-alpine';
+import { useAccountsContext } from '@core/ui/src/contexts/AccountsProvider';
+import { useNetworkContext } from '@core/ui/src/contexts/NetworkProvider';
+import { ChangeEvent, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { networks } from 'bitcoinjs-lib';
+import { useImportPrivateKey } from '../hooks/useImportPrivateKey';
+import { useHistory } from 'react-router-dom';
+
+type DerivedAddresses = {
+  addressC: string;
+  addressBTC: string;
+};
+export const ImportPrivateKeyForm = () => {
+  const { t } = useTranslation();
+  const { allAccounts, selectAccount } = useAccountsContext();
+  const [isKnownAccount, setIsKnownAccount] = useState(false);
+  const { network } = useNetworkContext();
+  const { replace } = useHistory();
+
+  const [privateKey, setPrivateKey] = useState('');
+  const [derivedAddresses, setDerivedAddresses] = useState<DerivedAddresses>();
+
+  const [error, setError] = useState('');
+  const [isDuplicatedAccountDialogOpen, setIsDuplicatedAccountDialogOpen] =
+    useState(false);
+
+  const { isImporting: isImportLoading, importPrivateKey } =
+    useImportPrivateKey();
+
+  const checkIfAccountExists = useCallback(
+    (address) => {
+      const findAccount = allAccounts.find(
+        ({ addressC }) => addressC.toLowerCase() === address.toLowerCase(),
+      );
+      if (findAccount) {
+        setIsKnownAccount(true);
+      }
+    },
+    [allAccounts],
+  );
+
+  const errorHandler = useCallback((errorMessage: string) => {
+    setDerivedAddresses(undefined);
+    setError(errorMessage);
+  }, []);
+
+  const validate = useCallback(
+    (key: string) => {
+      const validationError = t('Invalid key. Please re-enter the key.');
+      const strippedPk = utils.strip0x(key);
+
+      if (strippedPk.length === 64) {
+        try {
+          const publicKey = getPublicKeyFromPrivateKey(strippedPk);
+
+          const addressC = getEvmAddressFromPubKey(publicKey);
+          checkIfAccountExists(addressC);
+
+          const addressBTC = getBtcAddressFromPubKey(
+            publicKey,
+            network?.isTestnet ? networks.testnet : networks.bitcoin,
+          );
+
+          setDerivedAddresses({
+            addressC,
+            addressBTC,
+          });
+          setPrivateKey(key);
+          setError('');
+        } catch (_err) {
+          errorHandler(validationError);
+        }
+      } else {
+        errorHandler(validationError);
+      }
+    },
+    [checkIfAccountExists, errorHandler, network?.isTestnet, t],
+  );
+
+  const keyInputHandler = useCallback(
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const newKey = event.target.value;
+      if (newKey) {
+        validate(newKey);
+      } else {
+        errorHandler(t('Please enter the private key.'));
+      }
+    },
+    [errorHandler, t, validate],
+  );
+
+  const readyToImport = useMemo(() => {
+    console.log({
+      derivedAddresses,
+      error,
+      isKnownAccount,
+    });
+    return derivedAddresses && !error && !isImportLoading;
+  }, [derivedAddresses, error, isImportLoading, isKnownAccount]);
+
+  const handleImport = async () => {
+    // capture('ImportPrivateKeyClicked');
+    if (isKnownAccount && !isDuplicatedAccountDialogOpen) {
+      setIsDuplicatedAccountDialogOpen(true);
+      return;
+    }
+    try {
+      const importedAccountId = await importPrivateKey(privateKey);
+      await selectAccount(importedAccountId);
+      toast.success(t('Private Key Imported'), { duration: 1000 });
+      // capture('ImportPrivateKeySucceeded');
+      replace(`/account-management`); //TODO: change the path
+    } catch (err) {
+      toast.error(t('Private Key Import Failed'), { duration: 1000 });
+      console.error(err);
+    }
+  };
+
+  return (
+    <Stack>
+      <Typography variant="h2">{t('Import private key')}</Typography>
+
+      <TextField onChange={keyInputHandler} />
+      {error && <Typography color="error">{error}</Typography>}
+      <Button disabled={!readyToImport} onClick={handleImport}>
+        {t('Import')}
+      </Button>
+    </Stack>
+  );
+};

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/ImportPrivateKeyForm.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/ImportPrivateKeyForm.tsx
@@ -107,7 +107,6 @@ export const ImportPrivateKeyForm = () => {
             addressC,
             addressBTC,
           });
-          setPrivateKey(key);
           setError('');
         } catch (_err) {
           errorHandler(validationError);
@@ -122,6 +121,8 @@ export const ImportPrivateKeyForm = () => {
   const keyInputHandler = useCallback(
     (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const newKey = event.target.value;
+      setPrivateKey(newKey);
+
       if (newKey) {
         validate(newKey);
       } else {
@@ -258,11 +259,8 @@ export const ImportPrivateKeyForm = () => {
                       direction="row"
                       sx={{ justifyContent: 'space-between' }}
                     >
-                      <Typography
-                        variant="body2"
-                        sx={{ fontWeight: 'fontWeightSemibold' }}
-                      >
-                        {t('Total Balance')}
+                      <Typography sx={{ fontWeight: 'fontWeightMedium' }}>
+                        {t('Total balance')}
                       </Typography>
                       <Typography variant="body2">
                         {isBalanceLoading ? (
@@ -288,7 +286,7 @@ export const ImportPrivateKeyForm = () => {
               color: 'background.default',
             }}
           >
-            {t('Next')}
+            {t('Import')}
           </Button>
         </>
       )}

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/ImportPrivateKeyForm.tsx
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/components/ImportPrivateKeyForm.tsx
@@ -6,7 +6,10 @@ import {
 } from '@avalabs/core-wallets-sdk';
 import {
   Button,
+  Card,
   CircularProgress,
+  IconButton,
+  InputAdornment,
   Stack,
   TextField,
   toast,
@@ -24,20 +27,22 @@ import { DerivedAddressList } from './DerivedAddressList';
 import { useBalanceTotalInCurrency } from '@core/ui/src/hooks/useBalanceTotalInCurrency';
 import { Account } from '@core/types';
 import { useBalancesContext, useSettingsContext } from '@core/ui';
+import { EyeIcon, EyeOffIcon } from '@avalabs/core-k2-components';
 
 export const ImportPrivateKeyForm = () => {
   const { t } = useTranslation();
+  const { replace } = useHistory();
+
   const { allAccounts, selectAccount } = useAccountsContext();
   const { network } = useNetworkContext();
   const { updateBalanceOnNetworks } = useBalancesContext();
   const { currency, currencyFormatter } = useSettingsContext();
 
-  const { replace } = useHistory();
-
   const [isKnownAccount, setIsKnownAccount] = useState(false);
   const [privateKey, setPrivateKey] = useState('');
   const [derivedAddresses, setDerivedAddresses] = useState<DerivedAddresses>();
   const [isBalanceLoading, setIsBalanceLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   const balance = useBalanceTotalInCurrency(derivedAddresses as Account);
 
@@ -146,35 +151,84 @@ export const ImportPrivateKeyForm = () => {
     }
   };
 
+  const handleClickShowPassword = () => setShowPassword(!showPassword);
+  const handleMouseDownPassword = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.preventDefault();
+  };
+  const handleMouseUpPassword = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.preventDefault();
+  };
+
   return (
-    <Stack>
-      <Typography variant="h2">{t('Import private key')}</Typography>
+    <Stack sx={{ height: '100%' }}>
+      <Typography variant="h2" sx={{ mt: '23px', mb: 6 }}>
+        {t('Import private key')}
+      </Typography>
 
-      <TextField onChange={keyInputHandler} />
-      {error && <Typography color="error">{error}</Typography>}
-      <DerivedAddressList
-        derivedAddresses={derivedAddresses}
-        isLoading={isImportLoading}
-      />
+      <Stack sx={{ rowGap: 2 }}>
+        <TextField
+          onChange={keyInputHandler}
+          type={showPassword ? 'text' : 'password'}
+          slotProps={{
+            input: {
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label={
+                      showPassword
+                        ? 'hide the password'
+                        : 'display the password'
+                    }
+                    onClick={handleClickShowPassword}
+                    onMouseDown={handleMouseDownPassword}
+                    onMouseUp={handleMouseUpPassword}
+                    edge="end"
+                  >
+                    {showPassword ? <EyeIcon /> : <EyeOffIcon />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            },
+          }}
+          label={t('Enter private key')}
+        />
+        {error && <Typography color="error">{error}</Typography>}
+        <DerivedAddressList
+          derivedAddresses={derivedAddresses}
+          isLoading={isImportLoading}
+        />
 
-      {derivedAddresses && (
-        <Stack direction="row" sx={{ justifyContent: 'space-between' }}>
-          <Typography variant="body2" sx={{ fontWeight: 'fontWeightSemibold' }}>
-            {t('Total Balance')}
-          </Typography>
-          <Typography variant="body2">
-            {isBalanceLoading ? (
-              <CircularProgress size={16} />
-            ) : balance !== null && balance?.sum ? (
-              currencyFormatter(balance?.sum).replace(currency, '')
-            ) : (
-              '-'
-            )}
-          </Typography>
-        </Stack>
-      )}
-
-      <Button disabled={!readyToImport} onClick={handleImport}>
+        {derivedAddresses && (
+          <Card sx={{ p: 2 }}>
+            <Stack direction="row" sx={{ justifyContent: 'space-between' }}>
+              <Typography
+                variant="body2"
+                sx={{ fontWeight: 'fontWeightSemibold' }}
+              >
+                {t('Total Balance')}
+              </Typography>
+              <Typography variant="body2">
+                {isBalanceLoading ? (
+                  <CircularProgress size={16} />
+                ) : balance !== null && balance?.sum ? (
+                  currencyFormatter(balance?.sum).replace(currency, '')
+                ) : (
+                  '-'
+                )}
+              </Typography>
+            </Stack>
+          </Card>
+        )}
+      </Stack>
+      <Button
+        disabled={!readyToImport}
+        onClick={handleImport}
+        sx={{ marginTop: 'auto' }}
+      >
         {t('Import')}
       </Button>
     </Stack>

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/hooks/useImportPrivateKey.ts
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/hooks/useImportPrivateKey.ts
@@ -1,0 +1,40 @@
+import { utils } from '@avalabs/avalanchejs';
+import { Monitoring } from '@core/common';
+import { ImportType } from '@core/types';
+import { useAccountsContext } from '@core/ui';
+import { useCallback, useState } from 'react';
+
+export const useImportPrivateKey = () => {
+  const [isImporting, setIsImporting] = useState(false);
+
+  const { addAccount } = useAccountsContext();
+
+  const importPrivateKey = useCallback(
+    async (privateKey: string) => {
+      setIsImporting(true);
+
+      try {
+        const accountId = await addAccount('', {
+          importType: ImportType.PRIVATE_KEY,
+          data: utils.strip0x(privateKey),
+        });
+
+        return accountId;
+      } catch (err) {
+        Monitoring.sentryCaptureException(
+          err as Error,
+          Monitoring.SentryExceptionTypes.WALLET_IMPORT,
+        );
+        throw err;
+      } finally {
+        setIsImporting(false);
+      }
+    },
+    [addAccount],
+  );
+
+  return {
+    isImporting,
+    importPrivateKey,
+  };
+};

--- a/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/types.ts
+++ b/apps/next/src/pages/AccountManagement/components/ImportPrivateKey/types.ts
@@ -1,0 +1,4 @@
+export type DerivedAddresses = {
+  addressC: string;
+  addressBTC: string;
+};


### PR DESCRIPTION
## Description
Ticket: https://ava-labs.atlassian.net/browse/CP-11428

## Changes

1. Making the link button to import private key now takes the user to the importing screen
2. the users are able to import private keys
3. If the account with the same address exist, we show duplicated account importing confrmation screen

## Testing
Please try to add accounts using the private key

## Screenshots:

https://github.com/user-attachments/assets/50c952a5-ad36-4926-87ff-81e6efc03fd1


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [X] I've tested the changes myself before sending it to code review and QA.
