### PR TITLE
[Legacy] Fix missing Solana keys for mnemonic wallets

### DIFF
--- a/packages/common/src/monitoring/sentryCaptureException.ts
+++ b/packages/common/src/monitoring/sentryCaptureException.ts
@@ -41,6 +41,8 @@ export enum SentryExceptionTypes {
   FIREBASE = 'firebase',
 
   NOTIFICATIONS = 'notifications',
+
+  ACCOUNTS = 'accounts',
 }
 
 // wrapper to make error reporting contexts unfirom accross the codebase

--- a/packages/common/src/utils/account.ts
+++ b/packages/common/src/utils/account.ts
@@ -1,6 +1,22 @@
 import { Account } from '@core/types';
 
 export function getAllAddressesForAccount(acc: Partial<Account>) {
+  return getAllAddressesForAccountUnfiltered(acc).filter(
+    (addr): addr is string => typeof addr === 'string',
+  );
+}
+
+export function getAllAddressesForAccounts(accounts: Account[]): string[] {
+  return accounts
+    .flatMap(getAllAddressesForAccount)
+    .filter((v) => typeof v === 'string');
+}
+
+export function isMissingAnyAddress(acc: Partial<Account>) {
+  return getAllAddressesForAccountUnfiltered(acc).some((addr) => !addr);
+}
+
+function getAllAddressesForAccountUnfiltered(acc: Partial<Account>) {
   return [
     acc.addressC,
     acc.addressBTC,
@@ -9,11 +25,5 @@ export function getAllAddressesForAccount(acc: Partial<Account>) {
     acc.addressCoreEth,
     acc.addressHVM,
     acc.addressSVM,
-  ].filter((addr): addr is string => typeof addr === 'string');
-}
-
-export function getAllAddressesForAccounts(accounts: Account[]): string[] {
-  return accounts
-    .flatMap(getAllAddressesForAccount)
-    .filter((v) => typeof v === 'string');
+  ];
 }

--- a/packages/service-worker/src/services/secrets/SecretsService.ts
+++ b/packages/service-worker/src/services/secrets/SecretsService.ts
@@ -818,7 +818,7 @@ export class SecretsService implements OnUnlock {
         newPublicKeys.push(publicKeyAVM);
       }
     } else if (secrets.secretType === SecretType.Mnemonic) {
-      // For mnemonic, we can derive public keys for EVM/Bitcoin, AVM and HVM
+      // For mnemonic, we can derive public keys for EVM/Bitcoin, X/P-Chains, HyperVM and Solana
       if (!hasEVMPublicKey) {
         const publicKeyEVM = await AddressPublicKey.fromSeedphrase(
           secrets.mnemonic,


### PR DESCRIPTION
* [CP-11576](https://ava-labs.atlassian.net/browse/CP-11576)
* ⚠️ Based on #343 

## Description
@rictorlome encountered an issue where some of his accounts did not have a Solana address derived (missing `addressSVM` property)

After some debugging I found the problem -- those accounts must have been created during a time when `solana-support` feature flag has been disabled, which would cause the Solana public key not to be derived upon account creation.

## Changes
With this change, extension will look for missing keys upon unlocking and derive them as needed.
We already have similar mechanisms in place for Seedless and Ledger, because it was natural those would not support Solana out-of-the-box, but the mechanism was missing for the mnemonic wallets.

## Testing
1. Run this snippet to simulate the `solana-support` feature flag being disabled:

    ```js
    await chrome.storage.local.set({ '__feature-flag-overrides__': { data: {  'solana-support': false }} })
    ```

2. Create an account. It should not have the Solana address key set.
3. Run this snippet to simulate the `solana-support` feature flag being toggled back on:

    ```js
    await chrome.storage.local.set({ '__feature-flag-overrides__': { data: {  'solana-support': true }} })
    ```

4. Lock extension
5. Unlock extension.
6. Solana address should now be derived.

## Screenshots:

### Before

https://github.com/user-attachments/assets/6a7b90bc-2c42-4867-b967-c27c3d23cbc9

### After


https://github.com/user-attachments/assets/35ce8482-00de-4916-9da0-26ab13d9c07b



## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
