### PR TITLE
fix: sentry overload

### DIFF
--- a/packages/types/webextension-polyfill.d.ts
+++ b/packages/types/webextension-polyfill.d.ts
@@ -5,6 +5,7 @@ import '@types/webextension-polyfill';
 
 declare module 'webextension-polyfill' {
   const sidePanel: typeof chrome.sidePanel;
+  const offscreen: typeof chrome.offscreen;
 
   namespace Storage {
     interface Static {


### PR DESCRIPTION
## Changes
Bullet-proofs `chrome.offscreen.*` calls.


## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
