### PR TITLE
fix: CP-11625 get the token from the active network

### DIFF
--- a/packages/ui/src/hooks/useTokensWithBalances.ts
+++ b/packages/ui/src/hooks/useTokensWithBalances.ts
@@ -56,10 +56,10 @@ export const useTokensWithBalances = (
   const customTokensWithZeroBalance: {
     [address: string]: TokenWithBalance;
   } = useMemo(() => {
-    if (!network?.chainId) {
+    if (!activeNetwork?.chainId) {
       return {};
     }
-    const customTokensForActiveNetwork = customTokens[network?.chainId];
+    const customTokensForActiveNetwork = customTokens[activeNetwork.chainId];
     if (!customTokensForActiveNetwork) {
       return {};
     }
@@ -77,7 +77,7 @@ export const useTokensWithBalances = (
 
       return acc;
     }, {});
-  }, [customTokens, network?.chainId]);
+  }, [activeNetwork?.chainId, customTokens]);
 
   const visibleTokens = useCallback(
     (tokens: TokenWithBalance[]) => {


### PR DESCRIPTION
## Description

[](https://ava-labs.atlassian.net/browse/CP-11625)

## Changes

We use the right variable now.

## Testing

Go to ethereum -> add the token with this address `0xf94e7d0710709388bCe3161C32B4eEA56d3f91CC` -> try again.
It should appear in the list and you should see an error in the UI immediately and don't let you submit the address to the backend

## Screenshots:

<img width="426" height="626" alt="image" src="https://github.com/user-attachments/assets/5b1017bf-cdca-4695-9ee2-a7e55bb0bf06" />


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
