### PR TITLE
fix: resolve Solana fake chain ids to CAIP-2 ids

### DIFF
--- a/packages/common/src/utils/caipConversion.ts
+++ b/packages/common/src/utils/caipConversion.ts
@@ -127,7 +127,12 @@ export const caipToChainId = (identifier: string): number => {
 };
 
 export const chainIdToCaip = (chainId: number): string => {
-  return BitcoinCaipId[chainId] ?? AvaxCaipId[chainId] ?? `eip155:${chainId}`;
+  return (
+    BitcoinCaipId[chainId] ??
+    AvaxCaipId[chainId] ??
+    SolanaCaipId[chainId] ??
+    `eip155:${chainId}`
+  );
 };
 
 export const decorateWithCaipId = (


### PR DESCRIPTION
## Changes
* We currently map known _fake_ chain IDs (like the ones we have for Bitcoin or X/P chains) to proper CAIP-2 ids (e.g. `eip155:4503599627370475` -> `bip122:000000000019d6689c085ae165831e93`). This was missing for Solana chains.

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
