### PR TITLE
feat: add new core.app domains

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -2,26 +2,26 @@ import { isDevelopment, isProductionBuild } from './utils/environment';
 import browser from 'webextension-polyfill';
 
 const CORE_WEB_DOMAIN = 'core.app' as const;
-const CORE_WEB_TESTNET_DOMAIN = 'test.core.app' as const;
-const CORE_WEB_STAGING_DOMAIN = 'core-web.pages.dev' as const;
+const CORE_WEB_STAGING_DOMAINS = [
+  'staging.core.app',
+  'core-web.pages.dev', // Can be removed once Core Web is moved to CF Workers.
+] as const;
 const DAPP_DEV_DOMAINS = [
   'localhost',
   '127.0.0.1',
-  'redesign-aa3.pages.dev',
+  'develop.core.app',
 ] as const;
 
 const SYNCED_DOMAINS_PRODUCTION_BUILD = [CORE_WEB_DOMAIN] as const;
 const SYNCED_DOMAINS_DEVELOPMENT_BUILD = [
   CORE_WEB_DOMAIN,
-  CORE_WEB_TESTNET_DOMAIN,
-  CORE_WEB_STAGING_DOMAIN,
+  ...CORE_WEB_STAGING_DOMAINS,
   ...DAPP_DEV_DOMAINS,
 ] as const;
 
 export const KNOWN_CORE_DOMAINS = [
   CORE_WEB_DOMAIN,
-  CORE_WEB_TESTNET_DOMAIN,
-  CORE_WEB_STAGING_DOMAIN,
+  ...CORE_WEB_STAGING_DOMAINS,
   ...DAPP_DEV_DOMAINS,
 ] as const;
 

--- a/packages/types/src/ui-connection.ts
+++ b/packages/types/src/ui-connection.ts
@@ -333,11 +333,11 @@ export const CORE_DOMAINS = [
   '127.0.0.1',
   'core-web.pages.dev',
   'core.app',
-  'test.core.app',
+  'staging.core.app',
+  'develop.core.app',
   'ava-labs.github.io', // playground
   'avacloud.io',
   'avacloud-app.pages.dev',
-  'redesign-aa3.pages.dev',
   'launch-4zn.pages.dev',
   'launchpad.avacloud.io ',
 ];


### PR DESCRIPTION
Core Web will be migrating to CF Workers in the near future (from CF Pages).

As part of this, the domains `develop.core.app` and `staging.core.app` have been setup to point to their respective environments (this way `.workers.dev` urls do not have to be used, except for preview deployments).

This PR adds the new domains, and removes no longer used domains (ie `test.core.app` and `redesign-aa3.pages.dev`)