### PR TITLE
feat: CP-11567 set new portfolio url and remove network param

### DIFF
--- a/packages/common/src/utils/getCoreWebUrl.test.ts
+++ b/packages/common/src/utils/getCoreWebUrl.test.ts
@@ -14,14 +14,6 @@ describe('utils/getCoreWebUrl.ts', () => {
     it('returns Core Web URL with address', () => {
       expect(getCoreWebUrl('0x00000')).toBe('https://core.app/account/0x00000');
     });
-    it('returns Core Web URL with address and network', () => {
-      expect(getCoreWebUrl('0x00000', 1)).toBe(
-        'https://core.app/account/0x00000?network=1',
-      );
-    });
-    it('returns base Core Web URL given networkId and no address ', () => {
-      expect(getCoreWebUrl('', 1)).toBe('https://core.app');
-    });
     it('returns base Core Web URL with no address', () => {
       expect(getCoreWebUrl('')).toBe('https://core.app');
     });

--- a/packages/common/src/utils/getCoreWebUrl.test.ts
+++ b/packages/common/src/utils/getCoreWebUrl.test.ts
@@ -12,7 +12,9 @@ describe('utils/getCoreWebUrl.ts', () => {
     });
 
     it('returns Core Web URL with address', () => {
-      expect(getCoreWebUrl('0x00000')).toBe('https://core.app/account/0x00000');
+      expect(getCoreWebUrl('0x00000')).toBe(
+        'https://core.app/portfolio/0x00000',
+      );
     });
     it('returns base Core Web URL with no address', () => {
       expect(getCoreWebUrl('')).toBe('https://core.app');

--- a/packages/common/src/utils/getCoreWebUrl.ts
+++ b/packages/common/src/utils/getCoreWebUrl.ts
@@ -1,11 +1,8 @@
-export const getCoreWebUrl = (address?: string, networkId?: number) => {
+export const getCoreWebUrl = (address?: string) => {
   const baseCoreWebUrl = process.env.CORE_WEB_BASE_URL;
   if (!address) {
     return baseCoreWebUrl;
   }
 
-  if (address && networkId) {
-    return `${baseCoreWebUrl}/account/${address}?network=${networkId}`;
-  }
-  return `${baseCoreWebUrl}/account/${address}`;
+  return `${baseCoreWebUrl}/portfolio/${address}`;
 };


### PR DESCRIPTION
## Description

There is a new URL in Core web, instead of `/address` they use `/portfolio` (it is cheating though they redirect the old `/address` requests to `/portfolio`..)

## Changes

Set the new URL and remove the network GET param which is not used to anything from now.

## Testing

go to settings -> check the Core Web link on the top of the list

## Screenshots:


https://github.com/user-attachments/assets/1645cdef-f14d-41bc-ac5a-b28c1b019200



## Checklist for the author

Tick each of them when done or if not applicable.

- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
