### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -7,7 +7,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup Node.js

--- a/.github/workflows/crowdin_sync.yml
+++ b/.github/workflows/crowdin_sync.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: crowdin action
         uses: crowdin/github-action@1.4.16

--- a/.github/workflows/e2e_testing.yaml
+++ b/.github/workflows/e2e_testing.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           corepack enable
       - name: Checkout extension
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: '${{ github.head_ref }}'
           fetch-depth: 0
@@ -138,7 +138,7 @@ jobs:
           node-version: 20.18.3
           check-latest: true
       - name: Checkout automation repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ava-labs/avalanche-test-automation
           path: ./

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -10,7 +10,7 @@ jobs:
     environment: alpha
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup Node.js

--- a/.github/workflows/pr-checks-nextgen.yml
+++ b/.github/workflows/pr-checks-nextgen.yml
@@ -10,7 +10,7 @@ jobs:
     environment: alpha
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup Node.js

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -7,7 +7,7 @@ jobs:
     environment: alpha
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup Node.js


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0