### PR TITLE
perf: try to lower the confirmation delay for swap

### DIFF
--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -104,3 +104,4 @@ export * from './fetchAndVerify';
 export * from './openFullscreenTab';
 export * from './approveSeedlessRegistration';
 export * from './isChainSupportedByWallet';
+export * from './retry';

--- a/packages/common/src/utils/retry.test.ts
+++ b/packages/common/src/utils/retry.test.ts
@@ -1,0 +1,100 @@
+import { RetryBackoffPolicy } from './retry';
+
+describe('RetryBackoffPolicy', () => {
+  describe('exponential()', () => {
+    it('returns 2^i * 1000 (ms)', () => {
+      const policy = RetryBackoffPolicy.exponential();
+      expect(policy(0)).toBe(1000);
+      expect(policy(1)).toBe(2000);
+      expect(policy(2)).toBe(4000);
+      expect(policy(3)).toBe(8000);
+    });
+  });
+
+  describe('constant()', () => {
+    it('returns secondsToDelay * 1000 (ms) regardless of index', () => {
+      const policy = RetryBackoffPolicy.constant(1); // 1s
+      expect(policy(0)).toBe(1000);
+      expect(policy(3)).toBe(1000);
+      expect(policy(10)).toBe(1000);
+    });
+  });
+
+  describe('constantMs()', () => {
+    it('returns the fixed ms regardless of index', () => {
+      const policy = RetryBackoffPolicy.constantMs(250);
+      expect(policy(0)).toBe(250);
+      expect(policy(5)).toBe(250);
+    });
+  });
+
+  describe('linearThenExponential()', () => {
+    /**
+     * Spec (from JSDoc):
+     * - First `linearCount` retries increase linearly by `linearStepMs`
+     * - After that, the *increment itself* grows exponentially based on `linearStepMs`
+     *   Example for (linearCount=4, linearStepMs=1000):
+     *     1s, 2s, 3s, 4s, 6s, 10s, 18s, 34s...
+     *
+     * Interpretation used in the test:
+     * - Linear phase (i = 0..linearCount-1): delay = (i+1) * step
+     * - Exponential-increment phase (i >= linearCount):
+     *     start from cumulative = linearCount * step,
+     *     start increment = 2 * step (not 1 * step),
+     *     each next step doubles the increment.
+     */
+    it('matches the documented example sequence for (linearCount=4, step=1000)', () => {
+      const linearCount = 4;
+      const step = 1000;
+      const policy = RetryBackoffPolicy.linearThenExponential(
+        linearCount,
+        step,
+      );
+
+      // Expected: 1s, 2s, 3s, 4s, 6s, 10s, 18s, 34s (in ms)
+      const expected = [1000, 2000, 3000, 4000, 6000, 10000, 18000, 34000];
+
+      const actual = expected.map((_, i) => policy(i));
+      expect(actual).toEqual(expected);
+    });
+
+    it('works for different parameters (linearCount=2, step=500)', () => {
+      const linearCount = 2;
+      const step = 500;
+      const policy = RetryBackoffPolicy.linearThenExponential(
+        linearCount,
+        step,
+      );
+
+      // Build expected iteratively using the same interpretation:
+      // i=0..1: 500, 1000
+      // then increments: +1000, +2000, +4000, ...
+      const expected: number[] = [];
+      let cumulative = 0;
+      let inc = 2 * step; // first exponential increment after linear
+
+      for (let i = 0; i < 7; i++) {
+        if (i < linearCount) {
+          expected.push((i + 1) * step);
+        } else {
+          if (i === linearCount) cumulative = linearCount * step;
+          cumulative += inc;
+          expected.push(cumulative);
+          inc *= 2;
+        }
+      }
+
+      const actual = expected.map((_, i) => policy(i));
+      expect(actual).toEqual(expected);
+    });
+
+    it('is strictly increasing (monotonic)', () => {
+      const policy = RetryBackoffPolicy.linearThenExponential(3, 750);
+
+      const seq: number[] = Array.from({ length: 10 }, (_, i) => policy(i));
+      for (let i = 1; i < seq.length; i++) {
+        expect(seq[i]).toBeGreaterThan(seq[i - 1]!);
+      }
+    });
+  });
+});

--- a/packages/common/src/utils/retry.ts
+++ b/packages/common/src/utils/retry.ts
@@ -1,0 +1,123 @@
+/**
+ * This file is a direct copy of the `retry` function from the VM-Modules repository.
+ * Placing it here until we make our app use the ApprovalController.onTransaction[...] methods
+ * instead of waiting for the transaction to be mined in the Core Extension repository.
+ */
+
+const DEFAULT_MAX_RETRIES = 10;
+
+type RetryParams<T> = {
+  operation: (retryIndex: number) => Promise<T>;
+  isSuccess: (result: T) => boolean;
+  maxRetries?: number;
+  backoffPolicy?: RetryBackoffPolicyInterface;
+};
+/*
+ * Retries an operation with defined backoff policy.
+ *
+ * @param operation - The operation to retry.
+ * @param isSuccess - The predicate to check if the operation succeeded.
+ * @param maxRetries - The maximum number of retries.
+ * @param backoffPolicy - Function to generate delay time based on current retry count.
+ *
+ * @returns The result of the operation.
+ * @throws An error if the operation fails after the maximum number of retries.
+ *
+ * @example
+ *   const result = await retry(
+ *     async () => {
+ *       const response = await fetch('https://example.com')
+ *       return response.json()
+ *     },
+ *     result => result.status === 200
+ *   )
+ */
+export const retry = async <T>({
+  operation,
+  isSuccess,
+  maxRetries = DEFAULT_MAX_RETRIES,
+  backoffPolicy = RetryBackoffPolicy.exponential(),
+}: RetryParams<T>): Promise<T> => {
+  let backoffPeriodMillis = 0;
+  let retries = 0;
+  let lastError: unknown;
+
+  while (retries < maxRetries) {
+    if (retries > 0) {
+      await delay(backoffPeriodMillis);
+    }
+
+    try {
+      const result = await operation(retries);
+
+      if (isSuccess(result)) {
+        return result;
+      }
+    } catch (err) {
+      // when the operation throws an error, we still retry
+      lastError = err;
+    }
+
+    backoffPeriodMillis = backoffPolicy(retries);
+    retries++;
+  }
+
+  const errorMessage = lastError
+    ? `Max retry exceeded. ${lastError}`
+    : 'Max retry exceeded.';
+
+  throw new Error(errorMessage);
+};
+
+type RetryBackoffPolicyInterface = (retryIndex: number) => number;
+
+export class RetryBackoffPolicy {
+  static exponential(): RetryBackoffPolicyInterface {
+    return (retryIndex: number): number => {
+      return Math.pow(2, retryIndex) * 1000;
+    };
+  }
+
+  static constant(secondsToDelay: number): RetryBackoffPolicyInterface {
+    return (_: number): number => {
+      return secondsToDelay * 1000;
+    };
+  }
+
+  static constantMs(msToDelay: number): RetryBackoffPolicyInterface {
+    return (_: number): number => {
+      return msToDelay;
+    };
+  }
+
+  /**
+   * linearThenExponential backoff:
+   * - First `linearCount` retries: linear increase by `linearStepMs`
+   * - After that: increment grows exponentially based on `linearStepMs`
+   *   Example (linearCount=4, linearStepMs=1000):
+   *     1s, 2s, 3s, 4s, 6s, 10s, 18s, 34s...
+   */
+  static linearThenExponential(
+    linearCount: number,
+    linearStepMs: number,
+  ): RetryBackoffPolicyInterface {
+    return (retryIndex: number): number => {
+      if (retryIndex < linearCount) {
+        // Linear phase: (i+1) * step
+        return (retryIndex + 1) * linearStepMs;
+      }
+      // Exponential-increment phase (closed form):
+      // n = number of exponential increments applied
+      // base = linearCount * step
+      // increment sum = 2*step * (2^n - 1)
+      const n = retryIndex - linearCount + 1;
+      const base = linearCount * linearStepMs;
+      const incSum = 2 * linearStepMs * (Math.pow(2, n) - 1);
+      return base + incSum;
+    };
+  }
+}
+
+function delay(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}


### PR DESCRIPTION
## Description
This replicates the logic introduced in the EVM Module for fetching the transaction receipt.
From my testing, it speeds up the appearance of the "success" toast by ~2s. Not great, but it's a start.

## Testing
Sanity check on the swap feature.

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
