### PR TITLE
fix: CP-11878 call loginWithoutMFA

### DIFF
--- a/apps/next/src/pages/Onboarding/flows/SeedlessFlow/screens/SeedlessChooseSetupMethod.tsx
+++ b/apps/next/src/pages/Onboarding/flows/SeedlessFlow/screens/SeedlessChooseSetupMethod.tsx
@@ -15,6 +15,8 @@ import { NavButton } from '@/pages/Onboarding/components/NavButton';
 import { CardMenu, CardMenuItem } from '@/pages/Onboarding/components/CardMenu';
 
 import { NewMfaMethod } from '../types';
+import { useSeedlessActions } from '@core/ui';
+import { SEEDLESS_ACTIONS_OPTIONS } from '@/pages/Onboarding/config';
 
 type SeedlessChooseSetupMethodProps = StackProps & {
   onMethodChosen: (method: NewMfaMethod) => void;
@@ -25,6 +27,7 @@ export const SeedlessChooseSetupMethod: FC<SeedlessChooseSetupMethodProps> = ({
 }) => {
   const { t } = useTranslation();
   const { setTotal } = useModalPageControl();
+  const { loginWithoutMFA } = useSeedlessActions(SEEDLESS_ACTIONS_OPTIONS);
 
   useEffect(() => {
     setTotal(0);
@@ -69,7 +72,13 @@ export const SeedlessChooseSetupMethod: FC<SeedlessChooseSetupMethodProps> = ({
         </CardMenu>
       </FullscreenModalContent>
       <FullscreenModalActions>
-        <NavButton color="secondary" onClick={() => onMethodChosen('none')}>
+        <NavButton
+          color="secondary"
+          onClick={() => {
+            loginWithoutMFA();
+            onMethodChosen('none');
+          }}
+        >
           {t('Skip')}
         </NavButton>
       </FullscreenModalActions>


### PR DESCRIPTION
## Description

https://ava-labs.atlassian.net/browse/CP-11878

## Changes

Call the login if the user clicks on the Skip button.

## Testing

go to onboarding -> try to login with a seedless account which does not have any MFA device added -> do NOT add an MFA method just skip the step -> you should be able to enter your wallet

## Screenshots:

https://github.com/user-attachments/assets/f5895dc6-fabb-4d2d-8553-4089c0877493




## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
