### PR TITLE
fix(seedless): seedless skipped customize core page

### DIFF
--- a/apps/next/src/pages/Onboarding/flows/SeedlessFlow/SeedlessFlow.tsx
+++ b/apps/next/src/pages/Onboarding/flows/SeedlessFlow/SeedlessFlow.tsx
@@ -59,7 +59,7 @@ export const SeedlessFlow = () => {
           <ProvideWalletDetailsScreen
             step={3}
             totalSteps={TOTAL_STEPS}
-            onNext={() => history.push(`${BASE_PATH}/select-avatar`)}
+            onNext={() => history.push(`${BASE_PATH}/customize-core`)}
           />
         </Route>
         <Route path={`${BASE_PATH}/customize-core`}>


### PR DESCRIPTION
## Description
Ticket: https://ava-labs.atlassian.net/browse/CP-11884

When onboarding with seedless, customize core page was skipped.

## Changes
Changed the path in onNext. 

## Testing
Please onboard using seedless and once you fill out the wallet details, hitting next should take you to the customize core page and not the select avatar page

## Screenshots:

https://github.com/user-attachments/assets/b2b3e360-51f4-4d83-925b-5c0cf80797b0

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [X] I've tested the changes myself before sending it to code review and QA.
