### PR TITLE
fix(swaps): remove slippage from displayed amountOut

### DIFF
--- a/packages/ui/src/contexts/SwapProvider/SwapProvider.tsx
+++ b/packages/ui/src/contexts/SwapProvider/SwapProvider.tsx
@@ -272,7 +272,6 @@ export function SwapContextProvider({
     (
       metadata: NormalizedSwapQuoteResult['selected']['metadata'],
       swapSide: SwapSide,
-      slippage: number,
       skipFeeDeduction = false,
     ) => {
       // Set amountOut for sell side
@@ -283,9 +282,7 @@ export function SwapContextProvider({
         typeof amountOut === 'string'
       ) {
         setDestAmount(
-          skipFeeDeduction
-            ? amountOut
-            : applyFeeDeduction(amountOut, swapSide, slippage),
+          skipFeeDeduction ? amountOut : applyFeeDeduction(amountOut, swapSide),
         );
       }
       // Set amountIn for buy side
@@ -296,9 +293,7 @@ export function SwapContextProvider({
         typeof amountIn === 'string'
       ) {
         setSrcAmount(
-          skipFeeDeduction
-            ? amountIn
-            : applyFeeDeduction(amountIn, swapSide, slippage),
+          skipFeeDeduction ? amountIn : applyFeeDeduction(amountIn, swapSide),
         );
       }
     },
@@ -360,7 +355,7 @@ export function SwapContextProvider({
             setQuotes(update);
             const selected = update.selected;
             // Set amounts based on the swap side
-            setAmounts(selected.metadata, swapSide, Number(slippageTolerance));
+            setAmounts(selected.metadata, swapSide);
           },
         })
           .then((result) => {
@@ -372,7 +367,6 @@ export function SwapContextProvider({
               setAmounts(
                 metadata,
                 swapSide,
-                Number(slippageTolerance),
                 result.provider === SwapProviders.WNATIVE,
               );
               // Check balance here

--- a/packages/ui/src/contexts/SwapProvider/swap-utils.ts
+++ b/packages/ui/src/contexts/SwapProvider/swap-utils.ts
@@ -435,20 +435,14 @@ export async function buildUnwrapTx({
   };
 }
 
-export function applyFeeDeduction(
-  amount: string,
-  direction: SwapSide,
-  slippage: number,
-): string {
-  const slippagePercent = slippage / 100;
+export function applyFeeDeduction(amount: string, direction: SwapSide): string {
   const feePercent = PARASWAP_PARTNER_FEE_BPS / 10_000;
-  const totalPercent = slippagePercent + feePercent;
 
   if (direction === SwapSide.SELL) {
-    const minAmountOut = new Big(amount).times(1 - totalPercent).toFixed(0);
+    const minAmountOut = new Big(amount).times(1 - feePercent).toFixed(0);
     return minAmountOut;
   } else {
-    const maxAmountIn = new Big(amount).times(1 + totalPercent).toFixed(0);
+    const maxAmountIn = new Big(amount).times(1 + feePercent).toFixed(0);
     return maxAmountIn;
   }
 }


### PR DESCRIPTION
## Description

This PR updates the swap logic to remove the application of slippage on the quoted amountOut values.

Currently, we’re displaying “min amount out” by applying the slippage to the quoted output, which leads to users seeing worse rates compared to competitors — even when our quotes are actually better. This fix ensures the actual quoted amount is displayed, aligning our UI with user expectations and improving rate clarity.

## Changes

- Removed slippage adjustment from amountOut calculations
- Now displaying the raw amountOut returned by the quote API
