### PR TITLE
fix(dapp): rate limit dapp spamming

### DIFF
--- a/packages/inpage/src/ChainAgnosticProvider.ts
+++ b/packages/inpage/src/ChainAgnosticProvider.ts
@@ -27,6 +27,8 @@ export class ChainAgnosticProvider extends EventEmitter {
   #requestRateLimiter = new RequestRatelimiter([
     'eth_requestAccounts',
     'avalanche_selectWallet',
+    'wallet_addEthereumChain',
+    'wallet_switchEthereumChain',
   ]);
 
   constructor(connection) {


### PR DESCRIPTION
## Description
No ticket

## Changes
Adding wallet_addEthereumChain and wallet_switchEthereumChain to rate limited function list since dapp can spam these handlers and cause multiple popup windows to open. 

## Testing
Follow these steps
lauch the dapp at  [gmx.io](http://gmx.io/)
give access to one of your accounts
lock your extension
navigate back to [gmx.io](http://gmx.io/)
unlock your wallet
launch app
get hammered by wallet_switchEthereumChain requests.

## Screenshots:

<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [X] I've tested the changes myself before sending it to code review and QA.
