### PR TITLE
fix: remove platformFee when no feeAccount

### DIFF
--- a/packages/ui/src/contexts/SwapProvider/providers/JupiterProvider.ts
+++ b/packages/ui/src/contexts/SwapProvider/providers/JupiterProvider.ts
@@ -149,6 +149,15 @@ export const JupiterProvider: SwapProvider = {
       throw swapError(CommonError.MismatchingProvider);
     }
 
+    // If no fee account is available, remove platformFee from quote to maintain consistency
+    // Jupiter API expects either both platformFee + feeAccount or neither
+    const cleanedQuote = feeAccount
+      ? quote
+      : {
+          ...quote,
+          platformFee: null,
+        };
+
     const [txResponse, buildTxError] = await resolve(
       fetchAndVerify(
         [
@@ -159,10 +168,10 @@ export const JupiterProvider: SwapProvider = {
               'Content-Type': 'application/json',
             },
             body: JSON.stringify({
-              quoteResponse: quote,
+              quoteResponse: cleanedQuote,
               userPublicKey: userAddress,
               dynamicComputeUnitLimit: true, // Gives us a higher chance of the transaction landing
-              feeAccount,
+              ...(feeAccount && { feeAccount }),
             }),
           },
         ],


### PR DESCRIPTION
## Description

Fixes issue when swapping SLP tokens we don't have a fee account initialized for.

## Changes

Removes platformFee property from the quote for tokens without fee accounts.

## Testing

Do a solana swap with a destination token being something less popular.

## Screenshots:

<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
