### PR TITLE
fix(network-switch): unblock network switch for imported accounts

### DIFF
--- a/apps/legacy/src/components/common/header/NetworkSwitcher/NetworkSwitcher.tsx
+++ b/apps/legacy/src/components/common/header/NetworkSwitcher/NetworkSwitcher.tsx
@@ -1,27 +1,31 @@
-import { useNetworkContext } from '@core/ui';
-import { useRef, useState } from 'react';
 import { ChainId } from '@avalabs/core-chains-sdk';
-import { useHistory } from 'react-router-dom';
-import { NetworkLogo } from '../../NetworkLogo';
-import { useTranslation } from 'react-i18next';
 import {
-  ChevronDownIcon,
+  Box,
   CheckIcon,
-  GearIcon,
-  styled,
-  Typography,
-  Stack,
+  ChevronDownIcon,
   Chip,
+  ClickAwayListener,
+  GearIcon,
+  Grow,
   MenuItem,
   MenuList,
   Popper,
-  Grow,
-  ClickAwayListener,
-  Box,
+  Stack,
+  styled,
   Tooltip,
+  Typography,
 } from '@avalabs/core-k2-components';
-import { useAnalyticsContext, useWalletContext } from '@core/ui';
-import { isChainSupportedByWallet } from '@core/common';
+import { isChainSupportedWalletOrAccount } from '@core/common';
+import {
+  useAccountsContext,
+  useAnalyticsContext,
+  useNetworkContext,
+  useWalletContext,
+} from '@core/ui';
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
+import { NetworkLogo } from '../../NetworkLogo';
 
 const defaultNetworks = [
   ChainId.AVALANCHE_MAINNET_ID,
@@ -37,7 +41,7 @@ const Chevron = styled(ChevronDownIcon, {
   transform: rotateX(${({ isOpen }) => (isOpen ? `180deg` : `0`)});
 `;
 
-const NetworkSelectronMenuItem = styled(MenuItem)`
+const NetworkSelectorMenuItem = styled(MenuItem)`
   color: ${({ theme }) => theme.palette.text.secondary};
 `;
 
@@ -45,6 +49,9 @@ export function NetworkSwitcher() {
   const { network, setNetwork, favoriteNetworks, networks } =
     useNetworkContext();
   const { walletDetails } = useWalletContext();
+  const {
+    accounts: { active: activeAccount },
+  } = useAccountsContext();
 
   const networkList = [
     ...networks.filter(
@@ -142,9 +149,11 @@ export function NetworkSwitcher() {
                       if (!networkItem) {
                         return null;
                       }
-                      const isSupported = isChainSupportedByWallet(
-                        networkItem.vmName,
-                        walletDetails?.type,
+
+                      const isSupported = isChainSupportedWalletOrAccount(
+                        networkItem,
+                        walletDetails,
+                        activeAccount,
                       );
                       return (
                         <Tooltip
@@ -158,7 +167,7 @@ export function NetworkSwitcher() {
                               : ''
                           }
                         >
-                          <NetworkSelectronMenuItem
+                          <NetworkSelectorMenuItem
                             data-testid={`select-network-${networkItem.chainId}-button`}
                             onClick={
                               isSupported
@@ -196,11 +205,11 @@ export function NetworkSwitcher() {
                             {networkItem.chainId === network?.chainId && (
                               <CheckIcon size={16} />
                             )}
-                          </NetworkSelectronMenuItem>
+                          </NetworkSelectorMenuItem>
                         </Tooltip>
                       );
                     })}
-                  <NetworkSelectronMenuItem
+                  <NetworkSelectorMenuItem
                     data-testid="manage-networks-button"
                     key="NetworksPage"
                     onClick={() => {
@@ -218,7 +227,7 @@ export function NetworkSwitcher() {
                         {t('Manage Networks')}
                       </Typography>
                     </Stack>
-                  </NetworkSelectronMenuItem>
+                  </NetworkSelectorMenuItem>
                 </Stack>
               </MenuList>
             </Grow>

--- a/apps/legacy/src/pages/Networks/common/NetworkList.tsx
+++ b/apps/legacy/src/pages/Networks/common/NetworkList.tsx
@@ -1,7 +1,3 @@
-import { useState } from 'react';
-import { useHistory } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { ChainId } from '@avalabs/core-chains-sdk';
 import {
   Collapse,
@@ -19,15 +15,23 @@ import {
   toast,
   useTheme,
 } from '@avalabs/core-k2-components';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 import { NetworkLogo } from '@/components/common/NetworkLogo';
-import { useNetworkContext, useWalletContext } from '@core/ui';
-import { useAnalyticsContext } from '@core/ui';
 import {
   ipfsResolverWithFallback,
-  isChainSupportedByWallet,
+  isChainSupportedWalletOrAccount,
 } from '@core/common';
 import { NetworkWithCaipId } from '@core/types';
+import {
+  useAccountsContext,
+  useAnalyticsContext,
+  useNetworkContext,
+  useWalletContext,
+} from '@core/ui';
 
 import { NetworkListItem } from './NetworkListItem';
 import {
@@ -54,6 +58,9 @@ export function NetworkList({ networkList }: NetworkListProps) {
   const theme = useTheme();
   const { capture } = useAnalyticsContext();
   const [favoritedItem, setFavoritedItem] = useState<number | null>(null);
+  const {
+    accounts: { active: activeAccount },
+  } = useAccountsContext();
 
   if (!networkList.length) {
     return null;
@@ -64,9 +71,10 @@ export function NetworkList({ networkList }: NetworkListProps) {
       <TransitionGroup component={null}>
         {networkList.map((networkItem, index) => {
           const isFavorite = isFavoriteNetwork(networkItem.chainId);
-          const isSupportedByActiveWallet = isChainSupportedByWallet(
-            networkItem.vmName,
-            walletDetails?.type,
+          const isSupportedByActiveWallet = isChainSupportedWalletOrAccount(
+            networkItem,
+            walletDetails,
+            activeAccount,
           );
           return (
             <Collapse key={networkItem.chainId} className="item">

--- a/packages/common/src/utils/getAddressForChain.ts
+++ b/packages/common/src/utils/getAddressForChain.ts
@@ -1,5 +1,3 @@
-import { NetworkVMType } from '@avalabs/vm-module-types';
-
 import { Account, NetworkWithCaipId } from '@core/types';
 
 import { mapAddressesToVMs } from './address';
@@ -12,7 +10,5 @@ export function getAddressForChain(
     return '';
   }
 
-  return (
-    mapAddressesToVMs(account)[network.vmName satisfies NetworkVMType] ?? ''
-  );
+  return mapAddressesToVMs(account)[network.vmName] ?? '';
 }

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -106,3 +106,4 @@ export * from './openFullscreenTab';
 export * from './approveSeedlessRegistration';
 export * from './isChainSupportedByWallet';
 export * from './retry';
+export * from './isChainSupportedWalletOrAccount';

--- a/packages/common/src/utils/isChainSupportedByAccount.ts
+++ b/packages/common/src/utils/isChainSupportedByAccount.ts
@@ -6,6 +6,5 @@ export const isChainSupportedByAccount = (
   account?: Account,
 ) => {
   const addressForNetwork = getAddressForChain(network, account);
-
-  return !!addressForNetwork;
+  return Boolean(addressForNetwork);
 };

--- a/packages/common/src/utils/isChainSupportedByWallet.ts
+++ b/packages/common/src/utils/isChainSupportedByWallet.ts
@@ -47,7 +47,7 @@ export const isChainSupportedByWallet = (
         secretType === SecretType.Mnemonic ||
         secretType === SecretType.PrivateKey
       );
+    default:
+      return false;
   }
-
-  return false;
 };

--- a/packages/common/src/utils/isChainSupportedWalletOrAccount.ts
+++ b/packages/common/src/utils/isChainSupportedWalletOrAccount.ts
@@ -1,0 +1,19 @@
+import {
+  isChainSupportedByAccount,
+  isChainSupportedByWallet,
+} from '@core/common';
+import { Account, NetworkWithCaipId, WalletDetails } from '@core/types';
+
+export function isChainSupportedWalletOrAccount(
+  network: NetworkWithCaipId | undefined,
+  wallet: WalletDetails | undefined,
+  account: Account | undefined,
+) {
+  if (!network) {
+    return false;
+  }
+
+  return wallet
+    ? isChainSupportedByWallet(network.vmName, wallet.type)
+    : isChainSupportedByAccount(network, account);
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
<!--- Link and relevant resources e.g JIRA ticket, Figma Designs, PRs -->
https://ava-labs.atlassian.net/browse/CP-12284

## Changes

<!--- What types of changes does your code introduce? -->
Introduces facade function called "isChainSupportedWalletOrAccount" which
checks chain support for imported accounts using `isChainSupportedByAccount` function
instead of `isChainSupportedByWallet`.


## Testing

<!--- Describe in detail how your changes were tested. -->
<!--- Repeatable Steps to derive the desired output -->

## Screenshots:

<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->
https://github.com/user-attachments/assets/aa6ec44c-fe6a-4197-a0c9-09918611f0b1

## Checklist for the author

Tick each of them when done or if not applicable.

- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
