### PR TITLE
feat: allow core preview url in prod whitelist

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -2,17 +2,27 @@ import { isDevelopment, isProductionBuild } from './utils/environment';
 import browser from 'webextension-polyfill';
 
 const CORE_WEB_DOMAIN = 'core.app' as const;
+/**
+ * Supports Core Web preview URLs.
+ *
+ * @example 'https://abc123-core-web-dev.avalabs.workers.dev'
+ */
+const CORE_WEB_PREVIEW_DOMAIN = 'avalabs.workers.dev' as const;
+
 const CORE_WEB_STAGING_DOMAINS = [
   'staging.core.app',
   'develop.core.app',
 ] as const;
 const DAPP_DEV_DOMAINS = [
-  'avalabs.workers.dev', // Supports Core Web preview URLS (ie https://abc123-core-web-dev.avalabs.workers.dev)
+  CORE_WEB_PREVIEW_DOMAIN,
   'localhost',
   '127.0.0.1',
 ] as const;
 
-const SYNCED_DOMAINS_PRODUCTION_BUILD = [CORE_WEB_DOMAIN] as const;
+const SYNCED_DOMAINS_PRODUCTION_BUILD = [
+  CORE_WEB_DOMAIN,
+  CORE_WEB_PREVIEW_DOMAIN,
+] as const;
 const SYNCED_DOMAINS_DEVELOPMENT_BUILD = [
   CORE_WEB_DOMAIN,
   ...CORE_WEB_STAGING_DOMAINS,


### PR DESCRIPTION
https://avalancheavax.slack.com/archives/C07N64YE43Y/p1760732178231069

Allows Core Web preview URLs to be whitelisted on prod build.

For consideration, if there is a problem with allowing this, we can close the PR.