### PR TITLE
fix(next-gen): truncate tx fee fraction

### DIFF
--- a/apps/next/src/components/CollapsedTokenAmount.tsx
+++ b/apps/next/src/components/CollapsedTokenAmount.tsx
@@ -84,5 +84,19 @@ export const CollapsedTokenAmount = ({
       </Tooltip>
     );
   }
+
+  // If the fraction is longer than the max fraction size, but we can't collapse
+  // the zeroes, let's truncate the amount and show an approximation with the
+  // exact amount in a tooltip.
+  if (fraction && fraction.length > MAX_FRACTION_SIZE) {
+    return (
+      <Tooltip title={amount}>
+        <Typography {...finalRegularProps}>
+          ~{integer}.{fraction.substring(0, MAX_FRACTION_SIZE)}
+        </Typography>
+      </Tooltip>
+    );
+  }
+
   return <Typography {...finalRegularProps}>{amount}</Typography>;
 };


### PR DESCRIPTION
## Description
* [CP-12147](https://ava-labs.atlassian.net/browse/CP-12147)

## Changes
Previously when the transaction fee had a long fraction part, but no consecutive zeroes to collapse into the subindex notation, the full fee amount would be displayed. With this change, the fraction part is truncated and the full amount is displayed on hover.


## Screenshots:
<img width="343" height="301" alt="image" src="https://github.com/user-attachments/assets/fb33cea4-f75c-49a4-89a2-ee6197b91984" />

## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
