### PR TITLE
feat: ERC-8004 agent identity resolution and approval UI

### DIFF
--- a/apps/next/src/pages/Approve/MessageApprovalScreen.tsx
+++ b/apps/next/src/pages/Approve/MessageApprovalScreen.tsx
@@ -5,13 +5,14 @@ import { Avatar, Stack, Typography } from '@avalabs/k2-alpine';
 import { runtime } from 'webextension-polyfill';
 
 import { useAccountsContext } from '@core/ui';
-import { ActionStatus, NetworkWithCaipId } from '@core/types';
+import { ActionStatus, AgentIdentity, NetworkWithCaipId } from '@core/types';
 
 import { NoScrollStack } from '@/components/NoScrollStack';
 
 import {
   ActionDetails,
   ActionDrawer,
+  AgentIdentityCard,
   Styled,
   MaliciousTxOverlay,
   NoteWarning,
@@ -142,6 +143,12 @@ export const MessageApprovalScreen: FC<MessageApprovalScreenProps> = ({
         {hasNoteWarning(action) && (
           <NoteWarning alert={action.displayData.alert} />
         )}
+
+        <AgentIdentityCard
+          agentIdentity={
+            action.context?.agentIdentity as AgentIdentity | undefined
+          }
+        />
 
         <Stack flexGrow={1} px={2} gap={1.5}>
           {(address || action.displayData.network) && (

--- a/apps/next/src/pages/Approve/TransactionApprovalScreen.tsx
+++ b/apps/next/src/pages/Approve/TransactionApprovalScreen.tsx
@@ -2,7 +2,12 @@ import { Stack } from '@avalabs/k2-alpine';
 import { TokenType } from '@avalabs/vm-module-types';
 import { FC, useCallback, useEffect, useRef } from 'react';
 
-import { ActionStatus, GaslessPhase, NetworkWithCaipId } from '@core/types';
+import {
+  ActionStatus,
+  AgentIdentity,
+  GaslessPhase,
+  NetworkWithCaipId,
+} from '@core/types';
 import { useLiveBalance } from '@core/ui';
 import { useTranslation } from 'react-i18next';
 
@@ -13,6 +18,7 @@ import { useIsUsingHardwareWallet } from '@/hooks/useIsUsingHardwareWallet';
 import {
   ActionDetails,
   ActionDrawer,
+  AgentIdentityCard,
   ApprovalScreenTitle,
   HardwareApprovalOverlay,
   MaliciousTxOverlay,
@@ -110,6 +116,11 @@ export const TransactionApprovalScreen: FC<TransactionApprovalScreenProps> = ({
             />
           </Stack>
         )}
+        <AgentIdentityCard
+          agentIdentity={
+            action.context?.agentIdentity as AgentIdentity | undefined
+          }
+        />
         <Stack flexGrow={1} px={2}>
           <ActionDetails
             network={network}

--- a/apps/next/src/pages/Approve/components/AgentIdentityCard.tsx
+++ b/apps/next/src/pages/Approve/components/AgentIdentityCard.tsx
@@ -1,0 +1,179 @@
+import { FC, useMemo } from 'react';
+import { Box, Stack, Typography } from '@avalabs/k2-alpine';
+import { AgentIdentity } from '@core/types';
+
+type AgentIdentityCardProps = {
+  agentIdentity?: AgentIdentity;
+};
+
+const truncateAddress = (address: string): string => {
+  if (address.length <= 10) {
+    return address;
+  }
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+};
+
+const getTrustLevelText = (trustLevel: AgentIdentity['trustLevel']): string => {
+  switch (trustLevel) {
+    case 'high':
+      return 'High Trust';
+    case 'medium':
+      return 'Medium Trust';
+    case 'low':
+      return 'Low Trust';
+    case 'unknown':
+    default:
+      return 'Unknown Trust';
+  }
+};
+
+export const AgentIdentityCard: FC<AgentIdentityCardProps> = ({
+  agentIdentity,
+}) => {
+  const scoreColor = useMemo(() => {
+    if (!agentIdentity) return '';
+    const score = agentIdentity.reputationScore;
+    if (score === null) {
+      return 'text.disabled';
+    }
+    if (score >= 75) {
+      return 'success.main';
+    }
+    if (score >= 40) {
+      return 'warning.main';
+    }
+    return 'error.main';
+  }, [agentIdentity]);
+
+  if (!agentIdentity) {
+    return null;
+  }
+
+  const registryAddress =
+    agentIdentity.agentRegistry.split(':')[2] ?? agentIdentity.agentRegistry;
+
+  return (
+    <Box
+      sx={{
+        p: 2,
+        borderRadius: 2,
+        bgcolor: 'background.paper',
+        border: 1,
+        borderColor: 'divider',
+      }}
+    >
+      <Stack spacing={1.5}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Typography
+            variant="body2"
+            sx={{
+              fontWeight: 600,
+            }}
+            color="text.secondary"
+          >
+            AI Agent
+          </Typography>
+          <Box
+            sx={{
+              px: 1,
+              py: 0.25,
+              borderRadius: 1,
+              bgcolor: scoreColor,
+              opacity: agentIdentity.reputationScore === null ? 0.5 : 1,
+            }}
+          >
+            <Typography
+              variant="caption"
+              sx={{
+                fontWeight: 600,
+                color: 'common.white',
+              }}
+            >
+              {agentIdentity.reputationScore !== null
+                ? `${agentIdentity.reputationScore}/100`
+                : 'N/A'}
+            </Typography>
+          </Box>
+        </Stack>
+
+        <Stack spacing={0.5}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            <Typography variant="body2" color="text.secondary">
+              Agent ID
+            </Typography>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              #{agentIdentity.agentId}
+            </Typography>
+          </Stack>
+
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            <Typography variant="body2" color="text.secondary">
+              Registry
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                fontWeight: 500,
+                fontFamily: 'monospace',
+              }}
+            >
+              {truncateAddress(registryAddress)}
+            </Typography>
+          </Stack>
+
+          {agentIdentity.owner && (
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Typography variant="body2" color="text.secondary">
+                Owner
+              </Typography>
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 500,
+                  fontFamily: 'monospace',
+                }}
+              >
+                {truncateAddress(agentIdentity.owner)}
+              </Typography>
+            </Stack>
+          )}
+
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            <Typography variant="body2" color="text.secondary">
+              Trust Level
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                fontWeight: 500,
+                color: scoreColor,
+              }}
+            >
+              {getTrustLevelText(agentIdentity.trustLevel)}
+            </Typography>
+          </Stack>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+};

--- a/apps/next/src/pages/Approve/components/index.ts
+++ b/apps/next/src/pages/Approve/components/index.ts
@@ -6,3 +6,4 @@ export * from './ErrorScreen';
 export * as Styled from './Styled';
 export * from './warnings';
 export * from './hardware';
+export * from './AgentIdentityCard';

--- a/packages/service-worker/src/connections/dAppConnection/DAppConnectionController.ts
+++ b/packages/service-worker/src/connections/dAppConnection/DAppConnectionController.ts
@@ -9,6 +9,7 @@ import { injectable, injectAll } from 'tsyringe';
 import { Runtime } from 'webextension-polyfill';
 import { Context, Pipeline } from '../middlewares/models';
 import { PermissionMiddleware } from '../middlewares/PermissionMiddleware';
+import { AgentIdentityMiddleware } from '../middlewares/AgentIdentityMiddleware';
 import { DAppRequestHandlerMiddleware } from '../middlewares/DAppRequestHandlerMiddleware';
 import {
   LoggerMiddleware,
@@ -38,6 +39,7 @@ import { ModuleManager } from '../../vmModules/ModuleManager';
 import { ActiveNetworkMiddleware } from '../middlewares/ActiveNetworkMiddleware';
 import { AvalancheTxContextMiddleware } from '../middlewares/AvalancheTxContextMiddleware';
 import { SecretsService } from '~/services/secrets/SecretsService';
+import { AgentIdentityService } from '../../services/agentIdentity/AgentIdentityService';
 
 /**
  * This needs to be a controller per dApp, to separate messages
@@ -60,6 +62,7 @@ export class DAppConnectionController implements ConnectionController {
     private secretsService: SecretsService,
     private lockService: LockService,
     private moduleManager: ModuleManager,
+    private agentIdentityService: AgentIdentityService,
   ) {
     this.onRequest = this.onRequest.bind(this);
     this.disconnect = this.disconnect.bind(this);
@@ -77,6 +80,7 @@ export class DAppConnectionController implements ConnectionController {
       // @ts-ignore
       LoggerMiddleware(SideToLog.REQUEST),
       SiteMetadataMiddleware(connection),
+      AgentIdentityMiddleware(this.agentIdentityService),
       PermissionMiddleware(
         this.permissionsService,
         this.accountsService,

--- a/packages/service-worker/src/connections/dAppConnection/registry.ts
+++ b/packages/service-worker/src/connections/dAppConnection/registry.ts
@@ -41,6 +41,7 @@ import { WalletSetSettingsHandler } from '~/services/settings/handlers/wallet_se
 import { WalletGetSettingsHandler } from '~/services/settings/handlers/wallet_getSettings';
 import { WalletGetCapabilitiesHandler } from '../../services/web3/handlers/wallet_getCapabilities';
 import { WalletEnableNetworkHandler } from '../../services/network/handlers/wallet_enableNetwork';
+import { AvalancheDeclareAgentIdentityHandler } from '../../services/agentIdentity/handlers/avalanche_declareAgentIdentity';
 
 /**
  * TODO: GENERATE THIS FILE AS PART OF THE BUILD PROCESS
@@ -94,6 +95,10 @@ const SHARED_HANDLERS = [
   { token: 'DAppRequestHandler', useToken: WalletSetSettingsHandler },
   { token: 'DAppRequestHandler', useToken: WalletGetCapabilitiesHandler },
   { token: 'DAppRequestHandler', useToken: WalletEnableNetworkHandler },
+  {
+    token: 'DAppRequestHandler',
+    useToken: AvalancheDeclareAgentIdentityHandler,
+  },
 ];
 
 const ALL_REQUEST_HANDLERS = [...SHARED_HANDLERS];

--- a/packages/service-worker/src/connections/middlewares/AgentIdentityMiddleware.ts
+++ b/packages/service-worker/src/connections/middlewares/AgentIdentityMiddleware.ts
@@ -1,0 +1,41 @@
+import {
+  DAppProviderRequest,
+  JsonRpcRequest,
+  JsonRpcRequestPayload,
+  JsonRpcResponse,
+  AgentIdentityDeclaration,
+} from '@core/types';
+import { Middleware } from './models';
+import { AgentIdentityService } from '../../services/agentIdentity/AgentIdentityService';
+
+type AgentIdentityRequest = JsonRpcRequestPayload<
+  DAppProviderRequest.AGENT_DECLARE_IDENTITY,
+  AgentIdentityDeclaration
+>;
+
+const isAgentIdentityRequest = (
+  request: JsonRpcRequestPayload<string, unknown>,
+): request is AgentIdentityRequest => {
+  return request.method === DAppProviderRequest.AGENT_DECLARE_IDENTITY;
+};
+
+export function AgentIdentityMiddleware(
+  agentIdentityService: AgentIdentityService,
+): Middleware<JsonRpcRequest, JsonRpcResponse> {
+  return async (context, next) => {
+    const requestData = context.request.params.request;
+
+    if (isAgentIdentityRequest(requestData)) {
+      try {
+        const identity = await agentIdentityService.resolveIdentity(
+          requestData.params,
+        );
+        context.agentIdentity = identity;
+      } catch {
+        // Non-blocking: if resolution fails, just don't set agent identity
+      }
+    }
+
+    next();
+  };
+}

--- a/packages/service-worker/src/connections/middlewares/DAppRequestHandlerMiddleware.ts
+++ b/packages/service-worker/src/connections/middlewares/DAppRequestHandlerMiddleware.ts
@@ -85,6 +85,7 @@ export function DAppRequestHandlerMiddleware(
             // This field is for our internal use only (only used with extension's direct connection)
             context: {
               account: context.account,
+              agentIdentity: context.agentIdentity,
             },
           },
           context.network,

--- a/packages/service-worker/src/connections/middlewares/PermissionMiddleware.ts
+++ b/packages/service-worker/src/connections/middlewares/PermissionMiddleware.ts
@@ -102,6 +102,7 @@ export const UNRESTRICTED_METHODS = Object.freeze([
   RpcMethod.SOLANA_SIGN_TRANSACTION,
   RpcMethod.SOLANA_SIGN_AND_SEND_TRANSACTION,
   RpcMethod.SOLANA_SIGN_MESSAGE,
+  DAppProviderRequest.AGENT_DECLARE_IDENTITY,
 ]);
 
 const CORE_METHODS = Object.freeze([

--- a/packages/service-worker/src/connections/middlewares/models.ts
+++ b/packages/service-worker/src/connections/middlewares/models.ts
@@ -1,6 +1,7 @@
 import { CurrentAvalancheAccount } from '@avalabs/avalanche-module';
 
 import {
+  AgentIdentity,
   DEFERRED_RESPONSE,
   DomainMetadata,
   NetworkWithCaipId,
@@ -16,6 +17,7 @@ export type Context<RequestType, ResponseType> = {
   account?: CurrentAvalancheAccount;
   authenticated: boolean;
   response?: ResponseType | typeof DEFERRED_RESPONSE;
+  agentIdentity?: AgentIdentity;
 };
 
 export type Middleware<RequestType, ResponseType> = (

--- a/packages/service-worker/src/services/agentIdentity/AgentIdentityService.test.ts
+++ b/packages/service-worker/src/services/agentIdentity/AgentIdentityService.test.ts
@@ -1,0 +1,182 @@
+import { AgentIdentityService } from './AgentIdentityService';
+import { Contract } from 'ethers';
+
+// Mock ethers
+jest.mock('ethers', () => ({
+  JsonRpcProvider: jest.fn().mockImplementation(() => ({})),
+  Contract: jest.fn().mockImplementation(() => ({
+    getFunction: jest.fn(),
+  })),
+}));
+
+describe('AgentIdentityService', () => {
+  let service: AgentIdentityService;
+
+  const setupMocks = (overrides?: {
+    tokenURI?: jest.Mock;
+    ownerOf?: jest.Mock;
+    getReputation?: jest.Mock;
+  }) => {
+    const mockTokenURI =
+      overrides?.tokenURI ??
+      jest.fn().mockResolvedValue('ipfs://metadata');
+    const mockOwnerOf =
+      overrides?.ownerOf ??
+      jest.fn().mockResolvedValue('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266');
+    const mockGetReputation =
+      overrides?.getReputation ??
+      jest.fn().mockResolvedValue(BigInt(85));
+
+    (service as any).identityRegistry.getFunction = jest
+      .fn()
+      .mockImplementation((name: string) => {
+        if (name === 'tokenURI') return mockTokenURI;
+        if (name === 'ownerOf') return mockOwnerOf;
+        return jest.fn().mockRejectedValue(new Error('Unknown'));
+      });
+
+    (service as any).reputationRegistry.getFunction = jest
+      .fn()
+      .mockImplementation((name: string) => {
+        if (name === 'getReputation') return mockGetReputation;
+        return jest.fn().mockRejectedValue(new Error('Unknown'));
+      });
+
+    return { mockTokenURI, mockOwnerOf, mockGetReputation };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AgentIdentityService();
+  });
+
+  describe('resolveIdentity', () => {
+    const validDeclaration = {
+      agentId: '1599',
+      agentRegistry:
+        'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+    };
+
+    it('returns identity with high trust for score >= 75', async () => {
+      setupMocks();
+
+      const result = await service.resolveIdentity(validDeclaration);
+
+      expect(result).toEqual({
+        agentId: '1599',
+        agentRegistry:
+          'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+        owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+        reputationScore: 85,
+        metadataUri: 'ipfs://metadata',
+        trustLevel: 'high',
+      });
+    });
+
+    it('returns identity with medium trust for score >= 40 and < 75', async () => {
+      setupMocks({
+        getReputation: jest.fn().mockResolvedValue(BigInt(50)),
+      });
+
+      const result = await service.resolveIdentity(validDeclaration);
+
+      expect(result.trustLevel).toBe('medium');
+      expect(result.reputationScore).toBe(50);
+    });
+
+    it('returns identity with low trust for score < 40', async () => {
+      setupMocks({
+        getReputation: jest.fn().mockResolvedValue(BigInt(20)),
+      });
+
+      const result = await service.resolveIdentity(validDeclaration);
+
+      expect(result.trustLevel).toBe('low');
+      expect(result.reputationScore).toBe(20);
+    });
+
+    it('returns unknown trust level when reputation call fails', async () => {
+      setupMocks({
+        getReputation: jest
+          .fn()
+          .mockRejectedValue(new Error('Network error')),
+      });
+
+      const result = await service.resolveIdentity(validDeclaration);
+
+      expect(result.trustLevel).toBe('unknown');
+      expect(result.reputationScore).toBeNull();
+      expect(result.metadataUri).toBe('ipfs://metadata');
+      expect(result.owner).toBe(
+        '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      );
+    });
+
+    it('returns null metadataUri when tokenURI call fails', async () => {
+      setupMocks({
+        tokenURI: jest
+          .fn()
+          .mockRejectedValue(new Error('Token not found')),
+        getReputation: jest.fn().mockResolvedValue(BigInt(75)),
+      });
+
+      const result = await service.resolveIdentity(validDeclaration);
+
+      expect(result.metadataUri).toBeNull();
+      expect(result.reputationScore).toBe(75);
+      expect(result.trustLevel).toBe('high');
+    });
+
+    it('returns null owner when ownerOf call fails', async () => {
+      setupMocks({
+        ownerOf: jest
+          .fn()
+          .mockRejectedValue(new Error('Not found')),
+      });
+
+      const result = await service.resolveIdentity(validDeclaration);
+
+      expect(result.owner).toBeNull();
+      expect(result.metadataUri).toBe('ipfs://metadata');
+      expect(result.reputationScore).toBe(85);
+    });
+
+    it('returns unknown identity for invalid CAIP-10 format', async () => {
+      const invalidDeclaration = {
+        agentId: '1599',
+        agentRegistry: 'invalid-format',
+      };
+
+      const result = await service.resolveIdentity(invalidDeclaration);
+
+      expect(result).toEqual({
+        agentId: '1599',
+        agentRegistry: 'invalid-format',
+        owner: null,
+        reputationScore: null,
+        metadataUri: null,
+        trustLevel: 'unknown',
+      });
+    });
+
+    it('caches identity and returns cached result on subsequent calls', async () => {
+      const { mockTokenURI } = setupMocks();
+
+      const result1 = await service.resolveIdentity(validDeclaration);
+      const result2 = await service.resolveIdentity(validDeclaration);
+
+      expect(mockTokenURI).toHaveBeenCalledTimes(1);
+      expect(result1).toEqual(result2);
+    });
+
+    it('clamps reputation score to 0-100 range', async () => {
+      setupMocks({
+        getReputation: jest.fn().mockResolvedValue(BigInt(150)),
+      });
+
+      const result = await service.resolveIdentity(validDeclaration);
+
+      expect(result.reputationScore).toBe(100);
+    });
+  });
+});

--- a/packages/service-worker/src/services/agentIdentity/AgentIdentityService.ts
+++ b/packages/service-worker/src/services/agentIdentity/AgentIdentityService.ts
@@ -1,0 +1,167 @@
+import { singleton } from 'tsyringe';
+import { JsonRpcProvider, Contract } from 'ethers';
+import { AgentIdentity, AgentIdentityDeclaration } from '@core/types';
+
+const AVALANCHE_C_CHAIN_RPC = 'https://api.avax.network/ext/bc/C/rpc';
+const IDENTITY_REGISTRY_ADDRESS = '0x8004A169FB4a3325136EB29fA0ceB6D2e539a432';
+const REPUTATION_REGISTRY_ADDRESS =
+  '0x8004BAa17C55a88189AE136b182e5fdA19dE9b63';
+
+const IDENTITY_REGISTRY_ABI = [
+  'function tokenURI(uint256 agentId) view returns (string)',
+  'function ownerOf(uint256 agentId) view returns (address)',
+];
+const REPUTATION_REGISTRY_ABI = [
+  'function getReputation(uint256 agentId) view returns (uint256)',
+];
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface CacheEntry {
+  identity: AgentIdentity;
+  timestamp: number;
+}
+
+@singleton()
+export class AgentIdentityService {
+  private cache: Map<string, CacheEntry> = new Map();
+  private provider: JsonRpcProvider;
+  private identityRegistry: Contract;
+  private reputationRegistry: Contract;
+
+  constructor() {
+    this.provider = new JsonRpcProvider(AVALANCHE_C_CHAIN_RPC);
+    this.identityRegistry = new Contract(
+      IDENTITY_REGISTRY_ADDRESS,
+      IDENTITY_REGISTRY_ABI,
+      this.provider,
+    );
+    this.reputationRegistry = new Contract(
+      REPUTATION_REGISTRY_ADDRESS,
+      REPUTATION_REGISTRY_ABI,
+      this.provider,
+    );
+  }
+
+  private getCacheKey(declaration: AgentIdentityDeclaration): string {
+    return `${declaration.agentRegistry}:${declaration.agentId}`;
+  }
+
+  private getCachedIdentity(
+    declaration: AgentIdentityDeclaration,
+  ): AgentIdentity | null {
+    const key = this.getCacheKey(declaration);
+    const entry = this.cache.get(key);
+
+    if (!entry) {
+      return null;
+    }
+
+    const now = Date.now();
+    if (now - entry.timestamp > CACHE_TTL_MS) {
+      this.cache.delete(key);
+      return null;
+    }
+
+    return entry.identity;
+  }
+
+  private cacheIdentity(
+    declaration: AgentIdentityDeclaration,
+    identity: AgentIdentity,
+  ): void {
+    const key = this.getCacheKey(declaration);
+    this.cache.set(key, {
+      identity,
+      timestamp: Date.now(),
+    });
+  }
+
+  private parseContractAddress(agentRegistry: string): string | null {
+    // CAIP-10 format: eip155:43114:0x8004...
+    const parts = agentRegistry.split(':');
+    if (parts.length !== 3) {
+      return null;
+    }
+    return parts[2] ?? null;
+  }
+
+  private deriveTrustLevel(score: number | null): AgentIdentity['trustLevel'] {
+    if (score === null) {
+      return 'unknown';
+    }
+    if (score >= 75) {
+      return 'high';
+    }
+    if (score >= 40) {
+      return 'medium';
+    }
+    return 'low';
+  }
+
+  async resolveIdentity(
+    declaration: AgentIdentityDeclaration,
+  ): Promise<AgentIdentity> {
+    // Check cache first
+    const cached = this.getCachedIdentity(declaration);
+    if (cached) {
+      return cached;
+    }
+
+    const contractAddress = this.parseContractAddress(
+      declaration.agentRegistry,
+    );
+    if (!contractAddress) {
+      const identity: AgentIdentity = {
+        agentId: declaration.agentId,
+        agentRegistry: declaration.agentRegistry,
+        owner: null,
+        reputationScore: null,
+        metadataUri: null,
+        trustLevel: 'unknown',
+      };
+      this.cacheIdentity(declaration, identity);
+      return identity;
+    }
+
+    const agentIdBigInt = BigInt(declaration.agentId);
+
+    // Use Promise.allSettled so failures are non-blocking
+    const [metadataResult, ownerResult, reputationResult] =
+      await Promise.allSettled([
+        this.identityRegistry.getFunction('tokenURI')(
+          agentIdBigInt,
+        ) as Promise<string>,
+        this.identityRegistry.getFunction('ownerOf')(
+          agentIdBigInt,
+        ) as Promise<string>,
+        this.reputationRegistry.getFunction('getReputation')(
+          agentIdBigInt,
+        ) as Promise<bigint>,
+      ]);
+
+    const metadataUri =
+      metadataResult.status === 'fulfilled' ? metadataResult.value : null;
+    const owner =
+      ownerResult.status === 'fulfilled' ? ownerResult.value : null;
+
+    let reputationScore: number | null = null;
+    if (reputationResult.status === 'fulfilled') {
+      const score = Number(reputationResult.value);
+      // Clamp to 0-100 range
+      reputationScore = Math.max(0, Math.min(100, score));
+    }
+
+    const identity: AgentIdentity = {
+      agentId: declaration.agentId,
+      agentRegistry: declaration.agentRegistry,
+      owner,
+      reputationScore,
+      metadataUri,
+      trustLevel: this.deriveTrustLevel(reputationScore),
+    };
+
+    this.cacheIdentity(declaration, identity);
+    return identity;
+  }
+}

--- a/packages/service-worker/src/services/agentIdentity/handlers/avalanche_declareAgentIdentity.test.ts
+++ b/packages/service-worker/src/services/agentIdentity/handlers/avalanche_declareAgentIdentity.test.ts
@@ -1,0 +1,74 @@
+import { DAppProviderRequest } from '@core/types';
+import { AvalancheDeclareAgentIdentityHandler } from './avalanche_declareAgentIdentity';
+import { buildRpcCall } from '@shared/tests/test-utils';
+
+describe('avalanche_declareAgentIdentity handler', () => {
+  const mockIdentity = {
+    agentId: '1599',
+    agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+    reputationScore: 85,
+    metadataUri: 'ipfs://metadata',
+    trustLevel: 'high' as const,
+  };
+
+  const mockAgentIdentityService = {
+    resolveIdentity: jest.fn().mockResolvedValue(mockIdentity),
+  };
+
+  const request = {
+    id: '123',
+    method: DAppProviderRequest.AGENT_DECLARE_IDENTITY,
+    params: {
+      agentId: '1599',
+      agentRegistry: 'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+    },
+  } as const;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('has correct methods array', () => {
+    const handler = new AvalancheDeclareAgentIdentityHandler(
+      mockAgentIdentityService as any,
+    );
+
+    expect(handler.methods).toEqual([
+      DAppProviderRequest.AGENT_DECLARE_IDENTITY,
+    ]);
+  });
+
+  describe('handleAuthenticated', () => {
+    it('resolves and returns agent identity', async () => {
+      const handler = new AvalancheDeclareAgentIdentityHandler(
+        mockAgentIdentityService as any,
+      );
+
+      const result = await handler.handleAuthenticated(buildRpcCall(request));
+
+      expect(mockAgentIdentityService.resolveIdentity).toHaveBeenCalledWith({
+        agentId: '1599',
+        agentRegistry:
+          'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+      });
+      expect(result).toEqual({ result: mockIdentity });
+    });
+  });
+
+  describe('handleUnauthenticated', () => {
+    it('resolves and returns agent identity (same as authenticated)', async () => {
+      const handler = new AvalancheDeclareAgentIdentityHandler(
+        mockAgentIdentityService as any,
+      );
+
+      const result = await handler.handleUnauthenticated(buildRpcCall(request));
+
+      expect(mockAgentIdentityService.resolveIdentity).toHaveBeenCalledWith({
+        agentId: '1599',
+        agentRegistry:
+          'eip155:43114:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
+      });
+      expect(result).toEqual({ result: mockIdentity });
+    });
+  });
+});

--- a/packages/service-worker/src/services/agentIdentity/handlers/avalanche_declareAgentIdentity.ts
+++ b/packages/service-worker/src/services/agentIdentity/handlers/avalanche_declareAgentIdentity.ts
@@ -1,0 +1,27 @@
+import { injectable } from 'tsyringe';
+import {
+  DAppRequestHandler,
+  DAppProviderRequest,
+  AgentIdentityDeclaration,
+} from '@core/types';
+import { AgentIdentityService } from '../AgentIdentityService';
+
+@injectable()
+export class AvalancheDeclareAgentIdentityHandler extends DAppRequestHandler {
+  methods = [DAppProviderRequest.AGENT_DECLARE_IDENTITY];
+
+  constructor(private agentIdentityService: AgentIdentityService) {
+    super();
+  }
+
+  handleUnauthenticated = async ({ request }) => {
+    const declaration = request.params as AgentIdentityDeclaration;
+    const identity =
+      await this.agentIdentityService.resolveIdentity(declaration);
+    return { result: identity };
+  };
+
+  handleAuthenticated = async (rpcCall) => {
+    return this.handleUnauthenticated(rpcCall);
+  };
+}

--- a/packages/types/src/agent-identity.ts
+++ b/packages/types/src/agent-identity.ts
@@ -1,0 +1,13 @@
+export interface AgentIdentity {
+  agentId: string;
+  agentRegistry: string; // CAIP-10 format, e.g. "eip155:43114:0x8004..."
+  owner: string | null; // NFT owner address, null if unresolvable
+  reputationScore: number | null; // 0-100, null if unresolvable
+  metadataUri: string | null;
+  trustLevel: 'high' | 'medium' | 'low' | 'unknown';
+}
+
+export interface AgentIdentityDeclaration {
+  agentId: string;
+  agentRegistry: string; // CAIP-10
+}

--- a/packages/types/src/dapp-connection.ts
+++ b/packages/types/src/dapp-connection.ts
@@ -51,6 +51,7 @@ export enum DAppProviderRequest {
   WALLET_GET_SETTINGS = 'wallet_getSettings',
   WALLET_SET_SETTINGS = 'wallet_setSettings',
   WALLET_GET_CAPABILITIES = 'wallet_getCapabilities',
+  AGENT_DECLARE_IDENTITY = 'avalanche_declareAgentIdentity',
 }
 
 export enum Web3Event {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './address';
+export * from './agent-identity';
 export * from './account';
 export * from './actions';
 export * from './analytics';


### PR DESCRIPTION
## Summary

Adds on-chain agent identity resolution to Core Extension, enabling users to see an AI agent's reputation and trust level when approving transactions.

## Motivation

As AI agents increasingly interact with on-chain protocols, users need visibility into **who** (or what) is requesting transaction approval. [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) provides a standard for on-chain agent identity — this PR integrates it into Core's approval flow so users can make informed decisions.

## Changes

### Types (`packages/types`)
- `AgentIdentity`: `agentId`, `agentRegistry` (CAIP-10), `owner`, `reputationScore` (0-100, nullable), `metadataUri` (nullable), `trustLevel` (high/medium/low/unknown)
- `AgentIdentityDeclaration`: for dApp connection requests

### Service Worker
- **AgentIdentityService**: resolves ERC-8004 identity + reputation from on-chain registries with 5-min cache, `Promise.allSettled` for non-blocking resolution, score clamping 0-100
- **AgentIdentityMiddleware**: intercepts `avalanche_declareAgentIdentity` requests
- **Handler**: `avalanche_declareAgentIdentity` JSON-RPC method for dApps to declare agent identity during connection
- **DAppConnectionController**: wired into middleware pipeline

### Approval UI (`apps/next`)
- **AgentIdentityCard**: displays agent ID, registry, owner, reputation score, and trust level with color-coded badge (green/yellow/red)
- Shown in both `MessageApprovalScreen` and `TransactionApprovalScreen`

### Contracts (Avalanche C-Chain)
| Contract | Address |
|----------|---------|
| Identity Registry | `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` |
| Reputation Registry | `0x8004BAa17C55a88189AE136b182e5fdA19dE9b63` |

## Design Decisions

- **Non-blocking resolution**: Uses `Promise.allSettled` so if reputation or metadata lookups fail, the identity card still shows what's available (with null fields)
- **CAIP-10 format**: Registry addresses use `eip155:43114:0x...` for future multi-chain support
- **5-minute cache**: Prevents redundant RPC calls during rapid approval flows
- **Score clamping**: Reputation scores are clamped to 0-100 range for display safety
- **Trust thresholds**: ≥75 high, ≥40 medium, <40 low, null → unknown (matches the evalanche SDK)

## SDK Alignment

Types and resolution logic are aligned with [evalanche](https://github.com/iJaack/evalanche) v0.3.1 — the headless agent wallet SDK that implements the same ERC-8004 identity standard on the agent side. This ensures that agents using evalanche and users running Core Extension see identical identity data.

## Tests

- 9 unit tests for AgentIdentityService (trust levels, caching, error handling, score clamping, owner resolution)
- 1 unit test for `avalanche_declareAgentIdentity` handler

## How to Test

1. Deploy an ERC-8004 identity NFT on Fuji testnet
2. Connect a dApp that calls `avalanche_declareAgentIdentity` with the agent's ID and registry
3. Trigger a transaction — the approval screen should show the AgentIdentityCard with reputation data