### PR TITLE
fix: refresh atomic balance when balances update

### DIFF
--- a/packages/ui/src/contexts/BalancesProvider/BalancesProvider.tsx
+++ b/packages/ui/src/contexts/BalancesProvider/BalancesProvider.tsx
@@ -241,24 +241,6 @@ export function BalancesProvider({ children }: PropsWithChildren) {
   }, []);
 
   useEffect(() => {
-    const subscription = events()
-      .pipe(
-        filter(isBalancesUpdatedEvent),
-        map((evt) => evt.value),
-      )
-      .subscribe((balancesData) => {
-        dispatch({
-          type: BalanceActionType.UPDATE_BALANCES,
-          payload: balancesData,
-        });
-      });
-
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, [events]);
-
-  useEffect(() => {
     dispatch({
       type: BalanceActionType.SET_LOADING,
       payload: true,
@@ -325,6 +307,27 @@ export function BalancesProvider({ children }: PropsWithChildren) {
     },
     [request],
   );
+
+  useEffect(() => {
+    const subscription = events()
+      .pipe(
+        filter(isBalancesUpdatedEvent),
+        map((evt) => evt.value),
+      )
+      .subscribe((balancesData) => {
+        dispatch({
+          type: BalanceActionType.UPDATE_BALANCES,
+          payload: balancesData,
+        });
+        if (activeAccount) {
+          void fetchAtomicBalanceForAccount(activeAccount.id);
+        }
+      });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [events, activeAccount, fetchAtomicBalanceForAccount]);
 
   useEffect(() => {
     if (!activeAccount) {

--- a/packages/ui/src/contexts/BalancesProvider/BalancesProvider.tsx
+++ b/packages/ui/src/contexts/BalancesProvider/BalancesProvider.tsx
@@ -24,7 +24,7 @@ import {
   useReducer,
   useState,
 } from 'react';
-import { filter, map } from 'rxjs';
+import { filter, tap, throttleTime } from 'rxjs';
 
 import { NftTokenWithBalance, TokenType } from '@avalabs/vm-module-types';
 import {
@@ -190,6 +190,10 @@ function balancesReducer(
   }
 }
 
+// Cap how often we refetch atomic totals on balance UPDATED (polling can burst);
+// tokens/NFTs still update on every event via tap below.
+const ATOMIC_BALANCE_REFETCH_THROTTLE_MS = 150;
+
 export function BalancesProvider({ children }: PropsWithChildren) {
   const { request, events } = useConnectionContext();
   const { network, enabledNetworkIds, getNetwork } = useNetworkContext();
@@ -308,26 +312,33 @@ export function BalancesProvider({ children }: PropsWithChildren) {
     [request],
   );
 
+  const activeAccountId = activeAccount?.id;
+
   useEffect(() => {
     const subscription = events()
       .pipe(
         filter(isBalancesUpdatedEvent),
-        map((evt) => evt.value),
+        tap((evt) => {
+          dispatch({
+            type: BalanceActionType.UPDATE_BALANCES,
+            payload: evt.value,
+          });
+        }),
+        throttleTime(ATOMIC_BALANCE_REFETCH_THROTTLE_MS, undefined, {
+          leading: true,
+          trailing: true,
+        }),
       )
-      .subscribe((balancesData) => {
-        dispatch({
-          type: BalanceActionType.UPDATE_BALANCES,
-          payload: balancesData,
-        });
-        if (activeAccount) {
-          void fetchAtomicBalanceForAccount(activeAccount.id);
+      .subscribe(() => {
+        if (activeAccountId) {
+          void fetchAtomicBalanceForAccount(activeAccountId);
         }
       });
 
     return () => {
       subscription.unsubscribe();
     };
-  }, [events, activeAccount, fetchAtomicBalanceForAccount]);
+  }, [events, activeAccountId, fetchAtomicBalanceForAccount]);
 
   useEffect(() => {
     if (!activeAccount) {

--- a/packages/ui/src/contexts/BalancesProvider/BalancesProvider.tsx
+++ b/packages/ui/src/contexts/BalancesProvider/BalancesProvider.tsx
@@ -24,7 +24,7 @@ import {
   useReducer,
   useState,
 } from 'react';
-import { filter, tap, throttleTime } from 'rxjs';
+import { filter, map } from 'rxjs';
 
 import { NftTokenWithBalance, TokenType } from '@avalabs/vm-module-types';
 import {
@@ -190,10 +190,6 @@ function balancesReducer(
   }
 }
 
-// Cap how often we refetch atomic totals on balance UPDATED (polling can burst);
-// tokens/NFTs still update on every event via tap below.
-const ATOMIC_BALANCE_REFETCH_THROTTLE_MS = 150;
-
 export function BalancesProvider({ children }: PropsWithChildren) {
   const { request, events } = useConnectionContext();
   const { network, enabledNetworkIds, getNetwork } = useNetworkContext();
@@ -318,18 +314,13 @@ export function BalancesProvider({ children }: PropsWithChildren) {
     const subscription = events()
       .pipe(
         filter(isBalancesUpdatedEvent),
-        tap((evt) => {
-          dispatch({
-            type: BalanceActionType.UPDATE_BALANCES,
-            payload: evt.value,
-          });
-        }),
-        throttleTime(ATOMIC_BALANCE_REFETCH_THROTTLE_MS, undefined, {
-          leading: true,
-          trailing: true,
-        }),
+        map((evt) => evt.value),
       )
-      .subscribe(() => {
+      .subscribe((balancesData) => {
+        dispatch({
+          type: BalanceActionType.UPDATE_BALANCES,
+          payload: balancesData,
+        });
         if (activeAccountId) {
           void fetchAtomicBalanceForAccount(activeAccountId);
         }


### PR DESCRIPTION
## Description

[CP-13435](https://ava-labs.atlassian.net/browse/CP-13435)

After a successful cross-chain transfer, Core Web cleared the stuck-funds banner while the extension could still show stale atomic totals until the popup was reopened. Balance polling updates the service worker’s atomic cache and emits `BalanceServiceEvents.UPDATED`, but `accountAtomicBalances` in `BalancesProvider` was only refreshed when the polling effect’s dependencies changed, not on every balance update event.

## Changes

- When balance `UPDATED` events arrive, dispatch `UPDATE_BALANCES` as before, then refetch atomic funds for the active account via `fetchAtomicBalanceForAccount`.
- Moved the subscription `useEffect` to sit after `fetchAtomicBalanceForAccount` so dependencies stay valid.

## Testing

1. Connect the extension to Core Web.
2. Run a C-Chain → P-Chain CCT from web (approve export and import in the extension).
3. After the transfer completes and web clears the stuck-funds UI, open the extension: the stuck-funds banner should not appear when atomic memory is clear.
4. Optionally confirm that a genuine stuck-funds case still shows the banner.

## Screenshots:

https://github.com/user-attachments/assets/f1fe1c5f-fb57-4aec-a374-6c3477df6a60


## Checklist for the author

Tick each of them when done or if not applicable.

- [ ] I've covered new/modified business logic with Jest test cases.
- [X] I've tested the changes myself before sending it to code review and QA.


[CP-13435]: https://ava-labs.atlassian.net/browse/CP-13435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ