### PR TITLE
fix(keystone): derive x/p addresses for higher index accounts

### DIFF
--- a/apps/next/src/pages/Onboarding/flows/ConnectKeystoneFlow/components/KeystoneUSBConnector/hooks/useKeystoneBasePublicKeyFetcher.ts
+++ b/apps/next/src/pages/Onboarding/flows/ConnectKeystoneFlow/components/KeystoneUSBConnector/hooks/useKeystoneBasePublicKeyFetcher.ts
@@ -101,9 +101,8 @@ export const useKeystoneBasePublicKeyFetcher: UseKeystonePublicKeyFetcher = (
       for (const index of startingIndexes) {
         const publicKey = await getAddressPublicKeyFromXpub(evmXpub, index);
         publicKeys.push(publicKey);
+        onActivePublicKeysDiscovered?.(publicKeys);
       }
-
-      onActivePublicKeysDiscovered?.(publicKeys);
 
       let currentIndex = startingIndexes.at(-1)!;
 
@@ -160,10 +159,7 @@ export const useKeystoneBasePublicKeyFetcher: UseKeystonePublicKeyFetcher = (
           extendedPublicKeys: evmExtendedPublicKeys,
         } = await retrieveEvmKeys(startingIndexes);
 
-        // TODO: derive X/P addresses for all accounts after Keystone releases new SDK version.
-        // https://ava-labs.atlassian.net/browse/CP-12875
-        // const xpIndexes = evmAddressPublicKeys.map(({ index }) => index);
-        const xpIndexes = [0];
+        const xpIndexes = evmAddressPublicKeys.map(({ index }) => index);
 
         const {
           addressPublicKeys: xpAddressPublicKeys,


### PR DESCRIPTION
* [CP-13911](https://ava-labs.atlassian.net/browse/CP-13911)
* (Parent story) [CP-13229](https://ava-labs.atlassian.net/browse/CP-13229)

## Changes
1. When onboarding, derive X/P addresses for all created accounts
2. Notify the parent component about each discovered EVM address, not only after all are discovered.

## Testing
1. Onboard with Keystone that will result with at least 2 active EVM addresses.
2. Your 2nd and higher accounts should also have an X/P address derived.


## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.


[CP-13911]: https://ava-labs.atlassian.net/browse/CP-13911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-13229]: https://ava-labs.atlassian.net/browse/CP-13229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ