### PR TITLE
refactor: remove optimistic confetti - ACP-194

### DIFF
--- a/apps/next/src/components/Transactions/TransactionsProviderWithConfetti.test.tsx
+++ b/apps/next/src/components/Transactions/TransactionsProviderWithConfetti.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@shared/tests/test-utils';
 import { ChainId, NetworkVMType } from '@avalabs/core-chains-sdk';
 import { NetworkWithCaipId } from '@core/types';
 import { TransactionStatusProviderWithConfetti } from './TransactionsProviderWithConfetti';
+import { useIsOptimisticConfirmationEnabled } from '@core/ui';
 
 const mockTriggerConfetti = jest.fn();
 const mockHistoryReplace = jest.fn();
@@ -25,14 +26,15 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('@core/ui', () => ({
+  useIsOptimisticConfirmationEnabled: jest.fn(),
   TransactionStatusProvider: ({
     children,
     onPending,
     onSuccess,
   }: {
     children: React.ReactNode;
-    onPending?: (params: { network?: NetworkWithCaipId }) => void;
-    onSuccess?: (params: { network?: NetworkWithCaipId }) => void;
+    onPending?: (params: { network?: NetworkWithCaipId }) => Promise<void>;
+    onSuccess?: (params: { network?: NetworkWithCaipId }) => Promise<void>;
   }) => {
     capturedOnPending = onPending;
     capturedOnSuccess = onSuccess;
@@ -96,6 +98,10 @@ describe('TransactionStatusProviderWithConfetti', () => {
 
   describe('handlePending', () => {
     beforeEach(() => {
+      jest
+        .mocked(useIsOptimisticConfirmationEnabled)
+        .mockReturnValue(() => Promise.resolve(false));
+
       render(
         <TransactionStatusProviderWithConfetti>
           <div>Test</div>
@@ -103,50 +109,79 @@ describe('TransactionStatusProviderWithConfetti', () => {
       );
     });
 
-    it('navigates to home on pending', () => {
+    it('navigates to home on pending', async () => {
       const network = createMockNetwork(ChainId.ETHEREUM_HOMESTEAD);
-      capturedOnPending?.({ network });
+      await capturedOnPending?.({ network });
 
       expect(mockHistoryReplace).toHaveBeenCalledWith('/');
     });
 
-    it('triggers confetti for Avalanche C-Chain', () => {
-      const network = createMockNetwork(ChainId.AVALANCHE_MAINNET_ID);
-      capturedOnPending?.({ network });
+    it('triggers confetti for Avalanche primary chains before Helicon is enabled', async () => {
+      jest
+        .mocked(useIsOptimisticConfirmationEnabled)
+        .mockReturnValue(() => Promise.resolve(true));
 
+      render(
+        <TransactionStatusProviderWithConfetti>
+          <div>Test</div>
+        </TransactionStatusProviderWithConfetti>,
+      );
+
+      await capturedOnPending?.({
+        network: createMockNetwork(ChainId.AVALANCHE_MAINNET_ID),
+      });
       expect(mockTriggerConfetti).toHaveBeenCalledTimes(1);
+
+      await capturedOnPending?.({
+        network: createMockNetwork(ChainId.AVALANCHE_P, NetworkVMType.PVM),
+      });
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(2);
+
+      await capturedOnPending?.({
+        network: createMockNetwork(ChainId.AVALANCHE_X, NetworkVMType.AVM),
+      });
+
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(3);
     });
 
-    it('triggers confetti for Avalanche P-Chain', () => {
-      const network = createMockNetwork(ChainId.AVALANCHE_P, NetworkVMType.PVM);
-      capturedOnPending?.({ network });
+    it('does not trigger confetti for Avalanche primary chains after Helicon is enabled', async () => {
+      jest
+        .mocked(useIsOptimisticConfirmationEnabled)
+        .mockReturnValue(() => Promise.resolve(false));
 
-      expect(mockTriggerConfetti).toHaveBeenCalledTimes(1);
+      await capturedOnPending?.({
+        network: createMockNetwork(ChainId.AVALANCHE_MAINNET_ID),
+      });
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(0);
+
+      await capturedOnPending?.({
+        network: createMockNetwork(ChainId.AVALANCHE_P, NetworkVMType.PVM),
+      });
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(0);
+
+      await capturedOnPending?.({
+        network: createMockNetwork(ChainId.AVALANCHE_X, NetworkVMType.AVM),
+      });
+
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(0);
     });
 
-    it('triggers confetti for Avalanche X-Chain', () => {
-      const network = createMockNetwork(ChainId.AVALANCHE_X, NetworkVMType.AVM);
-      capturedOnPending?.({ network });
-
-      expect(mockTriggerConfetti).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not trigger confetti for Ethereum network', () => {
+    it('does not trigger confetti for Ethereum network', async () => {
       const network = createMockNetwork(ChainId.ETHEREUM_HOMESTEAD);
-      capturedOnPending?.({ network });
+      await capturedOnPending?.({ network });
 
       expect(mockTriggerConfetti).not.toHaveBeenCalled();
     });
 
-    it('does not trigger confetti for Bitcoin network', () => {
+    it('does not trigger confetti for Bitcoin network', async () => {
       const network = createMockNetwork(ChainId.BITCOIN);
-      capturedOnPending?.({ network });
+      await capturedOnPending?.({ network });
 
       expect(mockTriggerConfetti).not.toHaveBeenCalled();
     });
 
-    it('does not trigger confetti when network is undefined', () => {
-      capturedOnPending?.({ network: undefined });
+    it('does not trigger confetti when network is undefined', async () => {
+      await capturedOnPending?.({ network: undefined });
 
       expect(mockTriggerConfetti).not.toHaveBeenCalled();
     });
@@ -154,6 +189,9 @@ describe('TransactionStatusProviderWithConfetti', () => {
 
   describe('handleSuccess', () => {
     beforeEach(() => {
+      jest
+        .mocked(useIsOptimisticConfirmationEnabled)
+        .mockReturnValue(() => Promise.resolve(false));
       render(
         <TransactionStatusProviderWithConfetti>
           <div>Test</div>
@@ -161,43 +199,73 @@ describe('TransactionStatusProviderWithConfetti', () => {
       );
     });
 
-    it('triggers confetti for Ethereum network', () => {
+    it('triggers confetti for Ethereum network', async () => {
       const network = createMockNetwork(ChainId.ETHEREUM_HOMESTEAD);
-      capturedOnSuccess?.({ network });
+      await capturedOnSuccess?.({ network });
 
       expect(mockTriggerConfetti).toHaveBeenCalledTimes(1);
     });
 
-    it('triggers confetti for Bitcoin network', () => {
+    it('triggers confetti for Bitcoin network', async () => {
       const network = createMockNetwork(ChainId.BITCOIN);
-      capturedOnSuccess?.({ network });
+      await capturedOnSuccess?.({ network });
 
       expect(mockTriggerConfetti).toHaveBeenCalledTimes(1);
     });
 
-    it('does not trigger confetti for Avalanche C-Chain', () => {
-      const network = createMockNetwork(ChainId.AVALANCHE_MAINNET_ID);
-      capturedOnSuccess?.({ network });
+    it('triggers confetti for Avalanche primary chains after Helicon is enabled', async () => {
+      jest
+        .mocked(useIsOptimisticConfirmationEnabled)
+        .mockReturnValue(() => Promise.resolve(false));
 
-      expect(mockTriggerConfetti).not.toHaveBeenCalled();
+      await capturedOnSuccess?.({
+        network: createMockNetwork(ChainId.AVALANCHE_MAINNET_ID),
+      });
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(1);
+
+      await capturedOnSuccess?.({
+        network: createMockNetwork(ChainId.AVALANCHE_P, NetworkVMType.PVM),
+      });
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(2);
+
+      await capturedOnSuccess?.({
+        network: createMockNetwork(ChainId.AVALANCHE_X, NetworkVMType.AVM),
+      });
+
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(3);
     });
 
-    it('does not trigger confetti for Avalanche P-Chain', () => {
-      const network = createMockNetwork(ChainId.AVALANCHE_P, NetworkVMType.PVM);
-      capturedOnSuccess?.({ network });
+    it('does not trigger confetti for Avalanche primary chains before Helicon is enabled', async () => {
+      jest
+        .mocked(useIsOptimisticConfirmationEnabled)
+        .mockReturnValue(() => Promise.resolve(true));
 
-      expect(mockTriggerConfetti).not.toHaveBeenCalled();
+      // Gotta re-render the component to update the mock
+      render(
+        <TransactionStatusProviderWithConfetti>
+          <div>Test</div>
+        </TransactionStatusProviderWithConfetti>,
+      );
+
+      await capturedOnSuccess?.({
+        network: createMockNetwork(ChainId.AVALANCHE_MAINNET_ID),
+      });
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(0);
+
+      await capturedOnSuccess?.({
+        network: createMockNetwork(ChainId.AVALANCHE_P, NetworkVMType.PVM),
+      });
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(0);
+
+      await capturedOnSuccess?.({
+        network: createMockNetwork(ChainId.AVALANCHE_X, NetworkVMType.AVM),
+      });
+
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(0);
     });
 
-    it('does not trigger confetti for Avalanche X-Chain', () => {
-      const network = createMockNetwork(ChainId.AVALANCHE_X, NetworkVMType.AVM);
-      capturedOnSuccess?.({ network });
-
-      expect(mockTriggerConfetti).not.toHaveBeenCalled();
-    });
-
-    it('triggers confetti when network is undefined (non-Avalanche default)', () => {
-      capturedOnSuccess?.({ network: undefined });
+    it('triggers confetti when network is undefined (non-Avalanche default)', async () => {
+      await capturedOnSuccess?.({ network: undefined });
 
       expect(mockTriggerConfetti).toHaveBeenCalledTimes(1);
     });

--- a/apps/next/src/components/Transactions/TransactionsProviderWithConfetti.tsx
+++ b/apps/next/src/components/Transactions/TransactionsProviderWithConfetti.tsx
@@ -7,38 +7,40 @@ import {
   TransactionStatusProvider,
   TransactionStatusCallbackParams,
 } from '@core/ui';
-import {
-  openNewTab,
-  getExplorerAddressByNetwork,
-  isAvalanchePrimaryNetwork,
-} from '@core/common';
+import { openNewTab, getExplorerAddressByNetwork } from '@core/common';
 import { NetworkWithCaipId } from '@core/types';
+import { useIsOptimisticConfirmationEnabled } from '@core/ui';
 
 export const TransactionStatusProviderWithConfetti = ({
   children,
 }: PropsWithChildren) => {
   const { triggerConfetti, stopConfetti } = useConfettiContext();
   const history = useHistory();
+  const shouldUseOptimisticConfirmations = useIsOptimisticConfirmationEnabled();
 
   const handlePending = useCallback(
-    ({ network }: TransactionStatusCallbackParams) => {
+    async ({ network }: TransactionStatusCallbackParams) => {
       history.replace('/');
-      // Trigger confetti on pending for Avalanche C/P/X chains
-      if (isAvalanchePrimaryNetwork(network)) {
+      const showSuccessOnPending =
+        await shouldUseOptimisticConfirmations(network);
+
+      if (showSuccessOnPending) {
         triggerConfetti();
       }
     },
-    [history, triggerConfetti],
+    [history, triggerConfetti, shouldUseOptimisticConfirmations],
   );
 
   const handleSuccess = useCallback(
-    ({ network }: TransactionStatusCallbackParams) => {
-      // Trigger confetti on success for non-Avalanche chains
-      if (!isAvalanchePrimaryNetwork(network)) {
+    async ({ network }: TransactionStatusCallbackParams) => {
+      const showSuccessOnPending =
+        await shouldUseOptimisticConfirmations(network);
+
+      if (!showSuccessOnPending) {
         triggerConfetti();
       }
     },
-    [triggerConfetti],
+    [triggerConfetti, shouldUseOptimisticConfirmations],
   );
 
   return (

--- a/packages/ui/src/contexts/TransactionStatusProvider/TransactionStatusProvider.test.tsx
+++ b/packages/ui/src/contexts/TransactionStatusProvider/TransactionStatusProvider.test.tsx
@@ -11,6 +11,7 @@ import { TransactionStatusProvider } from './TransactionStatusProvider';
 import { useConnectionContext } from '../ConnectionProvider';
 import { useNetworkContext } from '../NetworkProvider';
 import { isSpecificContextContainer } from '../../utils';
+import { useIsOptimisticConfirmationEnabled } from '../../hooks/useIsOptimisticConfirmationEnabled';
 
 jest.mock('react-i18next', () => ({
   useTranslation: jest.fn(() => ({
@@ -36,19 +37,11 @@ jest.mock('../../utils', () => ({
   },
 }));
 
-jest.mock('@core/common', () => ({
-  isAvalanchePrimaryNetwork: jest.fn((network?: NetworkWithCaipId) => {
-    if (!network) return false;
-    return [
-      ChainId.AVALANCHE_MAINNET_ID,
-      ChainId.AVALANCHE_TESTNET_ID,
-      ChainId.AVALANCHE_P,
-      ChainId.AVALANCHE_TEST_P,
-      ChainId.AVALANCHE_X,
-      ChainId.AVALANCHE_TEST_X,
-    ].includes(network.chainId);
-  }),
+jest.mock('../../hooks/useIsOptimisticConfirmationEnabled', () => ({
+  useIsOptimisticConfirmationEnabled: jest.fn(),
 }));
+
+jest.mock('@core/common');
 
 const createMockNetwork = (
   chainId: number,
@@ -107,6 +100,10 @@ describe('TransactionStatusProvider', () => {
     eventSubject = new Subject();
 
     jest
+      .mocked(useIsOptimisticConfirmationEnabled)
+      .mockReturnValue(() => Promise.resolve(false));
+
+    jest
       .mocked<
         () => Partial<ReturnType<typeof useConnectionContext>>
       >(useConnectionContext)
@@ -148,7 +145,7 @@ describe('TransactionStatusProvider', () => {
   };
 
   describe('context restrictions', () => {
-    it('does not subscribe to events in disallowed contexts', () => {
+    it('does not subscribe to events in disallowed contexts', async () => {
       jest.mocked(isSpecificContextContainer).mockReturnValue(false);
 
       renderProvider();
@@ -160,11 +157,13 @@ describe('TransactionStatusProvider', () => {
         makeEvent(TransactionStatusEvents.PENDING, txHash, 'eip155:1'),
       );
 
+      await new Promise(process.nextTick);
+
       expect(mockOnPending).not.toHaveBeenCalled();
       expect(toast.pending).not.toHaveBeenCalled();
     });
 
-    it('subscribes to events in POPUP context', () => {
+    it('subscribes to events in POPUP context', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -174,12 +173,14 @@ describe('TransactionStatusProvider', () => {
         makeEvent(TransactionStatusEvents.PENDING, txHash, 'eip155:1'),
       );
 
+      await new Promise(process.nextTick);
+
       expect(mockOnPending).toHaveBeenCalled();
     });
   });
 
   describe('PENDING event', () => {
-    it('calls onPending callback with network and context', () => {
+    it('calls onPending callback with network and context', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -190,13 +191,15 @@ describe('TransactionStatusProvider', () => {
         makeEvent(TransactionStatusEvents.PENDING, txHash, 'eip155:1', context),
       );
 
+      await new Promise(process.nextTick);
+
       expect(mockOnPending).toHaveBeenCalledWith({
         network: ethereumNetwork,
         context,
       });
     });
 
-    it('shows pending toast for non-Avalanche networks', () => {
+    it('shows pending toast for non-Avalanche networks', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -206,12 +209,18 @@ describe('TransactionStatusProvider', () => {
         makeEvent(TransactionStatusEvents.PENDING, txHash, 'eip155:1'),
       );
 
+      await new Promise(process.nextTick);
+
       expect(toast.pending).toHaveBeenCalledWith('Transaction pending...', {
         id: `transaction-pending-${txHash}`,
       });
     });
 
-    it('shows success toast immediately for Avalanche C-Chain', () => {
+    it('shows success toast immediately for Avalanche networks before Helicon is enabled', async () => {
+      jest
+        .mocked(useIsOptimisticConfirmationEnabled)
+        .mockReturnValue(() => Promise.resolve(true));
+
       renderProvider();
 
       const txHash = '0x123';
@@ -221,6 +230,8 @@ describe('TransactionStatusProvider', () => {
         makeEvent(TransactionStatusEvents.PENDING, txHash, 'eip155:43114'),
       );
 
+      await new Promise(process.nextTick);
+
       expect(toast.success).toHaveBeenCalledWith(
         'Transaction successful',
         expect.objectContaining({
@@ -230,45 +241,27 @@ describe('TransactionStatusProvider', () => {
       expect(toast.pending).not.toHaveBeenCalled();
     });
 
-    it('shows success toast immediately for Avalanche P-Chain', () => {
+    it('does not show success toast for Avalanche networks after Helicon is enabled', async () => {
+      jest
+        .mocked(useIsOptimisticConfirmationEnabled)
+        .mockReturnValue(() => Promise.resolve(false));
+
       renderProvider();
 
       const txHash = '0x123';
-      mockGetNetwork.mockReturnValue(avalanchePChain);
+      mockGetNetwork.mockReturnValue(avalancheCChain);
 
       eventSubject.next(
-        makeEvent(TransactionStatusEvents.PENDING, txHash, 'avax:p-chain'),
+        makeEvent(TransactionStatusEvents.PENDING, txHash, 'eip155:43114'),
       );
 
-      expect(toast.success).toHaveBeenCalledWith(
-        'Transaction successful',
-        expect.objectContaining({
-          id: `transaction-success-${txHash}`,
-        }),
-      );
-      expect(toast.pending).not.toHaveBeenCalled();
+      await new Promise(process.nextTick);
+
+      expect(toast.pending).toHaveBeenCalled();
+      expect(toast.success).not.toHaveBeenCalled();
     });
 
-    it('shows success toast immediately for Avalanche X-Chain', () => {
-      renderProvider();
-
-      const txHash = '0x123';
-      mockGetNetwork.mockReturnValue(avalancheXChain);
-
-      eventSubject.next(
-        makeEvent(TransactionStatusEvents.PENDING, txHash, 'avax:x-chain'),
-      );
-
-      expect(toast.success).toHaveBeenCalledWith(
-        'Transaction successful',
-        expect.objectContaining({
-          id: `transaction-success-${txHash}`,
-        }),
-      );
-      expect(toast.pending).not.toHaveBeenCalled();
-    });
-
-    it('skips for intermediate transactions', () => {
+    it('skips for intermediate transactions', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -280,11 +273,13 @@ describe('TransactionStatusProvider', () => {
         }),
       );
 
+      await new Promise(process.nextTick);
+
       expect(mockOnPending).not.toHaveBeenCalled();
       expect(toast.pending).not.toHaveBeenCalled();
     });
 
-    it('skips for bridge transactions', () => {
+    it('skips for bridge transactions', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -296,13 +291,15 @@ describe('TransactionStatusProvider', () => {
         }),
       );
 
+      await new Promise(process.nextTick);
+
       expect(mockOnPending).not.toHaveBeenCalled();
       expect(toast.pending).not.toHaveBeenCalled();
     });
   });
 
   describe('CONFIRMED event', () => {
-    it('dismisses pending toast and shows success toast for non-Avalanche networks', () => {
+    it('dismisses pending toast and shows success toast for non-Avalanche networks', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -311,6 +308,8 @@ describe('TransactionStatusProvider', () => {
       eventSubject.next(
         makeEvent(TransactionStatusEvents.CONFIRMED, txHash, 'eip155:1'),
       );
+
+      await new Promise(process.nextTick);
 
       expect(toast.dismiss).toHaveBeenCalledWith(
         `transaction-pending-${txHash}`,
@@ -323,7 +322,7 @@ describe('TransactionStatusProvider', () => {
       );
     });
 
-    it('calls onSuccess callback with network and context', () => {
+    it('calls onSuccess callback with network and context', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -339,13 +338,19 @@ describe('TransactionStatusProvider', () => {
         ),
       );
 
+      await new Promise(process.nextTick);
+
       expect(mockOnSuccess).toHaveBeenCalledWith({
         network: ethereumNetwork,
         context,
       });
     });
 
-    it('skips for Avalanche C-Chain (already shown on pending)', () => {
+    it('skips for Avalanche networks before Helicon is enabled (already shown on pending)', async () => {
+      jest
+        .mocked(useIsOptimisticConfirmationEnabled)
+        .mockReturnValue(() => Promise.resolve(true));
+
       renderProvider();
 
       const txHash = '0x123';
@@ -355,39 +360,13 @@ describe('TransactionStatusProvider', () => {
         makeEvent(TransactionStatusEvents.CONFIRMED, txHash, 'eip155:43114'),
       );
 
-      expect(mockOnSuccess).not.toHaveBeenCalled();
-      expect(toast.success).not.toHaveBeenCalled();
-    });
-
-    it('skips for Avalanche P-Chain (already shown on pending)', () => {
-      renderProvider();
-
-      const txHash = '0x123';
-      mockGetNetwork.mockReturnValue(avalanchePChain);
-
-      eventSubject.next(
-        makeEvent(TransactionStatusEvents.CONFIRMED, txHash, 'avax:p-chain'),
-      );
+      await new Promise(process.nextTick);
 
       expect(mockOnSuccess).not.toHaveBeenCalled();
       expect(toast.success).not.toHaveBeenCalled();
     });
 
-    it('skips for Avalanche X-Chain (already shown on pending)', () => {
-      renderProvider();
-
-      const txHash = '0x123';
-      mockGetNetwork.mockReturnValue(avalancheXChain);
-
-      eventSubject.next(
-        makeEvent(TransactionStatusEvents.CONFIRMED, txHash, 'avax:x-chain'),
-      );
-
-      expect(mockOnSuccess).not.toHaveBeenCalled();
-      expect(toast.success).not.toHaveBeenCalled();
-    });
-
-    it('skips for intermediate transactions', () => {
+    it('skips for intermediate transactions', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -399,11 +378,13 @@ describe('TransactionStatusProvider', () => {
         }),
       );
 
+      await new Promise(process.nextTick);
+
       expect(mockOnSuccess).not.toHaveBeenCalled();
       expect(toast.success).not.toHaveBeenCalled();
     });
 
-    it('skips for bridge transactions', () => {
+    it('skips for bridge transactions', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -415,13 +396,15 @@ describe('TransactionStatusProvider', () => {
         }),
       );
 
+      await new Promise(process.nextTick);
+
       expect(mockOnSuccess).not.toHaveBeenCalled();
       expect(toast.success).not.toHaveBeenCalled();
     });
   });
 
   describe('REVERTED event', () => {
-    it('dismisses pending toast and shows error toast', () => {
+    it('dismisses pending toast and shows error toast', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -430,6 +413,8 @@ describe('TransactionStatusProvider', () => {
       eventSubject.next(
         makeEvent(TransactionStatusEvents.REVERTED, txHash, 'eip155:1'),
       );
+
+      await new Promise(process.nextTick);
 
       expect(toast.dismiss).toHaveBeenCalledWith(
         `transaction-pending-${txHash}`,
@@ -442,7 +427,7 @@ describe('TransactionStatusProvider', () => {
       });
     });
 
-    it('calls onReverted callback with network and context', () => {
+    it('calls onReverted callback with network and context', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -458,6 +443,8 @@ describe('TransactionStatusProvider', () => {
         ),
       );
 
+      await new Promise(process.nextTick);
+
       expect(mockOnReverted).toHaveBeenCalledWith({
         network: ethereumNetwork,
         context,
@@ -466,7 +453,7 @@ describe('TransactionStatusProvider', () => {
   });
 
   describe('explorer link', () => {
-    it('includes explorer link in success toast when renderExplorerLink is provided', () => {
+    it('includes explorer link in success toast when renderExplorerLink is provided', async () => {
       renderProvider();
 
       const txHash = '0x123';
@@ -475,6 +462,8 @@ describe('TransactionStatusProvider', () => {
       eventSubject.next(
         makeEvent(TransactionStatusEvents.CONFIRMED, txHash, 'eip155:1'),
       );
+
+      await new Promise(process.nextTick);
 
       expect(mockRenderExplorerLink).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -504,7 +493,11 @@ describe('TransactionStatusProvider', () => {
         { name: 'X-Chain', network: avalancheXChain, chainId: 'avax:x-chain' },
       ])(
         '$name: shows success toast on PENDING and skips on CONFIRMED',
-        ({ network, chainId }) => {
+        async ({ network, chainId }) => {
+          jest
+            .mocked(useIsOptimisticConfirmationEnabled)
+            .mockReturnValue(() => Promise.resolve(true));
+
           renderProvider();
           const txHash = '0xabc';
           mockGetNetwork.mockReturnValue(network);
@@ -513,6 +506,8 @@ describe('TransactionStatusProvider', () => {
           eventSubject.next(
             makeEvent(TransactionStatusEvents.PENDING, txHash, chainId),
           );
+
+          await new Promise(process.nextTick);
 
           expect(toast.success).toHaveBeenCalledWith(
             'Transaction successful',
@@ -531,6 +526,8 @@ describe('TransactionStatusProvider', () => {
             makeEvent(TransactionStatusEvents.CONFIRMED, txHash, chainId),
           );
 
+          await new Promise(process.nextTick);
+
           // Should NOT show another success toast (already shown on pending)
           expect(toast.success).not.toHaveBeenCalled();
           expect(mockOnSuccess).not.toHaveBeenCalled();
@@ -539,7 +536,11 @@ describe('TransactionStatusProvider', () => {
     });
 
     describe('non-Avalanche networks (Ethereum, etc.)', () => {
-      it('shows pending toast on PENDING and success toast on CONFIRMED', () => {
+      it('shows pending toast on PENDING and success toast on CONFIRMED', async () => {
+        jest
+          .mocked(useIsOptimisticConfirmationEnabled)
+          .mockReturnValue(() => Promise.resolve(false));
+
         renderProvider();
         const txHash = '0xdef';
         mockGetNetwork.mockReturnValue(ethereumNetwork);
@@ -548,6 +549,8 @@ describe('TransactionStatusProvider', () => {
         eventSubject.next(
           makeEvent(TransactionStatusEvents.PENDING, txHash, 'eip155:1'),
         );
+
+        await new Promise(process.nextTick);
 
         expect(toast.pending).toHaveBeenCalledWith('Transaction pending...', {
           id: `transaction-pending-${txHash}`,
@@ -565,6 +568,7 @@ describe('TransactionStatusProvider', () => {
           makeEvent(TransactionStatusEvents.CONFIRMED, txHash, 'eip155:1'),
         );
 
+        await new Promise(process.nextTick);
         expect(toast.dismiss).toHaveBeenCalledWith(
           `transaction-pending-${txHash}`,
         );

--- a/packages/ui/src/contexts/TransactionStatusProvider/TransactionStatusProvider.tsx
+++ b/packages/ui/src/contexts/TransactionStatusProvider/TransactionStatusProvider.tsx
@@ -15,8 +15,8 @@ import { useConnectionContext } from '../ConnectionProvider';
 import { useNetworkContext } from '../NetworkProvider';
 import { isTransactionStatusEvent } from './isTransactionStatusEvent';
 import { isSpecificContextContainer } from '../../utils';
-import { isAvalanchePrimaryNetwork } from '@core/common';
 import { toast } from '../../utils';
+import { useIsOptimisticConfirmationEnabled } from '../../hooks/useIsOptimisticConfirmationEnabled';
 
 const PENDING_TOAST_ID = 'transaction-pending';
 const SUCCESS_TOAST_ID = 'transaction-success';
@@ -60,6 +60,7 @@ export function TransactionStatusProvider({
   const { events } = useConnectionContext();
   const { getNetwork } = useNetworkContext();
   const { t } = useTranslation();
+  const shouldUseOptimisticConfirmations = useIsOptimisticConfirmationEnabled();
 
   const getExplorerLink = useCallback(
     (hash: string, network?: NetworkWithCaipId) => {
@@ -83,85 +84,90 @@ export function TransactionStatusProvider({
 
     const subscription = events()
       .pipe(filter(isTransactionStatusEvent))
-      .subscribe((evt: ExtensionConnectionEvent<TransactionStatusInfo>) => {
-        const { txHash, request } = evt.value;
-        const { context } = request;
-        const network = getNetwork(request.chainId);
+      .subscribe(
+        async (evt: ExtensionConnectionEvent<TransactionStatusInfo>) => {
+          const { txHash, request } = evt.value;
+          const { context } = request;
+          const network = getNetwork(request.chainId);
 
-        if (txHash) {
-          switch (evt.name) {
-            case TransactionStatusEventNames.PENDING: {
-              // Skip pending toast for intermediate transactions or bridge transactions
-              // (e.g., ERC-20 spend approvals before swaps/bridges)
-              if (
-                context?.surpressSuccessToast ||
-                context?.isIntermediateTransaction ||
-                context?.isBridge
-              ) {
+          const showSuccessOnPending =
+            await shouldUseOptimisticConfirmations(network);
+
+          if (txHash) {
+            switch (evt.name) {
+              case TransactionStatusEventNames.PENDING: {
+                // Skip pending toast for intermediate transactions or bridge transactions
+                // (e.g., ERC-20 spend approvals before swaps/bridges)
+                if (
+                  context?.surpressSuccessToast ||
+                  context?.isIntermediateTransaction ||
+                  context?.isBridge
+                ) {
+                  break;
+                }
+
+                onPending?.({ network, context });
+
+                if (showSuccessOnPending) {
+                  const explorerLink = getExplorerLink(txHash, network);
+                  toast.success(t('Transaction successful'), {
+                    id: `${SUCCESS_TOAST_ID}-${txHash}`,
+                    ...(explorerLink && { action: explorerLink }),
+                  });
+                } else {
+                  toast.pending(t('Transaction pending...'), {
+                    id: `${PENDING_TOAST_ID}-${txHash}`,
+                  });
+                }
+
                 break;
               }
 
-              onPending?.({ network, context });
+              case TransactionStatusEventNames.CONFIRMED: {
+                // Skip success callback and toast for intermediate transactions
+                // For bridge transactions, we take the user to the bridge transaction status page instead
+                // (e.g., ERC-20 spend approvals before swaps/bridges)
+                // Skip success callback and toast for Avalanche primary networks since we show a success toast in the pending callback
+                if (
+                  context?.surpressSuccessToast ||
+                  context?.isIntermediateTransaction ||
+                  context?.isBridge ||
+                  showSuccessOnPending
+                ) {
+                  break;
+                }
 
-              if (isAvalanchePrimaryNetwork(network)) {
+                toast.dismiss(`${PENDING_TOAST_ID}-${txHash}`);
+
                 const explorerLink = getExplorerLink(txHash, network);
+                onSuccess?.({ network, context });
                 toast.success(t('Transaction successful'), {
                   id: `${SUCCESS_TOAST_ID}-${txHash}`,
                   ...(explorerLink && { action: explorerLink }),
                 });
-              } else {
-                toast.pending(t('Transaction pending...'), {
-                  id: `${PENDING_TOAST_ID}-${txHash}`,
-                });
-              }
-
-              break;
-            }
-
-            case TransactionStatusEventNames.CONFIRMED: {
-              // Skip success callback and toast for intermediate transactions
-              // For bridge transactions, we take the user to the bridge transaction status page instead
-              // (e.g., ERC-20 spend approvals before swaps/bridges)
-              // Skip success callback and toast for Avalanche primary networks since we show a success toast in the pending callback
-              if (
-                context?.surpressSuccessToast ||
-                context?.isIntermediateTransaction ||
-                context?.isBridge ||
-                isAvalanchePrimaryNetwork(network)
-              ) {
                 break;
               }
 
-              toast.dismiss(`${PENDING_TOAST_ID}-${txHash}`);
+              case TransactionStatusEventNames.REVERTED: {
+                toast.dismiss(`${PENDING_TOAST_ID}-${txHash}`);
+                toast.dismiss(`${SUCCESS_TOAST_ID}-${txHash}`); // Success toast may be shown optimistically for X/C/P chains.
+                onReverted?.({ network, context });
 
-              const explorerLink = getExplorerLink(txHash, network);
-              onSuccess?.({ network, context });
-              toast.success(t('Transaction successful'), {
-                id: `${SUCCESS_TOAST_ID}-${txHash}`,
-                ...(explorerLink && { action: explorerLink }),
-              });
-              break;
-            }
+                const message =
+                  context?.revertReason ===
+                  SwapErrorCode.TransactionRevertedDueToSlippage
+                    ? t('Transaction failed due to slippage')
+                    : t('Transaction failed');
 
-            case TransactionStatusEventNames.REVERTED: {
-              toast.dismiss(`${PENDING_TOAST_ID}-${txHash}`);
-              toast.dismiss(`${SUCCESS_TOAST_ID}-${txHash}`); // Success toast may be shown optimistically for X/C/P chains.
-              onReverted?.({ network, context });
-
-              const message =
-                context?.revertReason ===
-                SwapErrorCode.TransactionRevertedDueToSlippage
-                  ? t('Transaction failed due to slippage')
-                  : t('Transaction failed');
-
-              toast.error(message, {
-                id: `${FAILURE_TOAST_ID}-${txHash}`,
-              });
-              break;
+                toast.error(message, {
+                  id: `${FAILURE_TOAST_ID}-${txHash}`,
+                });
+                break;
+              }
             }
           }
-        }
-      });
+        },
+      );
 
     return () => {
       subscription.unsubscribe();
@@ -175,6 +181,7 @@ export function TransactionStatusProvider({
     onSuccess,
     onReverted,
     getExplorerLink,
+    shouldUseOptimisticConfirmations,
   ]);
 
   return <>{children}</>;

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -75,3 +75,4 @@ export * from './useImportMissingKeysFromKeystone';
 export * from './useIsCorrectDeviceForActiveWallet';
 export * from './useImportMissingKeysFromLedger';
 export * from './useLiveWalletBalance';
+export * from './useIsOptimisticConfirmationEnabled';

--- a/packages/ui/src/hooks/useIsOptimisticConfirmationEnabled.ts
+++ b/packages/ui/src/hooks/useIsOptimisticConfirmationEnabled.ts
@@ -1,0 +1,39 @@
+import { utils } from '@avalabs/avalanchejs';
+import { Avalanche } from '@avalabs/core-wallets-sdk';
+import { useCallback, useMemo } from 'react';
+
+import { NetworkWithCaipId } from '@core/types';
+import { isAvalanchePrimaryNetwork } from '@core/common';
+
+import { useNetworkContext } from '../contexts';
+
+export const useIsOptimisticConfirmationEnabled = () => {
+  const { isDeveloperMode } = useNetworkContext();
+
+  const provider = useMemo(
+    () =>
+      isDeveloperMode
+        ? Avalanche.JsonRpcProvider.getDefaultFujiProvider()
+        : Avalanche.JsonRpcProvider.getDefaultMainnetProvider(),
+    [isDeveloperMode],
+  );
+
+  return useCallback(
+    async (network?: NetworkWithCaipId) => {
+      const isAvalanche = network && isAvalanchePrimaryNetwork(network);
+
+      if (!isAvalanche) {
+        return false;
+      }
+
+      const upgradesInfo = await provider.getInfo().getUpgradesInfo();
+
+      // Only use optimistic confirmations before Helicon is enabled,
+      // as this upgrade will introduce ACP-194, after which optimistic
+      // confirmations should no longer be needed.
+      // TODO: Remove all of these checks once Helicon is enabled.
+      return !utils.isHeliconEnabled(upgradesInfo);
+    },
+    [provider],
+  );
+};


### PR DESCRIPTION
* [CP-13804](https://ava-labs.atlassian.net/browse/CP-13804)

## Changes
1. Removes optimistic confetti & success toasts for Avalanche chains **_after Helicon update is live_**.

## Testing
Confetti should only be shown after the transactions are actually confirmed by the network (which with ACP-194 should happen way faster).

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.


[CP-13804]: https://ava-labs.atlassian.net/browse/CP-13804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ