### PR TITLE
fix: add ERC20 balance fallback for testnets (Sepolia)

### DIFF
--- a/packages/service-worker/src/services/balances/BalancesService.test.ts
+++ b/packages/service-worker/src/services/balances/BalancesService.test.ts
@@ -5,8 +5,10 @@ import { GetBalancesResponse, TokenType } from '@avalabs/vm-module-types';
 import { ModuleManager } from '~/vmModules/ModuleManager';
 import { NetworkVMType } from '@avalabs/core-chains-sdk';
 import * as Sentry from '@sentry/browser';
+import { getProviderForNetwork } from '@core/common';
 import { SettingsService } from '../settings/SettingsService';
 import LRUCache from 'lru-cache';
+import { ethers } from 'ethers';
 
 jest.mock('~/vmModules/ModuleManager');
 jest.mock('@sentry/browser', () => {
@@ -14,6 +16,10 @@ jest.mock('@sentry/browser', () => {
     startTransaction: jest.fn(),
   };
 });
+jest.mock('@core/common', () => ({
+  ...jest.requireActual('@core/common'),
+  getProviderForNetwork: jest.fn(),
+}));
 
 describe('src/background/services/balances/BalancesService.ts', () => {
   const account = {
@@ -181,6 +187,7 @@ describe('src/background/services/balances/BalancesService.ts', () => {
   let moduleManager: ModuleManager;
   const moduleMock = {
     getBalances: jest.fn(),
+    getTokens: jest.fn(),
   };
   const settingsService: SettingsService = {
     getSettings: jest.fn(),
@@ -411,6 +418,166 @@ describe('src/background/services/balances/BalancesService.ts', () => {
         tokenTypes: [],
         storage: expect.any(LRUCache),
       });
+    });
+  });
+
+  describe('ERC20 testnet fallback', () => {
+    const sepoliaNetwork = {
+      vmName: NetworkVMType.EVM,
+      caipId: 'eip155:11155111',
+      chainId: 11155111,
+      isTestnet: true,
+    } as any;
+
+    const makeNativeOnlyResult = (): GetBalancesResponse => ({
+      addressC: {
+        ETH: {
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+          type: TokenType.NATIVE,
+          balance: 1000000000000000000n,
+          balanceInCurrency: 2000,
+          balanceDisplayValue: '1.0',
+          balanceCurrencyDisplayValue: '2000',
+          priceInCurrency: 2000,
+          coingeckoId: 'ethereum',
+        },
+      },
+    });
+
+    const mockTokenList = [
+      { address: '0xToken1', name: 'USDC', symbol: 'USDC', decimals: 6 },
+      { address: '0xToken2', name: 'LINK', symbol: 'LINK', decimals: 18 },
+    ];
+
+    const mockBalanceOf = jest.fn();
+    const mockProvider = Object.create(
+      (jest.requireActual('@avalabs/core-wallets-sdk') as any)
+        .JsonRpcBatchInternal.prototype,
+    );
+
+    beforeEach(() => {
+      jest.mocked(getProviderForNetwork).mockResolvedValue(mockProvider as any);
+      moduleMock.getTokens.mockResolvedValue(mockTokenList);
+      mockBalanceOf.mockResolvedValue(5000000n);
+      jest.spyOn(ethers, 'Contract').mockImplementation(
+        () =>
+          ({
+            balanceOf: mockBalanceOf,
+          }) as any,
+      );
+    });
+
+    it('should fetch ERC20 balances via RPC when module returns only native', async () => {
+      moduleMock.getBalances.mockResolvedValue(makeNativeOnlyResult());
+
+      const result = await service.getBalancesForNetwork(
+        sepoliaNetwork,
+        [account],
+        [TokenType.NATIVE, TokenType.ERC20],
+      );
+
+      expect(moduleMock.getTokens).toHaveBeenCalled();
+      expect(getProviderForNetwork).toHaveBeenCalled();
+      expect(mockBalanceOf).toHaveBeenCalledWith('addressC');
+
+      expect(result.addressC).toBeDefined();
+      expect(result.addressC?.['0xtoken1']).toEqual(
+        expect.objectContaining({
+          type: TokenType.ERC20,
+          symbol: 'USDC',
+          balance: 5000000n,
+        }),
+      );
+      expect(result.addressC?.['0xtoken2']).toEqual(
+        expect.objectContaining({
+          type: TokenType.ERC20,
+          symbol: 'LINK',
+          balance: 5000000n,
+        }),
+      );
+    });
+
+    it('should skip fallback when ERC20 tokens are already present', async () => {
+      const resultWithErc20: GetBalancesResponse = {
+        addressC: {
+          ETH: (makeNativeOnlyResult().addressC as Record<string, any>).ETH,
+          '0xexisting': {
+            type: TokenType.ERC20,
+            address: '0xExisting',
+            name: 'Existing',
+            symbol: 'EXT',
+            decimals: 18,
+            balance: 100n,
+            balanceDisplayValue: '0.0000000000000001',
+            balanceInCurrency: 0,
+            balanceCurrencyDisplayValue: '0',
+            priceInCurrency: 0,
+            reputation: null,
+          } as any,
+        },
+      };
+
+      moduleMock.getBalances.mockResolvedValue(resultWithErc20);
+
+      await service.getBalancesForNetwork(
+        sepoliaNetwork,
+        [account],
+        [TokenType.NATIVE, TokenType.ERC20],
+      );
+
+      expect(moduleMock.getTokens).not.toHaveBeenCalled();
+      expect(getProviderForNetwork).not.toHaveBeenCalled();
+    });
+
+    it('should not run fallback for mainnet EVM networks', async () => {
+      const mainnetNetwork = {
+        vmName: NetworkVMType.EVM,
+        caipId: 'eip155:1',
+        chainId: 1,
+        isTestnet: false,
+      } as any;
+
+      moduleMock.getBalances.mockResolvedValue(makeNativeOnlyResult());
+
+      await service.getBalancesForNetwork(
+        mainnetNetwork,
+        [account],
+        [TokenType.NATIVE, TokenType.ERC20],
+      );
+
+      expect(moduleMock.getTokens).not.toHaveBeenCalled();
+    });
+
+    it('should not run fallback when ERC20 is not in tokenTypes', async () => {
+      moduleMock.getBalances.mockResolvedValue(makeNativeOnlyResult());
+
+      await service.getBalancesForNetwork(
+        sepoliaNetwork,
+        [account],
+        [TokenType.NATIVE],
+      );
+
+      expect(moduleMock.getTokens).not.toHaveBeenCalled();
+    });
+
+    it('should handle token list with invalid entries gracefully', async () => {
+      moduleMock.getTokens.mockResolvedValue([
+        { address: '0xValid', name: 'Valid', symbol: 'VLD', decimals: 18 },
+        { address: 123, name: 'Bad', symbol: 'BAD' },
+        { name: 'NoAddr', symbol: 'NA', decimals: 18 },
+      ]);
+      moduleMock.getBalances.mockResolvedValue(makeNativeOnlyResult());
+
+      const result = await service.getBalancesForNetwork(
+        sepoliaNetwork,
+        [account],
+        [TokenType.NATIVE, TokenType.ERC20],
+      );
+
+      expect(result.addressC?.['0xvalid']).toBeDefined();
+      expect(Object.keys(result.addressC ?? {}).length).toBe(2);
     });
   });
 });

--- a/packages/service-worker/src/services/balances/BalancesService.ts
+++ b/packages/service-worker/src/services/balances/BalancesService.ts
@@ -119,11 +119,17 @@ export class BalancesService {
             string,
             TokenWithBalance
           >;
-          const safeAccountBalances =
-            Object.getPrototypeOf(accountBalances) === null
-              ? accountBalances
-              : Object.assign(Object.create(null), accountBalances);
-          rawBalances[address] = safeAccountBalances as unknown as GetBalancesResponse[string];
+
+          const safeAccountBalances: Record<string, TokenWithBalance> =
+            Object.create(null);
+          for (const [existingTokenKey, existingTokenBalance] of Object.entries(
+            accountBalances,
+          )) {
+            safeAccountBalances[existingTokenKey] = existingTokenBalance;
+          }
+
+          rawBalances[address] =
+            safeAccountBalances as unknown as GetBalancesResponse[string];
 
           safeAccountBalances[tokenKey] = {
             type: TokenType.ERC20,

--- a/packages/service-worker/src/services/balances/BalancesService.ts
+++ b/packages/service-worker/src/services/balances/BalancesService.ts
@@ -6,6 +6,7 @@ import {
   TokenType,
   TokenWithBalance,
 } from '@avalabs/vm-module-types';
+import { JsonRpcBatchInternal } from '@avalabs/core-wallets-sdk';
 import {
   getPriceChangeValues,
   getProviderForNetwork,
@@ -28,6 +29,20 @@ const ERC20_BALANCE_OF_ABI = [
 const cacheStorage = new LRUCache({ max: 100, ttl: 60 * 1000 });
 
 const PROTO_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isValidErc20TokenEntry(
+  t: unknown,
+): t is { address: string; name: string; symbol: string; decimals: number } {
+  if (typeof t !== 'object' || t === null) return false;
+  const obj = t as Record<string, unknown>;
+  return (
+    typeof obj.address === 'string' &&
+    typeof obj.name === 'string' &&
+    typeof obj.symbol === 'string' &&
+    typeof obj.decimals === 'number' &&
+    Number.isFinite(obj.decimals)
+  );
+}
 
 @singleton()
 export class BalancesService {
@@ -66,7 +81,7 @@ export class BalancesService {
     const provider = await getProviderForNetwork(
       network as unknown as Parameters<typeof getProviderForNetwork>[0],
     ).catch(() => null);
-    if (!provider) return;
+    if (!(provider instanceof JsonRpcBatchInternal)) return;
 
     for (const address of addresses) {
       if (PROTO_POLLUTION_KEYS.has(address)) continue;
@@ -79,7 +94,7 @@ export class BalancesService {
             const contract = new ethers.Contract(
               token.address,
               ERC20_BALANCE_OF_ABI,
-              provider as ethers.Provider,
+              provider,
             );
             const balance: bigint = await contract.balanceOf!(address);
             return { ...token, balance };
@@ -132,26 +147,15 @@ export class BalancesService {
   > {
     try {
       const allTokens = await module.getTokens(network as Network);
-      return allTokens.filter(
-        (
-          t,
-        ): t is typeof t & {
-          address: string;
-          name: string;
-          symbol: string;
-          decimals: number;
-        } =>
-          'address' in t &&
-          typeof (t as unknown as Record<string, unknown>).address ===
-            'string' &&
-          'decimals' in t,
-      );
+      return (allTokens as unknown[]).filter(isValidErc20TokenEntry);
     } catch {
       try {
         const res = await fetch(
           `${process.env.PROXY_URL}/tokens?evmChainId=${network.chainId}`,
         );
-        return res.ok ? await res.json() : [];
+        if (!res.ok) return [];
+        const data: unknown = await res.json();
+        return Array.isArray(data) ? data.filter(isValidErc20TokenEntry) : [];
       } catch {
         return [];
       }
@@ -296,7 +300,11 @@ export class BalancesService {
             }
 
             const tokenBalance = rawAccountTokenList[tokenKey];
-            if (!tokenBalance || tokenBalance?.error) {
+            if (
+              !tokenBalance ||
+              tokenBalance instanceof Error ||
+              tokenBalance?.error
+            ) {
               if (tokenBalance?.error) {
                 console.warn(
                   `BalancesService: Skipping token ${tokenKey} on ${network.caipId}:`,

--- a/packages/service-worker/src/services/balances/BalancesService.ts
+++ b/packages/service-worker/src/services/balances/BalancesService.ts
@@ -1,4 +1,6 @@
 import {
+  GetBalancesResponse,
+  Module,
   Network,
   NetworkVMType,
   TokenType,
@@ -6,18 +8,26 @@ import {
 } from '@avalabs/vm-module-types';
 import {
   getPriceChangeValues,
+  getProviderForNetwork,
   isNotNullish,
   isPrimaryAccount,
 } from '@core/common';
 import { Account, NetworkWithCaipId, TokensPriceShortData } from '@core/types';
 import * as Sentry from '@sentry/browser';
+import { ethers } from 'ethers';
 import LRUCache from 'lru-cache';
 import { singleton } from 'tsyringe';
 import { ModuleManager } from '../../vmModules/ModuleManager';
 import { AddressResolver } from '../secrets/AddressResolver';
 import { SettingsService } from '../settings/SettingsService';
 
+const ERC20_BALANCE_OF_ABI = [
+  'function balanceOf(address owner) view returns (uint256)',
+];
+
 const cacheStorage = new LRUCache({ max: 100, ttl: 60 * 1000 });
+
+const PROTO_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 @singleton()
 export class BalancesService {
@@ -26,6 +36,127 @@ export class BalancesService {
     private moduleManager: ModuleManager,
     private addressResolver: AddressResolver,
   ) {}
+
+  /**
+   * Workaround for testnets where the VM module's balance provider
+   * (Glacier/Debank) claims to support the chain but returns no ERC20 data.
+   * Fetches balances directly via individual RPC balanceOf calls.
+   *
+   * Mutates rawBalances in-place.
+   * TODO: Remove once the evm-module properly falls through to the RPC provider.
+   */
+  async #fillMissingErc20Balances(
+    rawBalances: GetBalancesResponse,
+    network: NetworkWithCaipId,
+    module: Module,
+    addresses: string[],
+  ): Promise<void> {
+    const hasAnyErc20 = addresses.some((addr) => {
+      const acct = rawBalances[addr];
+      if (!acct || acct instanceof Error) return false;
+      return Object.values(acct).some(
+        (t) => !(t instanceof Error) && t.type === TokenType.ERC20,
+      );
+    });
+    if (hasAnyErc20) return;
+
+    const erc20Tokens = await this.#fetchErc20TokenList(network, module);
+    if (!erc20Tokens.length) return;
+
+    const provider = await getProviderForNetwork(
+      network as unknown as Parameters<typeof getProviderForNetwork>[0],
+    ).catch(() => null);
+    if (!provider) return;
+
+    for (const address of addresses) {
+      if (PROTO_POLLUTION_KEYS.has(address)) continue;
+      const acct = rawBalances[address];
+      if (!acct || acct instanceof Error) continue;
+
+      try {
+        const results = await Promise.allSettled(
+          erc20Tokens.map(async (token) => {
+            const contract = new ethers.Contract(
+              token.address,
+              ERC20_BALANCE_OF_ABI,
+              provider as ethers.Provider,
+            );
+            const balance: bigint = await contract.balanceOf!(address);
+            return { ...token, balance };
+          }),
+        );
+
+        for (const result of results) {
+          if (result.status !== 'fulfilled') continue;
+
+          const {
+            address: tokenAddr,
+            name,
+            symbol,
+            decimals,
+            balance,
+          } = result.value;
+
+          const tokenKey = tokenAddr.toLowerCase();
+          if (PROTO_POLLUTION_KEYS.has(tokenKey)) continue;
+
+          (rawBalances[address] as Record<string, TokenWithBalance>)[tokenKey] =
+            {
+              type: TokenType.ERC20,
+              address: tokenAddr,
+              name,
+              symbol,
+              decimals,
+              balance,
+              balanceDisplayValue: ethers.formatUnits(balance, decimals),
+              balanceInCurrency: undefined,
+              balanceCurrencyDisplayValue: '',
+              priceInCurrency: undefined,
+              reputation: null,
+            } as unknown as TokenWithBalance;
+        }
+      } catch (err) {
+        console.warn(
+          `BalancesService: ERC20 RPC fallback failed for ${address} on ${network.caipId}:`,
+          err,
+        );
+      }
+    }
+  }
+
+  async #fetchErc20TokenList(
+    network: NetworkWithCaipId,
+    module: Module,
+  ): Promise<
+    { address: string; name: string; symbol: string; decimals: number }[]
+  > {
+    try {
+      const allTokens = await module.getTokens(network as Network);
+      return allTokens.filter(
+        (
+          t,
+        ): t is typeof t & {
+          address: string;
+          name: string;
+          symbol: string;
+          decimals: number;
+        } =>
+          'address' in t &&
+          typeof (t as unknown as Record<string, unknown>).address ===
+            'string' &&
+          'decimals' in t,
+      );
+    } catch {
+      try {
+        const res = await fetch(
+          `${process.env.PROXY_URL}/tokens?evmChainId=${network.chainId}`,
+        );
+        return res.ok ? await res.json() : [];
+      } catch {
+        return [];
+      }
+    }
+  }
 
   async getBalancesForNetwork(
     network: NetworkWithCaipId,
@@ -120,40 +251,83 @@ export class BalancesService {
       storage: cacheStorage,
     });
 
-    // Apply price changes data, VM Modules don't do this yet
+    // Workaround: Glacier/Debank may claim to support testnets like Sepolia
+    // but return empty ERC20 results. When ERC20 was requested but no ERC20
+    // tokens were returned, fetch them directly via RPC balanceOf calls.
+    if (
+      network.isTestnet &&
+      network.vmName === NetworkVMType.EVM &&
+      tokenTypes.includes(TokenType.ERC20)
+    ) {
+      await this.#fillMissingErc20Balances(
+        rawBalances,
+        network,
+        module,
+        Array.from(addressesToFetch),
+      );
+    }
+
+    // Apply price changes data, VM Modules don't do this yet.
+    // Note: rawBalances may contain an account-level `error` property
+    // (e.g. when listErc20Balances fails but getNativeBalance succeeds).
+    // We must NOT skip the entire account in that case — instead we
+    // process individual tokens and only skip entries that are errors.
     const balances = Object.keys(rawBalances).reduce(
       (
         accountBalances,
         accountKey,
       ): Record<string, Record<string, TokenWithBalance>> => {
         const rawAccountTokenList = rawBalances[accountKey];
-        if (!rawAccountTokenList || rawAccountTokenList?.error) {
+        if (!rawAccountTokenList) {
+          return accountBalances;
+        }
+
+        if (rawAccountTokenList.error) {
+          console.warn(
+            `BalancesService: Partial failure for ${accountKey} on ${network.caipId}:`,
+            rawAccountTokenList.error,
+          );
+        }
+
+        const accountTokens = Object.keys(rawAccountTokenList).reduce(
+          (tokens, tokenKey): Record<string, TokenWithBalance> => {
+            if (tokenKey === 'error') {
+              return tokens;
+            }
+
+            const tokenBalance = rawAccountTokenList[tokenKey];
+            if (!tokenBalance || tokenBalance?.error) {
+              if (tokenBalance?.error) {
+                console.warn(
+                  `BalancesService: Skipping token ${tokenKey} on ${network.caipId}:`,
+                  tokenBalance.error,
+                );
+              }
+              return tokens;
+            }
+
+            return {
+              ...tokens,
+              [tokenKey]: {
+                ...tokenBalance,
+                priceChanges: getPriceChangeValues(
+                  tokenBalance.symbol,
+                  tokenBalance.balanceInCurrency,
+                  priceChanges,
+                ),
+              },
+            };
+          },
+          {},
+        );
+
+        if (Object.keys(accountTokens).length === 0) {
           return accountBalances;
         }
 
         return {
           ...accountBalances,
-          [accountKey]: Object.keys(rawAccountTokenList).reduce(
-            (tokens, tokenKey): Record<string, TokenWithBalance> => {
-              const tokenBalance = rawAccountTokenList[tokenKey];
-              if (tokenBalance?.error) {
-                return tokens;
-              }
-
-              return {
-                ...tokens,
-                [tokenKey]: {
-                  ...tokenBalance,
-                  priceChanges: getPriceChangeValues(
-                    tokenBalance.symbol,
-                    tokenBalance.balanceInCurrency,
-                    priceChanges,
-                  ),
-                },
-              };
-            },
-            {},
-          ),
+          [accountKey]: accountTokens,
         };
       },
       {},

--- a/packages/service-worker/src/services/balances/BalancesService.ts
+++ b/packages/service-worker/src/services/balances/BalancesService.ts
@@ -115,20 +115,29 @@ export class BalancesService {
           const tokenKey = tokenAddr.toLowerCase();
           if (PROTO_POLLUTION_KEYS.has(tokenKey)) continue;
 
-          (rawBalances[address] as Record<string, TokenWithBalance>)[tokenKey] =
-            {
-              type: TokenType.ERC20,
-              address: tokenAddr,
-              name,
-              symbol,
-              decimals,
-              balance,
-              balanceDisplayValue: ethers.formatUnits(balance, decimals),
-              balanceInCurrency: undefined,
-              balanceCurrencyDisplayValue: '',
-              priceInCurrency: undefined,
-              reputation: null,
-            } as unknown as TokenWithBalance;
+          const accountBalances = rawBalances[address] as Record<
+            string,
+            TokenWithBalance
+          >;
+          const safeAccountBalances =
+            Object.getPrototypeOf(accountBalances) === null
+              ? accountBalances
+              : Object.assign(Object.create(null), accountBalances);
+          rawBalances[address] = safeAccountBalances as unknown as GetBalancesResponse[string];
+
+          safeAccountBalances[tokenKey] = {
+            type: TokenType.ERC20,
+            address: tokenAddr,
+            name,
+            symbol,
+            decimals,
+            balance,
+            balanceDisplayValue: ethers.formatUnits(balance, decimals),
+            balanceInCurrency: undefined,
+            balanceCurrencyDisplayValue: '',
+            priceInCurrency: undefined,
+            reputation: null,
+          } as unknown as TokenWithBalance;
         }
       } catch (err) {
         console.warn(


### PR DESCRIPTION
## Description

Sepolia ERC20 tokens (USDC, LINK, WETH) were not displaying in the extension despite the token list being fetched successfully. The root cause is in `@avalabs/evm-module`: its internal balance provider selector picks Glacier/Debank for Sepolia (they claim `isNetworkSupported = true`) but those services return empty ERC20 results. The RPC fallback — which would actually call `balanceOf` and work — never runs.

This PR adds a workaround in `BalancesService` that detects missing ERC20 data on EVM testnets and fetches balances directly via individual RPC `balanceOf` calls.

## Changes

- **`BalancesService`**: Added `#fillMissingErc20Balances` — after `module.getBalances()` returns, checks if ERC20 tokens were requested but none returned. If so, fetches the token list via `module.getTokens()` and calls `balanceOf()` individually per token using `Promise.allSettled`.
- **`BalancesService`**: Added `#fetchErc20TokenList` helper that retrieves the ERC20 token list from the module (or falls back to the proxy API).
- Scoped to **EVM testnets only** (`network.isTestnet && vmName === EVM`) so mainnet flows are unaffected.

## Testing

- [x] Switch to Sepolia network and verify ERC20 tokens (USDC, LINK, WETH) display with correct balances.
- [x] Verify native Sepolia ETH balance continues to display correctly.
- [x] Verify mainnet EVM networks (Ethereum, Avalanche C-Chain) are unaffected.
- [x] Verify other testnets (Fuji) are unaffected.

## Screenshots:

## Checklist for the author

- [x] I've covered new/modified business logic with Jest test cases.
- [ ] I've tested the changes myself before sending it to code review and QA.
