### PR TITLE
fix(networks): show custom network tokens immediately after adding

### DIFF
--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -629,6 +629,32 @@ describe('background/services/network/NetworkService', () => {
         'customRpcHeaders' in networkWithoutHeaders,
       );
     });
+
+    it('enables the new chainId BEFORE dispatching the chainlist update', async () => {
+      // Regression test: `_allNetworks.dispatch` is what triggers
+      // `NETWORKS_UPDATED_EVENT` to the UI. If we dispatched before
+      // `enableNetwork` ran, the event would carry a stale `enabledNetworks`
+      // list and balances for the just-added network would not be polled
+      // until the user toggled it manually.
+      const enabledAtDispatch: number[][] = [];
+      const allNetworks = service['_allNetworks'];
+      const originalDispatch = allNetworks.dispatch.bind(allNetworks);
+      const spy = jest
+        .spyOn(allNetworks, 'dispatch')
+        .mockImplementation((value) => {
+          enabledAtDispatch.push([...service['_enabledNetworks']]);
+          originalDispatch(value);
+        });
+
+      try {
+        await service.saveCustomNetwork(customNetwork);
+
+        expect(enabledAtDispatch).toHaveLength(1);
+        expect(enabledAtDispatch[0]).toContain(customNetwork.chainId);
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
   describe('when chain list is not available through Glacier', () => {
     beforeEach(() => {

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -639,13 +639,19 @@ export class NetworkService implements OnLock, OnStorageReady {
       [chainId]: customNetwork,
     };
 
+    // Auto-favorite the new network BEFORE announcing the chainlist update.
+    // `_allNetworks.dispatch` is what triggers `NETWORKS_UPDATED_EVENT` (via
+    // the `activeNetworks` signal). If we dispatched first, the event would
+    // carry a stale `enabledNetworks` list — without the new chainId — and
+    // the UI would not poll balances for it until the user toggled it
+    // manually. Enabling first makes the single subsequent event carry the
+    // correct state for every consumer (UI balances, network state, etc.).
+    await this.enableNetwork(chainId);
+
     this._allNetworks.dispatch({
       ...chainlist,
       ...this._customNetworks,
     });
-
-    // Automatically favorite the newly added network
-    await this.enableNetwork(chainId);
 
     return customNetwork;
   }
@@ -714,10 +720,12 @@ export class NetworkService implements OnLock, OnStorageReady {
       delete chainlist[chainID];
     }
 
-    // Update the lsit of all networks.
-    this._allNetworks.dispatch({ ...chainlist, ...this._customNetworks });
+    // Disable BEFORE announcing the chainlist update so the resulting
+    // `NETWORKS_UPDATED_EVENT` carries the correct `enabledNetworks`. See
+    // `saveCustomNetwork` for the same ordering rationale.
+    await this.disableNetwork(chainID);
 
-    // Switch to Avalanache Mainnet or Fuji if the active network was removed.
+    // Switch to Avalanche Mainnet or Fuji if the active network was removed.
     if (this.uiActiveNetwork?.chainId === chainID) {
       const network = await this.getNetwork(
         wasTestnet
@@ -730,7 +738,7 @@ export class NetworkService implements OnLock, OnStorageReady {
       }
     }
 
-    await this.disableNetwork(chainID);
+    this._allNetworks.dispatch({ ...chainlist, ...this._customNetworks });
   }
 
   async getUnknownUsedNetwork(addressC: string) {


### PR DESCRIPTION
## Description

When a user adds a custom EVM network, its native and ERC-20 tokens did not show up on the Portfolio page until the user manually toggled the network off and back on in Settings → Networks.

This was a dispatch-ordering bug in `NetworkService`. `saveCustomNetwork` (and symmetrically `removeCustomNetwork`) ran:

1. `_allNetworks.dispatch(...)` — which is what feeds the `activeNetworks` signal that `NetworksUpdatedEvents` listens to and re-emits as `NETWORKS_UPDATED_EVENT` to the UI.
2. `enableNetwork(chainId)` / `disableNetwork(chainId)` — which actually updates `_enabledNetworks`.

Because step 1 happens first, the single `NETWORKS_UPDATED_EVENT` the UI receives carries a **stale** `enabledNetworks` list (without the new chainId). The UI's `NetworkProvider` keeps the old list, `BalancesProvider` polls the wrong chainIds, and the new network's tokens never arrive — until the user toggles the network manually, which fires `enableNetwork` again and re-syncs state.

## Changes

Reorder the operations in `NetworkService` so the enabled-networks list is up to date by the time we announce the chainlist change:

- `saveCustomNetwork`: `enableNetwork(chainId)` now runs **before** `_allNetworks.dispatch(...)`.
- `removeCustomNetwork`: `disableNetwork(chainID)` now runs **before** `_allNetworks.dispatch(...)`.
- Adds a regression test asserting the ordering invariant: at the moment `_allNetworks.dispatch` is called, `_enabledNetworks` already reflects the change.

The single existing event emit now carries correct state for every downstream consumer (UI balances, network state handlers, e2e snapshots, etc.) — no new subscriptions, no extra emit paths, no UI changes.


## Testing

> Note: on **dev builds** the same scenario can still appear empty for some networks because `glacier-api-dev.avax.network` does not have balance data for every chain (e.g. Monad). Test against a chain the dev API supports, or use an alpha/prod build to verify the fix end-to-end.


## Screenshots


## Checklist for the author

Tick each of them when done or if not applicable.

- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
