### PR TITLE
fix: approval button race condition

### DIFF
--- a/apps/next/src/pages/Approve/BatchApprovalScreen.tsx
+++ b/apps/next/src/pages/Approve/BatchApprovalScreen.tsx
@@ -26,6 +26,7 @@ import {
   NoteWarning,
   Styled,
 } from './components';
+import { TxDataUpdateProvider, useTxDataUpdate } from './contexts';
 import { useApprovalHelpers } from './hooks';
 import { hasNoteWarning, hasOverlayWarning } from './lib';
 import { CancelActionFn, UpdateActionFn, ActionError } from './types';
@@ -67,6 +68,7 @@ const BatchApprovalContent: FC<BatchApprovalContentProps> = ({
   useLiveBalance(POLLED_BALANCES);
 
   const { isUsingHardwareWallet, deviceType } = useIsUsingHardwareWallet();
+  const { isUpdating: isUpdatingTxData } = useTxDataUpdate();
 
   const approve = useCallback(async () => {
     updateAction(
@@ -163,6 +165,7 @@ const BatchApprovalContent: FC<BatchApprovalContentProps> = ({
           approve={handleApproval}
           reject={handleRejection}
           isProcessing={isProcessing}
+          isDisabled={isUpdatingTxData}
           withConfirmationSwitch={hasOverlayWarning(action)}
         />
       </NoScrollStack>
@@ -224,12 +227,14 @@ export const BatchApprovalScreen = () => {
   }
 
   return (
-    <BatchApprovalContent
-      action={action}
-      network={network}
-      updateAction={updateAction}
-      cancelHandler={cancelHandler}
-      error={error}
-    />
+    <TxDataUpdateProvider>
+      <BatchApprovalContent
+        action={action}
+        network={network}
+        updateAction={updateAction}
+        cancelHandler={cancelHandler}
+        error={error}
+      />
+    </TxDataUpdateProvider>
   );
 };

--- a/apps/next/src/pages/Approve/TransactionApprovalScreen.tsx
+++ b/apps/next/src/pages/Approve/TransactionApprovalScreen.tsx
@@ -19,6 +19,7 @@ import {
   NoteWarning,
   Styled,
 } from './components';
+import { TxDataUpdateProvider, useTxDataUpdate } from './contexts';
 import { useApprovalHelpers, useGasless } from './hooks';
 import { hasNoteWarning, hasOverlayWarning } from './lib';
 import {
@@ -38,7 +39,15 @@ type TransactionApprovalScreenProps = {
   error: ActionError;
 };
 
-export const TransactionApprovalScreen: FC<TransactionApprovalScreenProps> = ({
+export const TransactionApprovalScreen: FC<TransactionApprovalScreenProps> = (
+  props,
+) => (
+  <TxDataUpdateProvider>
+    <TransactionApprovalScreenContent {...props} />
+  </TxDataUpdateProvider>
+);
+
+const TransactionApprovalScreenContent: FC<TransactionApprovalScreenProps> = ({
   action,
   network,
   updateAction,
@@ -51,6 +60,7 @@ export const TransactionApprovalScreen: FC<TransactionApprovalScreenProps> = ({
   useLiveBalance(POLLED_BALANCES);
 
   const { isUsingHardwareWallet, deviceType } = useIsUsingHardwareWallet();
+  const { isUpdating: isUpdatingTxData } = useTxDataUpdate();
 
   const { tryFunding, setGaslessDefaultValues, gaslessPhase } = useGasless({
     action,
@@ -123,6 +133,7 @@ export const TransactionApprovalScreen: FC<TransactionApprovalScreenProps> = ({
           approve={() => tryFunding(handleApproval)}
           reject={handleRejection}
           isProcessing={isProcessing}
+          isDisabled={isUpdatingTxData}
           withConfirmationSwitch={hasOverlayWarning(action)}
         />
       </NoScrollStack>

--- a/apps/next/src/pages/Approve/components/ActionDetails/btc/components/BtcNetworkFeeWidget/hooks/useBtcTransactionFee/useBtcTransactionFee.tsx
+++ b/apps/next/src/pages/Approve/components/ActionDetails/btc/components/BtcNetworkFeeWidget/hooks/useBtcTransactionFee/useBtcTransactionFee.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { ExtensionRequest } from '@core/types';
 import { useConnectionContext } from '@core/ui';
@@ -69,9 +69,8 @@ export const useBtcTransactionFee: UseBtcTransactionFee = ({
     [networkFee, updateFee],
   );
 
-  const needsInitialFeeRate = useRef<boolean>(!getInitialFeeRate(signingData));
-  const [hasInitializedFeeRate, setHasInitializedFeeRate] = useState(
-    !needsInitialFeeRate.current,
+  const [hasInitializedFeeRate, setHasInitializedFeeRate] = useState(() =>
+    Boolean(getInitialFeeRate(signingData)),
   );
 
   // Keep approval blocked until the initial fee rate has been pushed to the

--- a/apps/next/src/pages/Approve/components/ActionDetails/btc/components/BtcNetworkFeeWidget/hooks/useBtcTransactionFee/useBtcTransactionFee.tsx
+++ b/apps/next/src/pages/Approve/components/ActionDetails/btc/components/BtcNetworkFeeWidget/hooks/useBtcTransactionFee/useBtcTransactionFee.tsx
@@ -9,6 +9,10 @@ import { DEFAULT_FEE_PRESET } from '@/config';
 import { useNativeToken } from '@/hooks/useNativeToken';
 import { useUpdateAccountBalance } from '@/hooks/useUpdateAccountBalance';
 import { useCurrentFeesForNetwork } from '@/hooks/useCurrentFeesForNetwork';
+import {
+  usePendingTxDataUpdate,
+  useTxDataUpdate,
+} from '@/pages/Approve/contexts';
 
 import { BtcFeePreset } from '../../types';
 import { BtcTxSigningData, UseBtcTransactionFee } from './types';
@@ -21,6 +25,7 @@ export const useBtcTransactionFee: UseBtcTransactionFee = ({
   useUpdateAccountBalance(network);
 
   const { request } = useConnectionContext();
+  const { trackTxDataUpdate } = useTxDataUpdate();
 
   const networkFee = useCurrentFeesForNetwork(network);
   const nativeToken = useNativeToken({ network });
@@ -41,12 +46,14 @@ export const useBtcTransactionFee: UseBtcTransactionFee = ({
         return;
       }
 
-      await request<UpdateActionTxDataHandler>({
-        method: ExtensionRequest.ACTION_UPDATE_TX_DATA,
-        params: [action.actionId, { feeRate: Number(feeRate) }],
-      });
+      await trackTxDataUpdate(
+        request<UpdateActionTxDataHandler>({
+          method: ExtensionRequest.ACTION_UPDATE_TX_DATA,
+          params: [action.actionId, { feeRate: Number(feeRate) }],
+        }),
+      );
     },
-    [action?.actionId, request],
+    [action?.actionId, request, trackTxDataUpdate],
   );
 
   const choosePreset = useCallback(
@@ -62,16 +69,28 @@ export const useBtcTransactionFee: UseBtcTransactionFee = ({
     [networkFee, updateFee],
   );
 
-  const initialFeeRate = useRef<bigint | undefined>(
-    getInitialFeeRate(signingData),
+  const needsInitialFeeRate = useRef<boolean>(!getInitialFeeRate(signingData));
+  const [hasInitializedFeeRate, setHasInitializedFeeRate] = useState(
+    !needsInitialFeeRate.current,
   );
 
+  // Keep approval blocked until the initial fee rate has been pushed to the
+  // service worker. Otherwise the user could submit the action while we're
+  // still about to dispatch the first ACTION_UPDATE_TX_DATA call.
+  usePendingTxDataUpdate(!hasInitializedFeeRate);
+
   useEffect(() => {
-    // If the dapp did not provide us any fee rate, we must initialize it ourselves.
-    if (!initialFeeRate.current) {
-      choosePreset(DEFAULT_FEE_PRESET);
+    if (hasInitializedFeeRate) {
+      return;
     }
-  }, [networkFee, choosePreset]);
+    if (!networkFee) {
+      return;
+    }
+
+    choosePreset(DEFAULT_FEE_PRESET).finally(() => {
+      setHasInitializedFeeRate(true);
+    });
+  }, [hasInitializedFeeRate, networkFee, choosePreset]);
 
   if (!networkFee || !nativeToken || !signingData) {
     return {

--- a/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmNetworkFeeWidget/hooks/useEvmTransactionFee/useEvmTransactionFee.tsx
+++ b/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmNetworkFeeWidget/hooks/useEvmTransactionFee/useEvmTransactionFee.tsx
@@ -8,6 +8,10 @@ import { calculateGasAndFees } from '@core/common';
 import { useNativeToken } from '@/hooks/useNativeToken';
 import { useUpdateAccountBalance } from '@/hooks/useUpdateAccountBalance';
 import { useCurrentFeesForNetwork } from '@/hooks/useCurrentFeesForNetwork';
+import {
+  usePendingTxDataUpdate,
+  useTxDataUpdate,
+} from '@/pages/Approve/contexts';
 
 import { EvmFeePreset, EvmGasSettings } from '../../types';
 import { getFeeInfo, getInitialFeeRate, hasEnoughForFee } from './lib';
@@ -21,6 +25,7 @@ export const useEvmTransactionFee: UseEvmTransactionFee = ({
   useUpdateAccountBalance(network);
 
   const { request } = useConnectionContext();
+  const { trackTxDataUpdate } = useTxDataUpdate();
 
   const networkFee = useCurrentFeesForNetwork(network);
   const nativeToken = useNativeToken({ network });
@@ -45,12 +50,14 @@ export const useEvmTransactionFee: UseEvmTransactionFee = ({
         return;
       }
 
-      await request<UpdateActionTxDataHandler>({
-        method: ExtensionRequest.ACTION_UPDATE_TX_DATA,
-        params: [action.actionId, { maxFeeRate, maxTipRate, gasLimit }],
-      });
+      await trackTxDataUpdate(
+        request<UpdateActionTxDataHandler>({
+          method: ExtensionRequest.ACTION_UPDATE_TX_DATA,
+          params: [action.actionId, { maxFeeRate, maxTipRate, gasLimit }],
+        }),
+      );
     },
-    [action?.actionId, request],
+    [action?.actionId, request, trackTxDataUpdate],
   );
 
   useEffect(() => {
@@ -92,16 +99,28 @@ export const useEvmTransactionFee: UseEvmTransactionFee = ({
     [networkFee, updateFee],
   );
 
-  const initialFeeRate = useRef<bigint | undefined>(
-    getInitialFeeRate(signingData),
+  const needsInitialFeeRate = useRef<boolean>(!getInitialFeeRate(signingData));
+  const [hasInitializedFeeRate, setHasInitializedFeeRate] = useState(
+    !needsInitialFeeRate.current,
   );
 
+  // Keep approval blocked until the initial fee rate has been pushed to the
+  // service worker. Otherwise the user could submit the action while we're
+  // still about to dispatch the first ACTION_UPDATE_TX_DATA call.
+  usePendingTxDataUpdate(!hasInitializedFeeRate);
+
   useEffect(() => {
-    // If the dapp did not give us any fee rate, we must initialize it ourselves.
-    if (!initialFeeRate.current) {
-      choosePreset(getDefaultFeePreset(network));
+    if (hasInitializedFeeRate) {
+      return;
     }
-  }, [networkFee, choosePreset, network]);
+    if (!networkFee) {
+      return;
+    }
+
+    choosePreset(getDefaultFeePreset(network)).finally(() => {
+      setHasInitializedFeeRate(true);
+    });
+  }, [hasInitializedFeeRate, networkFee, choosePreset, network]);
 
   if (!networkFee || !nativeToken || !signingData || !customPreset) {
     return {

--- a/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmNetworkFeeWidget/hooks/useEvmTransactionFee/useEvmTransactionFee.tsx
+++ b/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmNetworkFeeWidget/hooks/useEvmTransactionFee/useEvmTransactionFee.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useConnectionContext } from '@core/ui';
 import { ExtensionRequest } from '@core/types';
@@ -99,9 +99,8 @@ export const useEvmTransactionFee: UseEvmTransactionFee = ({
     [networkFee, updateFee],
   );
 
-  const needsInitialFeeRate = useRef<boolean>(!getInitialFeeRate(signingData));
-  const [hasInitializedFeeRate, setHasInitializedFeeRate] = useState(
-    !needsInitialFeeRate.current,
+  const [hasInitializedFeeRate, setHasInitializedFeeRate] = useState(() =>
+    Boolean(getInitialFeeRate(signingData)),
   );
 
   // Keep approval blocked until the initial fee rate has been pushed to the

--- a/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmTokenApprovals/components/CustomApprovalLimit.tsx
+++ b/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmTokenApprovals/components/CustomApprovalLimit.tsx
@@ -7,6 +7,8 @@ import { useConnectionContext } from '@core/ui';
 import type { UpdateActionTxDataHandler } from '@core/service-worker';
 import { Action, EnsureDefined, ExtensionRequest } from '@core/types';
 
+import { useTxDataUpdate } from '@/pages/Approve/contexts';
+
 import { DetailsSection } from '../../../generic/DetailsSection';
 import { TxDetailsRow } from '../../../generic/DetailsItem/items/DetailRow';
 
@@ -31,6 +33,7 @@ export const CustomApprovalLimit: FC<CustomApprovalLimitProps> = ({
 }) => {
   const { t } = useTranslation();
   const { request } = useConnectionContext();
+  const { trackTxDataUpdate } = useTxDataUpdate();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const { tokenValue } = approvalValue;
@@ -46,14 +49,16 @@ export const CustomApprovalLimit: FC<CustomApprovalLimitProps> = ({
     const limitAmount =
       spendLimit.type === 'unlimited' ? MaxUint256 : (spendLimit.value ?? 0n);
 
-    request<UpdateActionTxDataHandler>({
-      method: ExtensionRequest.ACTION_UPDATE_TX_DATA,
-      params: [
-        action.actionId,
-        { approvalLimit: `0x${limitAmount.toString(16)}` },
-      ],
-    });
-  }, [request, action.actionId, spendLimit]);
+    trackTxDataUpdate(
+      request<UpdateActionTxDataHandler>({
+        method: ExtensionRequest.ACTION_UPDATE_TX_DATA,
+        params: [
+          action.actionId,
+          { approvalLimit: `0x${limitAmount.toString(16)}` },
+        ],
+      }),
+    );
+  }, [request, action.actionId, spendLimit, trackTxDataUpdate]);
 
   const handleSave = () => {
     setIsDialogOpen(false);

--- a/apps/next/src/pages/Approve/contexts/TxDataUpdateContext.test.tsx
+++ b/apps/next/src/pages/Approve/contexts/TxDataUpdateContext.test.tsx
@@ -1,0 +1,231 @@
+import { ReactNode } from 'react';
+import { render, renderHook, act, waitFor } from '@testing-library/react';
+
+import {
+  TxDataUpdateProvider,
+  useTxDataUpdate,
+  usePendingTxDataUpdate,
+} from './TxDataUpdateContext';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <TxDataUpdateProvider>{children}</TxDataUpdateProvider>
+);
+
+describe('TxDataUpdateContext', () => {
+  describe('useTxDataUpdate', () => {
+    it('throws when used outside of TxDataUpdateProvider', () => {
+      const consoleError = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      expect(() => renderHook(() => useTxDataUpdate())).toThrow(
+        'useTxDataUpdate must be used within a TxDataUpdateProvider',
+      );
+
+      consoleError.mockRestore();
+    });
+
+    it('starts with isUpdating set to false', () => {
+      const { result } = renderHook(() => useTxDataUpdate(), { wrapper });
+
+      expect(result.current.isUpdating).toBe(false);
+    });
+  });
+
+  describe('trackTxDataUpdate', () => {
+    it('marks the context as updating while the promise is pending and clears it on resolve', async () => {
+      const { result } = renderHook(() => useTxDataUpdate(), { wrapper });
+
+      let resolve: (value: string) => void = () => undefined;
+      const pending = new Promise<string>((res) => {
+        resolve = res;
+      });
+
+      let tracked: Promise<string> | undefined;
+      act(() => {
+        tracked = result.current.trackTxDataUpdate(pending);
+      });
+
+      expect(result.current.isUpdating).toBe(true);
+
+      await act(async () => {
+        resolve('done');
+        await tracked;
+      });
+
+      expect(result.current.isUpdating).toBe(false);
+      await expect(tracked).resolves.toBe('done');
+    });
+
+    it('clears isUpdating when the tracked promise rejects and re-throws the error', async () => {
+      const { result } = renderHook(() => useTxDataUpdate(), { wrapper });
+
+      const error = new Error('boom');
+      let reject: (reason: Error) => void = () => undefined;
+      const pending = new Promise<string>((_, rej) => {
+        reject = rej;
+      });
+
+      let tracked: Promise<string> | undefined;
+      act(() => {
+        tracked = result.current.trackTxDataUpdate(pending);
+      });
+
+      expect(result.current.isUpdating).toBe(true);
+
+      await act(async () => {
+        reject(error);
+        await tracked?.catch(() => undefined);
+      });
+
+      expect(result.current.isUpdating).toBe(false);
+      await expect(tracked).rejects.toBe(error);
+    });
+
+    it('stays updating until all concurrent tracked promises settle', async () => {
+      const { result } = renderHook(() => useTxDataUpdate(), { wrapper });
+
+      let resolveA: () => void = () => undefined;
+      let resolveB: () => void = () => undefined;
+      const a = new Promise<void>((res) => {
+        resolveA = res;
+      });
+      const b = new Promise<void>((res) => {
+        resolveB = res;
+      });
+
+      let trackedA: Promise<void> | undefined;
+      let trackedB: Promise<void> | undefined;
+      act(() => {
+        trackedA = result.current.trackTxDataUpdate(a);
+        trackedB = result.current.trackTxDataUpdate(b);
+      });
+
+      expect(result.current.isUpdating).toBe(true);
+
+      await act(async () => {
+        resolveA();
+        await trackedA;
+      });
+
+      expect(result.current.isUpdating).toBe(true);
+
+      await act(async () => {
+        resolveB();
+        await trackedB;
+      });
+
+      expect(result.current.isUpdating).toBe(false);
+    });
+  });
+
+  describe('registerPendingTxDataUpdate', () => {
+    it('marks the context as updating until the cleanup runs', () => {
+      const { result } = renderHook(() => useTxDataUpdate(), { wrapper });
+
+      let release: (() => void) | undefined;
+      act(() => {
+        release = result.current.registerPendingTxDataUpdate();
+      });
+
+      expect(result.current.isUpdating).toBe(true);
+
+      act(() => {
+        release?.();
+      });
+
+      expect(result.current.isUpdating).toBe(false);
+    });
+
+    it('ignores subsequent cleanup calls so the count cannot be over-decremented', () => {
+      const { result } = renderHook(() => useTxDataUpdate(), { wrapper });
+
+      let releaseFirst: (() => void) | undefined;
+      let releaseSecond: (() => void) | undefined;
+      act(() => {
+        releaseFirst = result.current.registerPendingTxDataUpdate();
+        releaseSecond = result.current.registerPendingTxDataUpdate();
+      });
+
+      expect(result.current.isUpdating).toBe(true);
+
+      act(() => {
+        releaseFirst?.();
+        releaseFirst?.();
+      });
+
+      expect(result.current.isUpdating).toBe(true);
+
+      act(() => {
+        releaseSecond?.();
+      });
+
+      expect(result.current.isUpdating).toBe(false);
+    });
+  });
+
+  describe('usePendingTxDataUpdate', () => {
+    it('does not mark the context as updating when isPending is false', () => {
+      const { result } = renderHook(
+        () => {
+          usePendingTxDataUpdate(false);
+          return useTxDataUpdate();
+        },
+        { wrapper },
+      );
+
+      expect(result.current.isUpdating).toBe(false);
+    });
+
+    it('marks the context as updating while isPending is true and clears it when it flips back', async () => {
+      const { result, rerender } = renderHook(
+        ({ isPending }: { isPending: boolean }) => {
+          usePendingTxDataUpdate(isPending);
+          return useTxDataUpdate();
+        },
+        { wrapper, initialProps: { isPending: true } },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isUpdating).toBe(true);
+      });
+
+      rerender({ isPending: false });
+
+      await waitFor(() => {
+        expect(result.current.isUpdating).toBe(false);
+      });
+    });
+
+    it('releases the pending registration when the consuming component unmounts', async () => {
+      const PendingChild = () => {
+        usePendingTxDataUpdate(true);
+        return null;
+      };
+
+      const Status = () => {
+        const { isUpdating } = useTxDataUpdate();
+        return <div data-testid="status">{String(isUpdating)}</div>;
+      };
+
+      const Tree = ({ showChild }: { showChild: boolean }) => (
+        <TxDataUpdateProvider>
+          <Status />
+          {showChild && <PendingChild />}
+        </TxDataUpdateProvider>
+      );
+
+      const { getByTestId, rerender } = render(<Tree showChild />);
+
+      await waitFor(() => {
+        expect(getByTestId('status').textContent).toBe('true');
+      });
+
+      rerender(<Tree showChild={false} />);
+
+      await waitFor(() => {
+        expect(getByTestId('status').textContent).toBe('false');
+      });
+    });
+  });
+});

--- a/apps/next/src/pages/Approve/contexts/TxDataUpdateContext.tsx
+++ b/apps/next/src/pages/Approve/contexts/TxDataUpdateContext.tsx
@@ -1,0 +1,108 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+type TxDataUpdateContextValue = {
+  /**
+   * True while at least one descendant has a pending tx-data update
+   * (either an in-flight `ACTION_UPDATE_TX_DATA` request, or a known-pending
+   * initial update that hasn't been dispatched yet).
+   *
+   * Approval screens use this to keep the Approve button disabled so the user
+   * cannot submit the action with stale signing data.
+   */
+  isUpdating: boolean;
+  /**
+   * Wraps an async tx-data update so the provider can count it as in-flight
+   * until it settles.
+   */
+  trackTxDataUpdate: <T>(promise: Promise<T>) => Promise<T>;
+  /**
+   * Marks the context as "updating" until the returned cleanup runs. Useful
+   * when a hook knows on mount that an update will be dispatched on a later
+   * render, before any promise actually exists to track.
+   */
+  registerPendingTxDataUpdate: () => () => void;
+};
+
+const TxDataUpdateContext = createContext<TxDataUpdateContextValue | null>(
+  null,
+);
+
+export const TxDataUpdateProvider = ({ children }: { children: ReactNode }) => {
+  const [pendingCount, setPendingCount] = useState(0);
+
+  const increment = useCallback(() => {
+    setPendingCount((count) => count + 1);
+  }, []);
+
+  const decrement = useCallback(() => {
+    setPendingCount((count) => Math.max(0, count - 1));
+  }, []);
+
+  const trackTxDataUpdate = useCallback(
+    <T,>(promise: Promise<T>): Promise<T> => {
+      increment();
+      return promise.finally(decrement);
+    },
+    [increment, decrement],
+  );
+
+  const registerPendingTxDataUpdate = useCallback(() => {
+    increment();
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      decrement();
+    };
+  }, [increment, decrement]);
+
+  const value = useMemo<TxDataUpdateContextValue>(
+    () => ({
+      isUpdating: pendingCount > 0,
+      trackTxDataUpdate,
+      registerPendingTxDataUpdate,
+    }),
+    [pendingCount, trackTxDataUpdate, registerPendingTxDataUpdate],
+  );
+
+  return (
+    <TxDataUpdateContext.Provider value={value}>
+      {children}
+    </TxDataUpdateContext.Provider>
+  );
+};
+
+export const useTxDataUpdate = (): TxDataUpdateContextValue => {
+  const context = useContext(TxDataUpdateContext);
+
+  if (!context) {
+    throw new Error(
+      'useTxDataUpdate must be used within a TxDataUpdateProvider',
+    );
+  }
+
+  return context;
+};
+
+/**
+ * Marks the context as "updating" for as long as `isPending` is true.
+ * Use this when a hook can already tell during render that an update is
+ * required but the actual request hasn't been dispatched yet (e.g. waiting
+ * for a dependency to load).
+ */
+export const usePendingTxDataUpdate = (isPending: boolean) => {
+  const { registerPendingTxDataUpdate } = useTxDataUpdate();
+
+  useEffect(() => {
+    if (!isPending) return;
+    return registerPendingTxDataUpdate();
+  }, [isPending, registerPendingTxDataUpdate]);
+};

--- a/apps/next/src/pages/Approve/contexts/index.ts
+++ b/apps/next/src/pages/Approve/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './TxDataUpdateContext';


### PR DESCRIPTION
* https://ava-labs.atlassian.net/browse/CP-14175

## Description
TL;DR: Disables the "Approve" button until the transaction's fee data is populated.

## Changes
Due to the `useEvmTransactionFee` and `useBtcTransactionFee` hooks being nested deeper in the specialized components than the generic drawer with approve/reject buttons, a context is introduced to track the state of transaction data being ready to dispatch.

## Testing
1. Go to https://core.app
2. Go to Send
3. Initiate an EVM send
4. The "Approve" button should stay disabled for a brief moment to allow the transaction data to get populated.

## Screenshots:
_I added a bit of an artificial delay when recording both screencasts to easily reproduce the race condition_

### Before

https://github.com/user-attachments/assets/33ecfed1-e4e0-4082-9352-5b141a69d7c7

### After

https://github.com/user-attachments/assets/8a8d377c-ccdc-4f0c-9d57-0c0b66e4be22



## Checklist for the author
- [ ] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
