### PR TITLE
chore(network): shorten custom-network dispatch comments

### DIFF
--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -631,11 +631,7 @@ describe('background/services/network/NetworkService', () => {
     });
 
     it('enables the new chainId BEFORE dispatching the chainlist update', async () => {
-      // Regression test: `_allNetworks.dispatch` is what triggers
-      // `NETWORKS_UPDATED_EVENT` to the UI. If we dispatched before
-      // `enableNetwork` ran, the event would carry a stale `enabledNetworks`
-      // list and balances for the just-added network would not be polled
-      // until the user toggled it manually.
+      // Ensure the chain is enabled before dispatching network updates.
       const enabledAtDispatch: number[][] = [];
       const allNetworks = service['_allNetworks'];
       const originalDispatch = allNetworks.dispatch.bind(allNetworks);

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -639,13 +639,7 @@ export class NetworkService implements OnLock, OnStorageReady {
       [chainId]: customNetwork,
     };
 
-    // Auto-favorite the new network BEFORE announcing the chainlist update.
-    // `_allNetworks.dispatch` is what triggers `NETWORKS_UPDATED_EVENT` (via
-    // the `activeNetworks` signal). If we dispatched first, the event would
-    // carry a stale `enabledNetworks` list — without the new chainId — and
-    // the UI would not poll balances for it until the user toggled it
-    // manually. Enabling first makes the single subsequent event carry the
-    // correct state for every consumer (UI balances, network state, etc.).
+    // Enable first so the networks update event includes the new chainId.
     await this.enableNetwork(chainId);
 
     this._allNetworks.dispatch({
@@ -720,9 +714,7 @@ export class NetworkService implements OnLock, OnStorageReady {
       delete chainlist[chainID];
     }
 
-    // Disable BEFORE announcing the chainlist update so the resulting
-    // `NETWORKS_UPDATED_EVENT` carries the correct `enabledNetworks`. See
-    // `saveCustomNetwork` for the same ordering rationale.
+    // Disable first so the networks update event carries the right state.
     await this.disableNetwork(chainID);
 
     // Switch to Avalanche Mainnet or Fuji if the active network was removed.


### PR DESCRIPTION
## Description

Shorten custom-network dispatch ordering comments in `NetworkService` and `NetworkService.test` while keeping the existing behavior and test coverage unchanged.

## Changes

- Replace verbose ordering rationale comments with concise equivalents in `saveCustomNetwork` and `removeCustomNetwork`
- Shorten the matching unit test comment in `NetworkService.test`

## Testing

- Verified locally by reproducing the custom-network flow before this PR
- No functional code path changes in this PR (comment-only)

## Screenshots:

N/A

## Checklist for the author

Tick each of them when done or if not applicable.

- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.