### PR TITLE
fix: sync wallet_setSettings schema with the settings storage

### DIFF
--- a/packages/service-worker/src/services/settings/handlers/wallet_setSettings.test.ts
+++ b/packages/service-worker/src/services/settings/handlers/wallet_setSettings.test.ts
@@ -5,6 +5,8 @@ import {
   SettingsState,
   AnalyticsConsent,
   ColorTheme,
+  FeeSetting,
+  MaxBuyOption,
 } from '@core/types';
 import {
   WalletSetSettingsHandler,
@@ -28,6 +30,12 @@ describe('packages/service-worker/src/services/settings/handlers/wallet_setSetti
   const setCoreAssistantMock = jest.fn();
   const setPreferredViewMock = jest.fn();
   const setShowHighlightBannersMock = jest.fn();
+  const setQuickSwapsEnabledMock = jest.fn();
+  const setFeeSettingMock = jest.fn();
+  const setMaxBuyMock = jest.fn();
+  const setPrivacyModeMock = jest.fn();
+  const setFilterSmallUtxosMock = jest.fn();
+  const setBridgeDevEnvMock = jest.fn();
 
   const settingsServiceMock = {
     getSettings: getSettingsMock,
@@ -41,6 +49,12 @@ describe('packages/service-worker/src/services/settings/handlers/wallet_setSetti
     setCoreAssistant: setCoreAssistantMock,
     setPreferredView: setPreferredViewMock,
     setShowHighlightBanners: setShowHighlightBannersMock,
+    setQuickSwapsEnabled: setQuickSwapsEnabledMock,
+    setFeeSetting: setFeeSettingMock,
+    setMaxBuy: setMaxBuyMock,
+    setPrivacyMode: setPrivacyModeMock,
+    setFilterSmallUtxos: setFilterSmallUtxosMock,
+    setBridgeDevEnv: setBridgeDevEnvMock,
   } as unknown as SettingsService;
 
   const subscribeMock = jest.fn();
@@ -93,6 +107,11 @@ describe('packages/service-worker/src/services/settings/handlers/wallet_setSetti
     coreAssistant: true,
     preferredView: 'floating',
     showHighlightBanners: true,
+    isQuickSwapsEnabled: false,
+    feeSetting: 'low',
+    maxBuy: '1000',
+    privacyMode: false,
+    filterSmallUtxos: false,
     isBridgeDevEnv: false,
   };
 
@@ -242,6 +261,150 @@ describe('packages/service-worker/src/services/settings/handlers/wallet_setSetti
         ...request,
         result: updatedResponse,
       });
+    });
+
+    it('should successfully update isQuickSwapsEnabled', async () => {
+      const request = createRequest([{ isQuickSwapsEnabled: true }]);
+      const updatedResponse = {
+        ...mockSettingsResponse,
+        isQuickSwapsEnabled: true,
+      };
+      getSettingsMock.mockResolvedValueOnce({
+        ...mockSettingsState,
+        isQuickSwapsEnabled: true,
+      });
+
+      const result = await handler.handleAuthenticated(buildRpcCall(request));
+
+      expect(setQuickSwapsEnabledMock).toHaveBeenCalledWith(true);
+      expect(result).toEqual({
+        ...request,
+        result: updatedResponse,
+      });
+    });
+
+    it('should successfully update feeSetting', async () => {
+      const request = createRequest([{ feeSetting: 'high' }]);
+      const updatedResponse = {
+        ...mockSettingsResponse,
+        feeSetting: 'high' as FeeSetting,
+      };
+      getSettingsMock.mockResolvedValueOnce({
+        ...mockSettingsState,
+        feeSetting: 'high',
+      });
+
+      const result = await handler.handleAuthenticated(buildRpcCall(request));
+
+      expect(setFeeSettingMock).toHaveBeenCalledWith('high');
+      expect(result).toEqual({
+        ...request,
+        result: updatedResponse,
+      });
+    });
+
+    it('should successfully update maxBuy', async () => {
+      const request = createRequest([{ maxBuy: 'unlimited' }]);
+      const updatedResponse = {
+        ...mockSettingsResponse,
+        maxBuy: 'unlimited' as MaxBuyOption,
+      };
+      getSettingsMock.mockResolvedValueOnce({
+        ...mockSettingsState,
+        maxBuy: 'unlimited',
+      });
+
+      const result = await handler.handleAuthenticated(buildRpcCall(request));
+
+      expect(setMaxBuyMock).toHaveBeenCalledWith('unlimited');
+      expect(result).toEqual({
+        ...request,
+        result: updatedResponse,
+      });
+    });
+
+    it('should successfully update privacyMode', async () => {
+      const request = createRequest([{ privacyMode: true }]);
+      const updatedResponse = {
+        ...mockSettingsResponse,
+        privacyMode: true,
+      };
+      getSettingsMock.mockResolvedValueOnce({
+        ...mockSettingsState,
+        privacyMode: true,
+      });
+
+      const result = await handler.handleAuthenticated(buildRpcCall(request));
+
+      expect(setPrivacyModeMock).toHaveBeenCalledWith(true);
+      expect(result).toEqual({
+        ...request,
+        result: updatedResponse,
+      });
+    });
+
+    it('should successfully update filterSmallUtxos', async () => {
+      const request = createRequest([{ filterSmallUtxos: true }]);
+      const updatedResponse = {
+        ...mockSettingsResponse,
+        filterSmallUtxos: true,
+      };
+      getSettingsMock.mockResolvedValueOnce({
+        ...mockSettingsState,
+        filterSmallUtxos: true,
+      });
+
+      const result = await handler.handleAuthenticated(buildRpcCall(request));
+
+      expect(setFilterSmallUtxosMock).toHaveBeenCalledWith(true);
+      expect(result).toEqual({
+        ...request,
+        result: updatedResponse,
+      });
+    });
+
+    it('should successfully update isBridgeDevEnv', async () => {
+      const request = createRequest([{ isBridgeDevEnv: true }]);
+      const updatedResponse = {
+        ...mockSettingsResponse,
+        isBridgeDevEnv: true,
+      };
+      getSettingsMock.mockResolvedValueOnce({
+        ...mockSettingsState,
+        isBridgeDevEnv: true,
+      });
+
+      const result = await handler.handleAuthenticated(buildRpcCall(request));
+
+      expect(setBridgeDevEnvMock).toHaveBeenCalledWith(true);
+      expect(result).toEqual({
+        ...request,
+        result: updatedResponse,
+      });
+    });
+
+    it('should return error for invalid feeSetting', async () => {
+      const request = createRequest([{ feeSetting: 'invalid' as FeeSetting }]);
+      const result = await handler.handleAuthenticated(buildRpcCall(request));
+
+      expect(setFeeSettingMock).not.toHaveBeenCalled();
+      expect('error' in result).toBe(true);
+      if ('error' in result) {
+        expect(result.error.message).toContain('Error: Invalid settings:');
+        expect(result.error.message).toContain('feeSetting');
+      }
+    });
+
+    it('should return error for invalid maxBuy', async () => {
+      const request = createRequest([{ maxBuy: '999' as MaxBuyOption }]);
+      const result = await handler.handleAuthenticated(buildRpcCall(request));
+
+      expect(setMaxBuyMock).not.toHaveBeenCalled();
+      expect('error' in result).toBe(true);
+      if ('error' in result) {
+        expect(result.error.message).toContain('Error: Invalid settings:');
+        expect(result.error.message).toContain('maxBuy');
+      }
     });
 
     it('should return error when no settings provided', async () => {

--- a/packages/service-worker/src/services/settings/handlers/wallet_setSettings.ts
+++ b/packages/service-worker/src/services/settings/handlers/wallet_setSettings.ts
@@ -30,6 +30,11 @@ const SettingsSchema = z.object({
   collectiblesVisibility: z
     .record(z.string(), z.record(z.string(), z.boolean()))
     .optional(),
+  isQuickSwapsEnabled: z.boolean().optional(),
+  feeSetting: z.enum(['low', 'medium', 'high']).optional(),
+  maxBuy: z.enum(['1000', '5000', '10000', '50000', 'unlimited']).optional(),
+  privacyMode: z.boolean().optional(),
+  filterSmallUtxos: z.boolean().optional(),
   isBridgeDevEnv: z.boolean().optional(),
   notificationSubscriptions: z
     .record(
@@ -79,6 +84,11 @@ export interface WalletSetSettingsResponse {
   coreAssistant: boolean;
   preferredView: 'floating' | 'sidebar';
   showHighlightBanners: boolean;
+  isQuickSwapsEnabled: boolean;
+  feeSetting: 'low' | 'medium' | 'high';
+  maxBuy: '1000' | '5000' | '10000' | '50000' | 'unlimited';
+  privacyMode: boolean;
+  filterSmallUtxos: boolean;
   isBridgeDevEnv: boolean;
 }
 
@@ -174,6 +184,32 @@ export class WalletSetSettingsHandler extends DAppRequestHandler<
         );
       }
 
+      if (validatedSettings.isQuickSwapsEnabled !== undefined) {
+        await this.settingsService.setQuickSwapsEnabled(
+          validatedSettings.isQuickSwapsEnabled,
+        );
+      }
+
+      if (validatedSettings.feeSetting !== undefined) {
+        await this.settingsService.setFeeSetting(validatedSettings.feeSetting);
+      }
+
+      if (validatedSettings.maxBuy !== undefined) {
+        await this.settingsService.setMaxBuy(validatedSettings.maxBuy);
+      }
+
+      if (validatedSettings.privacyMode !== undefined) {
+        await this.settingsService.setPrivacyMode(
+          validatedSettings.privacyMode,
+        );
+      }
+
+      if (validatedSettings.filterSmallUtxos !== undefined) {
+        await this.settingsService.setFilterSmallUtxos(
+          validatedSettings.filterSmallUtxos,
+        );
+      }
+
       if (validatedSettings.isBridgeDevEnv !== undefined) {
         await this.settingsService.setBridgeDevEnv(
           validatedSettings.isBridgeDevEnv,
@@ -234,6 +270,11 @@ export class WalletSetSettingsHandler extends DAppRequestHandler<
         coreAssistant: finalSettings.coreAssistant,
         preferredView: finalSettings.preferredView,
         showHighlightBanners: finalSettings.showHighlightBanners,
+        isQuickSwapsEnabled: finalSettings.isQuickSwapsEnabled,
+        feeSetting: finalSettings.feeSetting,
+        maxBuy: finalSettings.maxBuy,
+        privacyMode: finalSettings.privacyMode,
+        filterSmallUtxos: finalSettings.filterSmallUtxos,
         isBridgeDevEnv: finalSettings.isBridgeDevEnv,
       };
 


### PR DESCRIPTION
## Description
Current `wallet_setSettings` handler's schema was missing a few fields from the settings storage, therefore not allowing them to be updated with an RPC call.

## Testing
1. Go to playground app: https://ava-labs.github.io/extension-avalanche-playground/rpc-calls
2. Fire up `wallet_setSettings` with one of the newly added keys.

## Screenshots:

https://github.com/user-attachments/assets/ee20277d-a8ce-4841-8386-5312e4834717


<!-- Additional Visual Tools like Screen recordings, Screenshots to showcase changes -->

## Checklist for the author
- [x] I've covered new/modified business logic with Jest test cases.
- [x] I've tested the changes myself before sending it to code review and QA.
