### PR TITLE
fix(networks): poll balances for custom network without manual toggle

### DIFF
--- a/packages/service-worker/src/services/balances/handlers/startBalancesPolling.test.ts
+++ b/packages/service-worker/src/services/balances/handlers/startBalancesPolling.test.ts
@@ -115,21 +115,34 @@ describe('background/services/balances/handlers/startBalancesPolling.ts', () => 
       });
     });
 
-    it('does not start polling', async () => {
+    // Regression: handler must restart polling so a new chainId (e.g. a
+    // freshly-added custom network) is picked up without requiring a manual
+    // toggle. `startPolling` is idempotent — it stops any existing cycle.
+    it('restarts polling with the latest chainIds', async () => {
       const handler = new StartBalancesPollingHandler(
         balancePollingService,
         aggregatorService,
       );
 
+      const scope = 'eip155:43114';
+
       await handler.handle(
-        buildRpcCall({
-          id: '123',
-          method: ExtensionRequest.BALANCES_START_POLLING,
-          params: [account, chainIds],
-        }),
+        buildRpcCall(
+          {
+            id: '123',
+            method: ExtensionRequest.BALANCES_START_POLLING,
+            params: [account, chainIds, [TokenType.ERC20]],
+          },
+          scope,
+        ),
       );
 
-      expect(balancePollingService.startPolling).not.toHaveBeenCalled();
+      expect(balancePollingService.startPolling).toHaveBeenCalledWith(
+        account,
+        caipToChainId(scope),
+        chainIds,
+        [TokenType.ERC20],
+      );
     });
   });
 });

--- a/packages/service-worker/src/services/balances/handlers/startBalancesPolling.test.ts
+++ b/packages/service-worker/src/services/balances/handlers/startBalancesPolling.test.ts
@@ -117,7 +117,8 @@ describe('background/services/balances/handlers/startBalancesPolling.ts', () => 
 
     // Regression: handler must restart polling so a new chainId (e.g. a
     // freshly-added custom network) is picked up without requiring a manual
-    // toggle. `startPolling` is idempotent — it stops any existing cycle.
+    // toggle. `startPolling` is safe to call repeatedly — it stops the
+    // existing cycle before starting a new one.
     it('restarts polling with the latest chainIds', async () => {
       const handler = new StartBalancesPollingHandler(
         balancePollingService,

--- a/packages/service-worker/src/services/balances/handlers/startBalancesPolling.ts
+++ b/packages/service-worker/src/services/balances/handlers/startBalancesPolling.ts
@@ -35,7 +35,8 @@ export class StartBalancesPollingHandler implements HandlerType {
 
   handle: HandlerType['handle'] = async ({ request, scope }) => {
     // Always (re)start so changes to `roundRobinChainIds` (e.g. after a
-    // custom network is added) are picked up. `startPolling` is idempotent.
+    // custom network is added) are picked up. `startPolling` is safe to call
+    // repeatedly — it stops the existing cycle before starting a new one.
     if (scope) {
       const activeChainId = caipToChainId(scope);
       const [account, roundRobinChainIds, tokenTypes] = request.params;

--- a/packages/service-worker/src/services/balances/handlers/startBalancesPolling.ts
+++ b/packages/service-worker/src/services/balances/handlers/startBalancesPolling.ts
@@ -34,7 +34,9 @@ export class StartBalancesPollingHandler implements HandlerType {
   ) {}
 
   handle: HandlerType['handle'] = async ({ request, scope }) => {
-    if (scope && !this.pollingService.isPollingActive) {
+    // Always (re)start so changes to `roundRobinChainIds` (e.g. after a
+    // custom network is added) are picked up. `startPolling` is idempotent.
+    if (scope) {
       const activeChainId = caipToChainId(scope);
       const [account, roundRobinChainIds, tokenTypes] = request.params;
 


### PR DESCRIPTION
# Summary

A follow-up to #909. After adding a custom network, balances were still not polled until the user manually toggled the network off and on in Settings.

The `BALANCES_START_POLLING` handler short-circuited when polling was already active, so the new `roundRobinChainIds` (now correctly including the just-added chainId thanks to #909) were dropped. Removed the guard — `BalancePollingService.startPolling` is already idempotent (calls `stopPolling()` first).

## Notes

- Production change is one condition + a 2-line comment.
- Updated the existing handler test that was effectively asserting the bug (`does not start polling` → `restarts polling with the latest chainIds`).

## Testing

1. Load the extension and unlock.
2. Navigate to Settings → Networks → Add Network and add a custom network you have a balance on (e.g. a custom RPC for an existing chain).
3. Go back to Portfolio → Assets tab → open the Filter dropdown.
4. The new network should appear if there is a balance for this network without having to toggle it off/on in Settings → Networks → Custom networks.

## Media