### PR TITLE
fix(ledger): skip Sentry capture for WalletExistsError

### DIFF
--- a/apps/next/src/components/ConnectLedger/LedgerConnector/BaseLedgerConnector.tsx
+++ b/apps/next/src/components/ConnectLedger/LedgerConnector/BaseLedgerConnector.tsx
@@ -13,6 +13,7 @@ import {
   ErrorType,
   PublicKey,
   UseLedgerPublicKeyFetcher,
+  WalletExistsError,
 } from './types';
 import { LedgerAppType } from '@core/ui';
 import { DerivationStatus } from '@core/types';
@@ -98,10 +99,12 @@ export const BaseLedgerConnector: FC<Props & LedgerConnectorOverrides> = (
         callbacks?.onConnectionSuccess();
       })
       .catch((err) => {
-        Monitoring.sentryCaptureException(
-          err,
-          Monitoring.SentryExceptionTypes.LEDGER,
-        );
+        if (!(err instanceof WalletExistsError)) {
+          Monitoring.sentryCaptureException(
+            err,
+            Monitoring.SentryExceptionTypes.LEDGER,
+          );
+        }
         console.error('Failed to derive keys', err);
         callbacks?.onConnectionFailed(err);
       })

--- a/apps/next/src/components/ConnectLedger/LedgerConnector/BaseLedgerConnector.tsx
+++ b/apps/next/src/components/ConnectLedger/LedgerConnector/BaseLedgerConnector.tsx
@@ -98,15 +98,17 @@ export const BaseLedgerConnector: FC<Props & LedgerConnectorOverrides> = (
         onSuccess(retrievedKeys);
         callbacks?.onConnectionSuccess();
       })
-      .catch((err) => {
-        if (!(err instanceof WalletExistsError)) {
+      .catch((err: unknown) => {
+        const normalizedError =
+          err instanceof Error ? err : new Error(String(err));
+        if (!(normalizedError instanceof WalletExistsError)) {
           Monitoring.sentryCaptureException(
-            err,
+            normalizedError,
             Monitoring.SentryExceptionTypes.LEDGER,
           );
         }
-        console.error('Failed to derive keys', err);
-        callbacks?.onConnectionFailed(err);
+        console.error('Failed to derive keys', normalizedError);
+        callbacks?.onConnectionFailed(normalizedError);
       })
       .finally(() => {
         setIsRetrieving(false);


### PR DESCRIPTION
* [CP-14242](https://ava-labs.atlassian.net/browse/CP-14242)

## Summary

`Monitoring.sentryCaptureException(..., LEDGER)` runs on every rejection in `BaseLedgerConnector.tsx`, including the expected `WalletExistsError` flow that's correctly routed by the caller to a separate `WalletImport_Ledger_DuplicateWallet` analytics event. Result: ~26 events / 30d in Sentry's `tags[type]:ledger` bucket that are normal "wallet already imported" UX, not failures.

This change skips the Sentry capture when `err instanceof WalletExistsError`. UI and analytics behavior unchanged — `assertUniqueWallet` still sets `status='error'` / `error='duplicated-wallet'` and the caller still emits `WalletImport_Ledger_DuplicateWallet`.

## Test plan

- [x] `yarn workspace @core-ext/next lint` clean
- [x] `yarn workspace @core-ext/next typecheck` clean
- [x] `yarn workspace @core-ext/next jest` — 243 / 243 pass
- [ ] Manual repro: import a Ledger wallet that's already imported under another secret-type → verify `WalletImport_Ledger_DuplicateWallet` event still fires in PostHog and no new `type:ledger` Sentry event is captured for the dup case.

## Related

Investigation context in [Slack thread](https://avalancheavax.slack.com/archives/C0440E1H8DS/p1778552995089489?thread_ts=1778097647.994569&cid=C0440E1H8DS). Companion tickets: CP-14241 (auto-retry loop spam), CP-14243 (\`reason\` property).

[CP-14242]: https://ava-labs.atlassian.net/browse/CP-14242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ