### PR TITLE
feat(ledger): add reason to import failure analytics

### DIFF
--- a/apps/next/src/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/classifyLedgerConnectionError.test.ts
+++ b/apps/next/src/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/classifyLedgerConnectionError.test.ts
@@ -84,6 +84,14 @@ describe('classifyLedgerConnectionError', () => {
       makeError('Error', 'getAppAndVersion: invalid version length'),
       'unexpected_response',
     ],
+    [
+      'public key must be 33 or 65 bytes assertion',
+      makeError(
+        'AssertionError',
+        'AssertionError [ERR_ASSERTION]: Public key must be 33 or 65 bytes.',
+      ),
+      'unexpected_response',
+    ],
     ['unknown', makeError('Error', 'something weird'), 'unknown'],
     ['non-Error throws', 'plain string', 'unknown'],
     ['null', null, 'unknown'],

--- a/apps/next/src/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/classifyLedgerConnectionError.test.ts
+++ b/apps/next/src/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/classifyLedgerConnectionError.test.ts
@@ -1,0 +1,99 @@
+import { WalletExistsError } from '../../types';
+import { classifyLedgerConnectionError } from './classifyLedgerConnectionError';
+
+function makeError(name: string, message: string) {
+  const err = new Error(message);
+  err.name = name;
+  return err;
+}
+
+describe('classifyLedgerConnectionError', () => {
+  it.each([
+    [
+      'LockedDeviceError by name',
+      makeError('LockedDeviceError', 'oops'),
+      'device_locked',
+    ],
+    [
+      'Locked device 0x5515 by message',
+      makeError('Error', 'Ledger device: Locked device (0x5515)'),
+      'device_locked',
+    ],
+    [
+      'Wrong app via 0x6700',
+      makeError(
+        'TransportStatusError',
+        'Ledger device: Incorrect length (0x6700)',
+      ),
+      'wrong_app',
+    ],
+    [
+      'TransportRaceCondition by name',
+      makeError('TransportRaceCondition', 'race'),
+      'transport_race',
+    ],
+    [
+      'Race by message',
+      makeError('Error', 'An action was already pending on the Ledger device.'),
+      'transport_race',
+    ],
+    [
+      'TransportInterfaceNotAvailable',
+      makeError(
+        'TransportInterfaceNotAvailable',
+        "Failed to execute 'claimInterface'",
+      ),
+      'usb_busy',
+    ],
+    [
+      'claimInterface message',
+      makeError('Error', "Failed to execute 'claimInterface' on 'USBDevice'"),
+      'usb_busy',
+    ],
+    [
+      'lock getAddress',
+      makeError('TransportError', 'Ledger Device is busy (lock getAddress)'),
+      'usb_busy',
+    ],
+    [
+      'Access denied',
+      makeError(
+        'SecurityError',
+        "Failed to execute 'open' on 'USBDevice': Access denied.",
+      ),
+      'permission_denied',
+    ],
+    [
+      'USB disconnected',
+      makeError(
+        'NotFoundError',
+        "Failed to execute 'close' on 'USBDevice': The device was disconnected.",
+      ),
+      'usb_disconnected',
+    ],
+    [
+      'publicKey length mismatch',
+      makeError(
+        'Error',
+        'Expected property "publicKey" of type Buffer(Length: 33), got Buffer(Length: 1)',
+      ),
+      'unexpected_response',
+    ],
+    [
+      'invalid version length',
+      makeError('Error', 'getAppAndVersion: invalid version length'),
+      'unexpected_response',
+    ],
+    ['unknown', makeError('Error', 'something weird'), 'unknown'],
+    ['non-Error throws', 'plain string', 'unknown'],
+    ['null', null, 'unknown'],
+  ])('classifies %s', (_label, err, expected) => {
+    expect(classifyLedgerConnectionError(err)).toBe(expected);
+  });
+
+  it('classifies WalletExistsError', () => {
+    expect(classifyLedgerConnectionError(new WalletExistsError('dup'))).toBe(
+      'duplicated_wallet',
+    );
+  });
+});

--- a/apps/next/src/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/classifyLedgerConnectionError.ts
+++ b/apps/next/src/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/classifyLedgerConnectionError.ts
@@ -1,0 +1,75 @@
+import { WalletExistsError } from '../../types';
+
+export type LedgerConnectionFailureReason =
+  | 'device_locked'
+  | 'wrong_app'
+  | 'usb_busy'
+  | 'transport_race'
+  | 'usb_disconnected'
+  | 'permission_denied'
+  | 'unexpected_response'
+  | 'duplicated_wallet'
+  | 'unknown';
+
+/**
+ * Maps an error thrown during Ledger key derivation into a stable, enumerated
+ * `reason` string used as a property on analytics events. Values must not carry
+ * user PII (no email, no public keys, no addresses) — only the classified
+ * error class.
+ */
+export function classifyLedgerConnectionError(
+  err: unknown,
+): LedgerConnectionFailureReason {
+  if (err instanceof WalletExistsError) {
+    return 'duplicated_wallet';
+  }
+
+  const name = err instanceof Error ? err.name : '';
+  const message = err instanceof Error ? err.message : String(err ?? '');
+
+  if (
+    name === 'LockedDeviceError' ||
+    message.includes('Locked device') ||
+    message.includes('0x5515')
+  ) {
+    return 'device_locked';
+  }
+
+  if (message.includes('0x6700') || /Incorrect length/i.test(message)) {
+    return 'wrong_app';
+  }
+
+  if (
+    name === 'TransportRaceCondition' ||
+    /action was already pending/i.test(message)
+  ) {
+    return 'transport_race';
+  }
+
+  if (
+    name === 'TransportInterfaceNotAvailable' ||
+    /claim(?:Interface)?/i.test(message) ||
+    /lock getAddress/i.test(message) ||
+    /Ledger Device is busy/i.test(message)
+  ) {
+    return 'usb_busy';
+  }
+
+  if (/Access denied/i.test(message)) {
+    return 'permission_denied';
+  }
+
+  if (/device was disconnected/i.test(message)) {
+    return 'usb_disconnected';
+  }
+
+  if (
+    (/publicKey/.test(message) && /length/i.test(message)) ||
+    /invalid version length/i.test(message) ||
+    /Public key must be 33 or 65 bytes/i.test(message)
+  ) {
+    return 'unexpected_response';
+  }
+
+  return 'unknown';
+}

--- a/apps/next/src/pages/Import/ImportLedgerFlow/components/ImportLedgerFlowContent.tsx
+++ b/apps/next/src/pages/Import/ImportLedgerFlow/components/ImportLedgerFlowContent.tsx
@@ -24,6 +24,7 @@ import {
   Troubleshooting,
   WalletExistsError,
 } from '@/components/ConnectLedger';
+import { classifyLedgerConnectionError } from '@/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/classifyLedgerConnectionError';
 import { useModalPageControl } from '@/components/FullscreenModal';
 import { useOpenApp } from '@/hooks/useOpenApp';
 
@@ -128,7 +129,9 @@ export const ImportLedgerFlowContent = () => {
       onConnectionFailed: (err: Error) =>
         err instanceof WalletExistsError
           ? capture(`${ANALYTICS_EVENT_PREFIX}DuplicateWallet`)
-          : capture(`${ANALYTICS_EVENT_PREFIX}ConnectionFailed`),
+          : capture(`${ANALYTICS_EVENT_PREFIX}ConnectionFailed`, {
+              reason: classifyLedgerConnectionError(err),
+            }),
       onConnectionRetry: () => capture(`${ANALYTICS_EVENT_PREFIX}Retry`),
     }),
     [capture],
@@ -138,8 +141,10 @@ export const ImportLedgerFlowContent = () => {
     () => ({
       onConnectionSuccess: () =>
         capture(`${ANALYTICS_EVENT_PREFIX}SolanaKeysDerived`),
-      onConnectionFailed: () =>
-        capture(`${ANALYTICS_EVENT_PREFIX}SolanaKeysFailed`),
+      onConnectionFailed: (err: Error) =>
+        capture(`${ANALYTICS_EVENT_PREFIX}SolanaKeysFailed`, {
+          reason: classifyLedgerConnectionError(err),
+        }),
       onConnectionRetry: () =>
         capture(`${ANALYTICS_EVENT_PREFIX}SolanaKeysRetry`),
     }),

--- a/apps/next/src/pages/Onboarding/flows/ConnectLedgerFlow/screens/ConnectLedgerScreen/ConnectLedgerScreen.tsx
+++ b/apps/next/src/pages/Onboarding/flows/ConnectLedgerFlow/screens/ConnectLedgerScreen/ConnectLedgerScreen.tsx
@@ -17,6 +17,7 @@ import {
   PromptSolana,
   Troubleshooting,
 } from '@/components/ConnectLedger';
+import { classifyLedgerConnectionError } from '@/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/classifyLedgerConnectionError';
 import { FeatureGates } from '@core/types';
 
 type ImportPhase =
@@ -64,7 +65,10 @@ export const ConnectLedgerScreen: FC<ConnectLedgerScreenProps> = ({
   const avalancheConnectorCallbacks = useMemo(
     () => ({
       onConnectionSuccess: () => capture('OnboardingLedgerConnected'),
-      onConnectionFailed: () => capture('OnboardingLedgerConnectionFailed'),
+      onConnectionFailed: (err: Error) =>
+        capture('OnboardingLedgerConnectionFailed', {
+          reason: classifyLedgerConnectionError(err),
+        }),
       onConnectionRetry: () => capture('OnboardingLedgerRetry'),
     }),
     [capture],
@@ -73,7 +77,10 @@ export const ConnectLedgerScreen: FC<ConnectLedgerScreenProps> = ({
   const solanaConnectorCallbacks = useMemo(
     () => ({
       onConnectionSuccess: () => capture('OnboardingLedgerSolanaKeysDerived'),
-      onConnectionFailed: () => capture('OnboardingLedgerSolanaKeysFailed'),
+      onConnectionFailed: (err: Error) =>
+        capture('OnboardingLedgerSolanaKeysFailed', {
+          reason: classifyLedgerConnectionError(err),
+        }),
       onConnectionRetry: () => capture('OnboardingLedgerSolanaKeysRetry'),
     }),
     [capture],


### PR DESCRIPTION
* [CP-14243](https://ava-labs.atlassian.net/browse/CP-14243)

## Summary

`WalletImport_Ledger_ConnectionFailed`, `WalletImport_Ledger_SolanaKeysFailed`, `OnboardingLedgerConnectionFailed`, and `OnboardingLedgerSolanaKeysFailed` now carry a `reason` property classifying the underlying Ledger SDK error into a stable, enumerated string. This lets PostHog/Metabase distinguish user-state issues (device locked, wrong app open, USB held by Ledger Live) from real bugs without leaving the dashboard.

Top 30-day Sentry breakdown (`tags[type]:ledger`) shows ~92% of failures are user-correctable; we've been over-counting these as "failures" because the event payload had no way to differentiate.

## Changes

- New `classifyLedgerConnectionError` util mapping Ledger / WebUSB / WebHID errors to one of:
  - `device_locked` (`LockedDeviceError`, status `0x5515`)
  - `wrong_app` (`TransportStatusError` `0x6700` — wrong APDU class because no app or wrong app is open)
  - `usb_busy` (`TransportInterfaceNotAvailable`, `lock getAddress`, `Ledger Device is busy`)
  - `transport_race` (`TransportRaceCondition`)
  - `usb_disconnected` (`NotFoundError: device was disconnected`)
  - `permission_denied` (`SecurityError: Access denied`)
  - `unexpected_response` (publicKey length mismatch, `invalid version length`)
  - `duplicated_wallet` (`WalletExistsError` — already routed to its own event, but classifier is exhaustive)
  - `unknown` (fallback)
- Pass `reason` as the second arg to `capture()` in `ImportLedgerFlowContent.tsx` (Avalanche + Solana callbacks) and `ConnectLedgerScreen.tsx` (Avalanche + Solana onboarding callbacks).
- 16 unit tests covering all classifications + non-Error / null inputs.

Reason values contain no user PII — only the classified error class string.

## Test plan

- [x] `yarn workspace @core-ext/next lint` clean
- [x] `yarn workspace @core-ext/next typecheck` clean
- [x] `yarn workspace @core-ext/next jest` — 259 / 259 pass (243 prior + 16 new)
- [ ] Update the Metabase / PostHog Core Extension failures dashboard to break down `WalletImport_Ledger_ConnectionFailed` by `reason`. (Followup; not part of this PR.)
- [ ] Manual: trigger a known failure mode (e.g. import with Ledger locked) and verify the `reason` property arrives in PostHog event payload.

## Related

[Slack investigation](https://avalancheavax.slack.com/archives/C0440E1H8DS/p1778552995089489?thread_ts=1778097647.994569&cid=C0440E1H8DS). Companion: CP-14242 (Sentry double-count), CP-14241 (auto-retry loop spam).

[CP-14243]: https://ava-labs.atlassian.net/browse/CP-14243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ