### PR TITLE
fix(ledger): stop Ledger import auto-retry analytics loop

### DIFF
--- a/apps/next/src/components/ConnectLedger/ConnectSolana.tsx
+++ b/apps/next/src/components/ConnectLedger/ConnectSolana.tsx
@@ -59,6 +59,7 @@ export const ConnectSolana: FC<ConnectionStepProps> = ({
       'app-not-installed': t(
         'The Solana app does not appear to be installed on your Ledger. Install it from Ledger Live, then try again.',
       ),
+      'retrieval-failed': t('Open the Solana app on your Ledger device'),
     }),
     [t],
   );

--- a/apps/next/src/components/ConnectLedger/LedgerConnector/BaseLedgerConnector.tsx
+++ b/apps/next/src/components/ConnectLedger/LedgerConnector/BaseLedgerConnector.tsx
@@ -1,6 +1,13 @@
 import { DerivationPath } from '@avalabs/core-wallets-sdk';
 import { Stack } from '@avalabs/k2-alpine';
-import { ComponentProps, FC, useCallback, useEffect, useState } from 'react';
+import {
+  ComponentProps,
+  FC,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DerivedAddresses } from '@/pages/Onboarding/components/DerivedAddresses';
@@ -89,16 +96,32 @@ export const BaseLedgerConnector: FC<Props & LedgerConnectorOverrides> = (
     );
   const [keys, setKeys] = useState<PublicKey[]>(EMPTY_KEYS);
   const [isRetrieving, setIsRetrieving] = useState(false);
+  // Identifier for the in-flight fetchKeys attempt. resetFetchState and each
+  // new fetch bump this counter so the .then/.catch/.finally of an obsolete
+  // attempt can detect it is stale and skip its state updates. Otherwise an
+  // old promise can clobber freshly-reset state (e.g. selecting a new
+  // derivation path while the previous fetch is still pending).
+  const attemptIdRef = useRef(0);
+
+  const resetFetchState = useCallback(() => {
+    attemptIdRef.current += 1;
+    setKeys(EMPTY_KEYS);
+  }, []);
 
   const fetchKeys = useCallback(async () => {
+    attemptIdRef.current += 1;
+    const myAttemptId = attemptIdRef.current;
+    const isCurrent = () => attemptIdRef.current === myAttemptId;
     setIsRetrieving(true);
     retrieveKeys(minNumberOfKeys)
       .then((retrievedKeys) => {
+        if (!isCurrent()) return;
         setKeys(retrievedKeys.addressPublicKeys);
         onSuccess(retrievedKeys);
         callbacks?.onConnectionSuccess();
       })
       .catch((err: unknown) => {
+        if (!isCurrent()) return;
         const normalizedError =
           err instanceof Error ? err : new Error(String(err));
         if (!(normalizedError instanceof WalletExistsError)) {
@@ -111,18 +134,28 @@ export const BaseLedgerConnector: FC<Props & LedgerConnectorOverrides> = (
         callbacks?.onConnectionFailed(normalizedError);
       })
       .finally(() => {
+        if (!isCurrent()) return;
         setIsRetrieving(false);
       });
   }, [minNumberOfKeys, retrieveKeys, onSuccess, callbacks]);
 
+  const handleManualRetry = useCallback(() => {
+    resetFetchState();
+    callbacks?.onConnectionRetry();
+    onRetry();
+  }, [resetFetchState, callbacks, onRetry]);
+
   // Attempt to automatically connect as soon as we establish the transport.
+  // A retrieval failure flips status to 'error' inside the hook, so this
+  // effect naturally stops firing. No extra connector-side gating needed
+  // (CP-14241).
   useEffect(() => {
     if (status === 'ready' && !keys.length && !isRetrieving) {
       fetchKeys();
     } else if (status === 'error') {
-      setKeys(EMPTY_KEYS);
+      resetFetchState();
     }
-  }, [fetchKeys, status, keys, isRetrieving]);
+  }, [fetchKeys, status, keys, isRetrieving, resetFetchState]);
 
   useEffect(() => {
     onStatusChange(status);
@@ -147,7 +180,7 @@ export const BaseLedgerConnector: FC<Props & LedgerConnectorOverrides> = (
                 derivationPathSpec={props.derivationPathSpec}
                 onSelect={(_derivationPathSpec) => {
                   props.setDerivationPathSpec(_derivationPathSpec);
-                  setKeys([]);
+                  resetFetchState();
                   onStatusChange('waiting');
                 }}
                 labels={props.overrides?.PathSelector?.labels}
@@ -174,12 +207,7 @@ export const BaseLedgerConnector: FC<Props & LedgerConnectorOverrides> = (
         )}
       </Stack>
       {status === 'needs-user-gesture' && (
-        <Styled.LedgerClickToConnectMessage
-          onConnect={() => {
-            callbacks?.onConnectionRetry();
-            onRetry();
-          }}
-        />
+        <Styled.LedgerClickToConnectMessage onConnect={handleManualRetry} />
       )}
       {status === 'error' && error && (
         <Styled.LedgerConnectionError
@@ -194,12 +222,10 @@ export const BaseLedgerConnector: FC<Props & LedgerConnectorOverrides> = (
                   ? DerivationPath.LedgerLive
                   : DerivationPath.BIP44,
               );
-              setKeys([]);
               onStatusChange('waiting');
             }
 
-            callbacks?.onConnectionRetry();
-            onRetry();
+            handleManualRetry();
           }}
           retryLabel={
             isDuplicatedWalletError

--- a/apps/next/src/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/useLedgerBasePublicKeyFetcher.ts
+++ b/apps/next/src/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/useLedgerBasePublicKeyFetcher.ts
@@ -331,6 +331,16 @@ export const useLedgerBasePublicKeyFetcher: UseLedgerPublicKeyFetcher = (
       } catch (err) {
         console.error(err);
         popDeviceSelection();
+        // WalletExistsError sets its own status/error in assertUniqueWallet.
+        // For other failures, surface 'retrieval-failed' on the hook so the
+        // connector stops seeing status='ready' and the auto-fetch effect
+        // doesn't loop. The dedicated error type lets the hook's
+        // auto-connect effect distinguish a retrieval failure (must not
+        // auto-recover) from a transport/app-switch error (which can).
+        if (!(err instanceof WalletExistsError)) {
+          setStatus('error');
+          setError('retrieval-failed');
+        }
         throw err;
       }
     },
@@ -339,9 +349,15 @@ export const useLedgerBasePublicKeyFetcher: UseLedgerPublicKeyFetcher = (
 
   // Attempt to automatically connect as soon as we establish the transport.
   useEffect(() => {
-    // If we have a duplicated wallet error, always wait for user action,
-    // do not attempt a reconnection.
-    if (error === 'duplicated-wallet' || status === 'needs-user-gesture') {
+    // If we have a duplicated wallet or retrieval error, always wait for
+    // user action. Returning here prevents the AVALANCHE branch below from
+    // re-flipping status to 'ready' and re-triggering the connector's
+    // auto-fetch.
+    if (
+      error === 'duplicated-wallet' ||
+      error === 'retrieval-failed' ||
+      status === 'needs-user-gesture'
+    ) {
       return;
     }
 

--- a/apps/next/src/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/useLedgerSolanaPublicKeyFetcher.ts
+++ b/apps/next/src/components/ConnectLedger/LedgerConnector/hooks/useLedgerPublicKeyFetcher/useLedgerSolanaPublicKeyFetcher.ts
@@ -73,6 +73,13 @@ export const useLedgerSolanaPublicKeyFetcher: UseLedgerPublicKeyFetcher = (
       } catch (err) {
         console.error(err);
         popDeviceSelection();
+        // Surface 'retrieval-failed' on the hook so the connector stops
+        // seeing status='ready' and the auto-fetch effect doesn't loop.
+        // The dedicated error type lets the hook's auto-connect effect
+        // distinguish a retrieval failure (must not auto-recover) from a
+        // transport/app-switch error (which can).
+        setStatus('error');
+        setError('retrieval-failed');
         throw err;
       }
     },
@@ -81,7 +88,13 @@ export const useLedgerSolanaPublicKeyFetcher: UseLedgerPublicKeyFetcher = (
 
   // Attempt to automatically connect as soon as we establish the transport.
   useEffect(() => {
-    if (error === 'duplicated-wallet' || status === 'needs-user-gesture') {
+    // Same guard as the Avalanche fetcher: never re-flip status back to
+    // 'ready' from the SOLANA branch below when a retrieval has failed.
+    if (
+      error === 'duplicated-wallet' ||
+      error === 'retrieval-failed' ||
+      status === 'needs-user-gesture'
+    ) {
       return;
     }
 
@@ -147,6 +160,7 @@ export const useLedgerSolanaPublicKeyFetcher: UseLedgerPublicKeyFetcher = (
     try {
       await popDeviceSelection();
       await initLedgerTransport();
+      setError(undefined);
       setStatus('waiting');
     } catch {
       setStatus('error');

--- a/apps/next/src/components/ConnectLedger/LedgerConnector/types.ts
+++ b/apps/next/src/components/ConnectLedger/LedgerConnector/types.ts
@@ -15,7 +15,8 @@ export type ErrorType =
   | 'no-app'
   | 'device-locked'
   | 'app-not-installed'
-  | 'duplicated-wallet';
+  | 'duplicated-wallet'
+  | 'retrieval-failed';
 export type PublicKey = {
   hasActivity?: boolean;
   key: AddressPublicKeyJson;

--- a/apps/next/src/components/ConnectLedger/Styled.tsx
+++ b/apps/next/src/components/ConnectLedger/Styled.tsx
@@ -96,7 +96,8 @@ export const LedgerConnectionError = ({
     >
       <Stack gap={1.5} alignItems="center" color="error.main">
         <FiAlertCircle size={32} color="currentColor" />
-        {errorType === 'unable-to-connect' && (
+        {(errorType === 'unable-to-connect' ||
+          errorType === 'retrieval-failed') && (
           <UnableToConnectMessage onTroubleshoot={onTroubleshoot} />
         )}
         {errorType === 'unsupported-version' && <UnsupportedVersionMessage />}


### PR DESCRIPTION
* [CP-14241](https://ava-labs.atlassian.net/browse/CP-14241)

## Summary

`BaseLedgerConnector.tsx`'s auto-fetch effect re-fires every time `isRetrieving` flips back to false, which happens *after every rejected fetch*. With status stuck at `'ready'` (the hook doesn't react to `retrieveKeys()` failures), and `keys` still empty, the effect re-runs `fetchKeys()` immediately. A user with a locked device, wrong Ledger app open, or Ledger Live holding the USB device gets stuck in a tight loop firing `WalletImport_Ledger_ConnectionFailed` events back to back. This explains the 5,000+ events / 4 weeks from a small device count on the Core Extension failures dashboard.

This is the same class of failure-loop that PR #821 ([CP-13529](https://ava-labs.atlassian.net/browse/CP-13529), "fix: ledger & keystone analytics spam") fixed for Keystone in March. The Sentry capture for Ledger was added then to gather more data, but the loop fix itself was never applied because the bug couldn't be reproduced locally.

## Fix

In `BaseLedgerConnector.tsx`:

- New `wasFetchAttempted` flag — set in `fetchKeys.finally()`, cleared on user-initiated retry, derivation-path change, or hook flipping to `'error'`. The auto-fetch effect now also requires `!wasFetchAttempted`, so each `'ready'` transport gets exactly one auto-attempt.
- New `fetchError` local state — set when `retrieveKeys()` rejects with anything other than `WalletExistsError` (which has its own UI path via `error='duplicated-wallet'`). When set, the UI renders the existing `LedgerConnectionError` component with `errorType='unable-to-connect'` instead of an indefinite skeleton.
- New `handleManualRetry` helper that resets both flags + clears keys + calls `callbacks?.onConnectionRetry()` + `onRetry()`. All Retry / Click-to-Connect handlers route through it so wasFetchAttempted is consistently reset.
- `WalletExistsError` import added so we can detect that flow correctly (the hook handles its UI path; we just avoid setting a redundant local `fetchError`).

Result: one `WalletImport_Ledger_ConnectionFailed` event per *explicit* Retry click instead of dozens-to-hundreds per session.

## Test plan

- [x] `yarn workspace @core-ext/next lint` clean
- [x] `yarn workspace @core-ext/next typecheck` clean
- [x] `yarn workspace @core-ext/next jest` — 243 / 243 pass
- [ ] **Manual repro (golden path)**: Connect a Ledger with the Avalanche app open and unlocked → addresses derive successfully on the first attempt, no change in UX vs. today.
- [ ] **Manual repro (loop case)**: Connect a Ledger with the device locked (or wrong app open) → see the `LedgerConnectionError` UI render once, *not* the blinking skeleton/error loop. Verify only one `WalletImport_Ledger_ConnectionFailed` is fired in PostHog devtools per Retry click.
- [ ] **Manual repro (duplicated wallet)**: Try to import a wallet that's already imported → existing duplicated-wallet UI still renders, Retry-with-other-derivation-path still works.
- [ ] **Manual repro (path switch)**: While in the connect screen, change the derivation path via the path selector → state correctly resets, a fresh fetch attempt runs once.

## Expected impact

Based on the Sentry breakdown (`tags[type]:ledger`, 30d, 1,807 events / 5,000+ PostHog events), the volume drop should be ~3-10× across all `Ledger_*Failed` events. Volume will look like:

- One event per user-initiated attempt instead of one per auto-retry tick.
- Per-device counts in PostHog become a meaningful denominator.
- Combined with the companion CP-14243 `reason` property, Product will be able to distinguish "device locked" / "wrong app" (~92% of events) from real failures without leaving the dashboard.

## Related

- [Slack investigation](https://avalancheavax.slack.com/archives/C0440E1H8DS/p1778552995089489?thread_ts=1778097647.994569&cid=C0440E1H8DS)
- Reference: PR #821 (Keystone equivalent of this fix, merged 2026-03-09)
- Companions: CP-14242 (Sentry double-count for \`WalletExistsError\`), CP-14243 (\`reason\` property)

[CP-14241]: https://ava-labs.atlassian.net/browse/CP-14241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CP-13529]: https://ava-labs.atlassian.net/browse/CP-13529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ