### PR TITLE
fix: native asset mapping

### DIFF
--- a/apps/next/src/hooks/useAllTokens/lib/getNativeAssetType.test.ts
+++ b/apps/next/src/hooks/useAllTokens/lib/getNativeAssetType.test.ts
@@ -1,0 +1,45 @@
+import { NetworkVMType } from '@avalabs/vm-module-types';
+import { NetworkWithCaipId } from '@core/types';
+
+import { getNativeAssetType } from './getNativeAssetType';
+
+const mockNetwork = (vmName: NetworkVMType): NetworkWithCaipId =>
+  ({ vmName }) as NetworkWithCaipId;
+
+describe('getNativeAssetType', () => {
+  it('maps EVM native tokens correctly', () => {
+    expect(getNativeAssetType(mockNetwork(NetworkVMType.EVM))).toBe(
+      'evm_native',
+    );
+  });
+
+  it('maps Solana native tokens correctly', () => {
+    expect(getNativeAssetType(mockNetwork(NetworkVMType.SVM))).toBe(
+      'svm_native',
+    );
+  });
+
+  it('maps Avalanche P-Chain native tokens correctly', () => {
+    expect(getNativeAssetType(mockNetwork(NetworkVMType.PVM))).toBe(
+      'pvm_native',
+    );
+  });
+
+  it('maps Avalanche X-Chain native tokens correctly', () => {
+    expect(getNativeAssetType(mockNetwork(NetworkVMType.AVM))).toBe(
+      'avm_native',
+    );
+  });
+
+  it('maps Bitcoin native tokens correctly', () => {
+    expect(getNativeAssetType(mockNetwork(NetworkVMType.BITCOIN))).toBe(
+      'btc_native',
+    );
+  });
+
+  it('returns unknown for unsupported VMs', () => {
+    expect(getNativeAssetType(mockNetwork(NetworkVMType.CoreEth))).toBe(
+      'unknown',
+    );
+  });
+});

--- a/apps/next/src/hooks/useAllTokens/lib/getNativeAssetType.ts
+++ b/apps/next/src/hooks/useAllTokens/lib/getNativeAssetType.ts
@@ -6,13 +6,13 @@ export const getNativeAssetType = (
 ): FungibleAssetType => {
   switch (network.vmName) {
     case NetworkVMType.EVM:
-      return 'evm_erc20';
+      return 'evm_native';
     case NetworkVMType.PVM:
       return 'pvm_native';
     case NetworkVMType.AVM:
       return 'avm_native';
     case NetworkVMType.SVM:
-      return 'svm_spl';
+      return 'svm_native';
     case NetworkVMType.BITCOIN:
       return 'btc_native';
     default:


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-14255

Slack issue: https://avalancheavax.slack.com/archives/C0A8NA4QRRA/p1778598870553179?thread_ts=1778010480.428099&cid=C0A8NA4QRRA

When attempting to get a swap quote for SOL > POL the Markr request fails (400 error) because `tokenOut` was missing in the params. This was because the POL asset was not being mapped to our "native" asset type the SDK expects, and instead was mapping to an ERC-20, but contained no valid token address.

## Notes

- In `apps/next/src/hooks/useAllTokens/lib/getNativeAssetType.ts:8`, EVM native was incorrectly mapped to 'evm_erc20' and Solana native to
    'svm_spl'.
- That value is used when building native placeholder tokens in `apps/next/src/hooks/useAllTokens/lib/getNetworkTokens.ts:28`.
- Later, Fusion converts tokens to SDK assets via `apps/next/src/pages/Fusion/contexts/hooks/useAssetAndChain/lib/buildAsset.ts:25`. With wrong assetType, a native token like POL is treated as ERC20 and gets address: `undefined`, which can produce Markr tokenOut missing.

I fixed the mapping:

- EVM -> evm_native
- SVM -> svm_native

And added regression tests in `apps/next/src/hooks/useAllTokens/lib/getNativeAssetType.test.ts:1`.

## Testing

<!-- Add high-level testing information for the reviewer to properly QA (wallet setup, local storage overrides, etc.) -->
Added unit test coverage for proper mapping of types.

## Testing Instructions

<!-- Add expected testing steps - be specific about whether or not you have a wallet connected, new routes, etc. -->
Visit swap. Attempt to get a quote for a SOL > POL swap.
