### PR TITLE
fix(portfolio): show back button on Manage Collectibles

### DIFF
--- a/apps/next/src/pages/Portfolio/components/PortfolioHome/components/PortolioDetails/components/CollectiblesTab/components/CollectiblesManagePopup.tsx
+++ b/apps/next/src/pages/Portfolio/components/PortfolioHome/components/PortolioDetails/components/CollectiblesTab/components/CollectiblesManagePopup.tsx
@@ -49,7 +49,12 @@ export const CollectiblesManagePopup = ({
     });
   }, [collectibles, searchQuery]);
   return (
-    <Dialog fullScreen={true} open={open} onClose={onClose}>
+    <Dialog
+      fullScreen={true}
+      open={open}
+      onClose={onClose}
+      sx={{ zIndex: (theme) => theme.zIndex.tooltip + 2 }}
+    >
       <Page
         title={t('Manage Collectibles')}
         withBackButton={true}


### PR DESCRIPTION
# Summary

The back button on `Manage Collectibles` was rendered behind the main Portfolio Header due to z-index — MUI `Dialog` defaults to `zIndex.modal` (1300) while the Header sits at `zIndex.tooltip` (1500). Raised the dialog's z-index above the header so the existing back button becomes visible.

## Notes

Minimal fix (1 file, 5 lines). Keeps Manage Collectibles as a fullscreen Dialog. A larger refactor to convert it into a proper route (matching `Manage Tokens`) was considered but skipped to limit blast radius.

## Testing

Local extension build, open Portfolio → Collectibles tab → click `Manage`.

## Testing Instructions

1. Open the extension and go to the Portfolio → Collectibles tab.
2. Click the `Manage` button in the toolbar.
3. Verify a back arrow is visible at the top-left of the Manage Collectibles page.
4. Click the back arrow and confirm it returns to the Collectibles tab.

## Media

_Before:_ no back button (hidden behind main Header).
_After:_ back arrow visible top-left, closes the dialog when clicked.
<img width="1493" height="691" alt="image" src="https://github.com/user-attachments/assets/39af0aaf-faf1-463a-ae12-82e8894c2678" />
