### PR TITLE
fix: seedless P-chain signing on non-zero accounts (CP-14284)

### DIFF
--- a/packages/service-worker/src/services/seedless/SeedlessWallet.test.ts
+++ b/packages/service-worker/src/services/seedless/SeedlessWallet.test.ts
@@ -60,6 +60,10 @@ jest.mock('./SeedlessMfaService');
 jest.mock('@core/common', () => ({
   ...jest.requireActual('@core/common'),
   getProviderForNetwork: jest.fn(),
+  Monitoring: {
+    ...jest.requireActual('@core/common').Monitoring,
+    sentryCaptureException: jest.fn(),
+  },
 }));
 jest.mock('@scure/base');
 

--- a/packages/service-worker/src/services/seedless/SeedlessWallet.ts
+++ b/packages/service-worker/src/services/seedless/SeedlessWallet.ts
@@ -34,6 +34,7 @@ import {
   hasAtLeastOneElement,
   isBitcoinNetwork,
   isTokenExpiredError,
+  Monitoring,
 } from '@core/common';
 import {
   AddressPublicKeyJson,
@@ -598,12 +599,22 @@ export class SeedlessWallet {
   ): Promise<string | Buffer> {
     assertPresent(this.#networkService, CommonError.UnknownNetwork); // TODO: is networkService actually needed? why is #network not enough?
     if (!this.#firstAddressPublicKey) {
-      throw new Error('Public key not available');
+      const err = new Error('Public key not available');
+      Monitoring.sentryCaptureException(
+        err,
+        Monitoring.SentryExceptionTypes.SEEDLESS,
+      );
+      throw err;
     }
 
     if (messageType === MessageType.AVALANCHE_SIGN) {
       if (!this.#firstAddressPublicKey.key) {
-        throw new Error('X/P public key not available');
+        const err = new Error('X/P public key not available');
+        Monitoring.sentryCaptureException(
+          err,
+          Monitoring.SentryExceptionTypes.SEEDLESS,
+        );
+        throw err;
       }
 
       const xpProvider = await this.#networkService.getAvalanceProviderXP();
@@ -694,6 +705,14 @@ export class SeedlessWallet {
       // Prevent leaking user information outside of extension
       // (original error message contains the user id).
       err.message = 'Session has expired';
+    } else {
+      // Token-expired errors flow through `notifyTokenExpired`; report
+      // everything else (key-lookup failures, signing failures, etc.) so
+      // regressions in the seedless signing path don't fail silently.
+      Monitoring.sentryCaptureException(
+        err as Error,
+        Monitoring.SentryExceptionTypes.SEEDLESS,
+      );
     }
 
     throw err;

--- a/packages/service-worker/src/services/wallet/WalletService.test.ts
+++ b/packages/service-worker/src/services/wallet/WalletService.test.ts
@@ -843,6 +843,63 @@ describe('background/services/wallet/WalletService.ts', () => {
         });
       });
 
+      describe('on a non-zero active account with no external indices', () => {
+        const mockedPublicKeys: AddressPublicKeyJson[] = [
+          {
+            curve: 'secp256k1',
+            derivationPath: "m/44'/9000'/0'/0/0",
+            type: 'address-pubkey',
+            key: '0x0000',
+          },
+          {
+            curve: 'secp256k1',
+            derivationPath: "m/44'/9000'/1'/0/0",
+            type: 'address-pubkey',
+            key: '0x0101',
+          },
+        ];
+
+        it('resolves the derivation path with addressIndex 0, not the active account index', async () => {
+          // Regression for CP-14284: prior to this fix, the fallback was
+          // `[secrets.account.index]`, which made the address index equal
+          // the active account index and produced a non-existent path of
+          // `m/44'/9000'/<acct>'/0/<acct>` for any non-zero account.
+          mockSeedlessWallet({ publicKeys: mockedPublicKeys }, {
+            index: 1,
+          } as any);
+
+          const getPathsSpy = jest
+            .spyOn(addressResolver, 'getDerivationPathsByVM')
+            .mockResolvedValueOnce({
+              [NetworkVMType.PVM]: "m/44'/9000'/1'/0/0",
+              [NetworkVMType.AVM]: "m/44'/9000'/1'/0/0",
+            });
+
+          jest
+            .spyOn(SeedlessWallet.prototype, 'signAvalancheTx')
+            .mockResolvedValueOnce(unsignedTxMock);
+
+          await walletService.sign(avalancheTxMock, {
+            ...networkMock,
+            vmName: NetworkVMType.PVM,
+            isTestnet: true,
+          });
+
+          expect(getPathsSpy).toHaveBeenCalledWith(
+            1, // BIP-44 account segment = active account
+            undefined, // derivationPathSpec (not relevant to this regression)
+            [NetworkVMType.AVM],
+            0, // address segment must default to 0, not the active account index
+          );
+
+          expect(SeedlessWallet).toHaveBeenCalledWith(
+            expect.objectContaining({
+              addressPublicKeys: expect.arrayContaining([mockedPublicKeys[1]]),
+            }),
+          );
+        });
+      });
+
       it('throws on wrong wallet type', async () => {
         spyOnGetWallet().mockResolvedValueOnce(btcWalletMock);
 

--- a/packages/service-worker/src/services/wallet/WalletService.ts
+++ b/packages/service-worker/src/services/wallet/WalletService.ts
@@ -30,6 +30,7 @@ import {
   isPrimaryAccount,
   isSolanaNetwork,
   isXchainNetwork,
+  Monitoring,
   omitUndefined,
 } from '@core/common';
 import {
@@ -198,9 +199,14 @@ export class WalletService implements OnUnlock {
     network: Network,
     accountIndex?: number | number[],
   ) {
-    const accountIndices = Array.isArray(accountIndex)
-      ? accountIndex
-      : [accountIndex ?? secrets.account.index];
+    // The `accountIndex` array form carries *address indices* within the
+    // active BIP-44 account (used by X/P-chain UTXO multi-address signing).
+    // When nothing is passed we sign with the active account's primary
+    // address (index 0), which is the only address CubeSigner provisions
+    // per account. Falling back to `secrets.account.index` here would
+    // produce `m/44'/9000'/<acct>'/0/<acct>` and miss the provisioned key
+    // for any non-zero active account.
+    const addressIndices = Array.isArray(accountIndex) ? accountIndex : [0];
 
     const vmName =
       isXchainNetwork(network) || isPchainNetwork(network)
@@ -212,12 +218,12 @@ export class WalletService implements OnUnlock {
     const curve = isSolanaNetwork(network) ? 'ed25519' : 'secp256k1';
 
     const derivationPaths = await Promise.all(
-      accountIndices.map((index) =>
+      addressIndices.map((addressIndex) =>
         this.addressResolver.getDerivationPathsByVM(
           secrets.account.index,
           secrets.derivationPathSpec,
           [vmName],
-          index,
+          addressIndex,
         ),
       ),
     );
@@ -227,9 +233,19 @@ export class WalletService implements OnUnlock {
       .filter(isNotNullish);
 
     if (!hasAtLeastOneElement(addressPublicKeys)) {
-      throw new Error('No public keys not available');
-    } else if (addressPublicKeys.length < accountIndices.length) {
-      throw new Error('Some of requested signing keys are not available');
+      const err = new Error('No public keys available');
+      Monitoring.sentryCaptureException(
+        err,
+        Monitoring.SentryExceptionTypes.SEEDLESS,
+      );
+      throw err;
+    } else if (addressPublicKeys.length < addressIndices.length) {
+      const err = new Error('Some of requested signing keys are not available');
+      Monitoring.sentryCaptureException(
+        err,
+        Monitoring.SentryExceptionTypes.SEEDLESS,
+      );
+      throw err;
     }
 
     return new SeedlessWallet({


### PR DESCRIPTION
# Summary

Jira ticket: [CP-14284](https://ava-labs.atlassian.net/browse/CP-14284)
Figma: n/a

Fixes a regression introduced by [#746](https://github.com/ava-labs/core-extension/pull/746) where seedless wallets on any non-zero account index can't sign P-chain / keychain transactions. The dapp surfaces *"can't sign message"* and the approval popup keeps reappearing.

That PR repurposed `accountIndices` in `WalletService.#getSeedlessWallet` from BIP-44 account indices to **address indices within the active account**, but the fallback was left as `[accountIndex ?? secrets.account.index]`. For the single-signer path (no explicit `externalIndices`) this puts the active account's BIP-44 index into the *address* segment, producing `m/44'/9000'/<acct>'/0/<acct>` — a path CubeSigner never provisions. It worked on account 0 only because both segments happen to be `0`.

The fix defaults `addressIndices` to `[0]` for the single-signer path so the derivation path becomes `m/44'/9000'/<acct>'/0/0`, which matches what CubeSigner holds.

## Notes

The bug never surfaced in Sentry — `SeedlessWallet.#handleError` is a bare rethrow and none of the seedless signing throw sites are wrapped in `Monitoring.sentryCaptureException`. To make sure the next regression in derivation-path resolution is observable, this PR also instruments:

- `WalletService.#getSeedlessWallet` — both `'No public keys available'` and `'Some of requested signing keys are not available'` throws.
- `SeedlessWallet.#handleError` — non-token-expired errors (covers `signAvalancheTx`, `signTx`, `signTransaction`, `signMessage`, `#getSigningKey`, `#signBlob`, `#signEip191`, `signSolanaTx`).
- `SeedlessWallet.signMessage(AVALANCHE_SIGN)` precheck throws (`'Public key not available'`, `'X/P public key not available'`) that bypass `#handleError`.

Token-expired errors keep flowing through `sessionManager.notifyTokenExpired()` unchanged.

Also corrects the stray `'No public keys not available'` message string (double negation typo) introduced by the original code.

Mobile (`core-mobile`) was verified unaffected — its `SeedlessWallet` keeps `accountIndex` and `addressIndex` as distinct params throughout, so the same conflation can't happen.

## Testing

- Seedless wallet (CubeSigner / Cube Signer) with at least two derived accounts (indices 0 and 1+).
- Mainnet or Fuji P-chain — easiest repro is the Builders Hub L1 validator balance flow:
  https://build.avax.network/console/layer-1/l1-validator-balance
- No special local storage overrides needed; behavior changes purely server-side of the extension.

## Testing Instructions

1. Set up a seedless wallet and add account index 1 (and optionally 2+).
2. Switch to account index 0 — initiate an L1 validator balance increase → confirm the tx signs and submits as before (regression guard).
3. Switch to account index 1 (or 2+) — initiate the same flow → confirm the tx signs and submits successfully (previously failed with *"can't sign message"* and a repeating approval popup).
4. While on account 1, sign an X-chain off-chain message (e.g. via a dapp that issues `avalanche_signMessage`) — confirm signature succeeds.
5. While on account 1, run a Fusion swap on C-chain to confirm EVM signing is still healthy.

Automated coverage:
- New unit test `WalletService.test.ts > sign > avalanche signing - XP / Coreth > on a non-zero active account with no external indices` asserts the derivation path is built with addressIndex=0 (not the active account index) and that the right pubkey ends up in the constructed `SeedlessWallet`.
- Multi-address case (`externalIndices: [0, 1]`) test from #746 still passes.

## Media

confirmed testing steps with Owen who reported this issue. 

https://github.com/user-attachments/assets/a2a8a219-2a01-440d-bcf3-dec9e709210c



[CP-14284]: https://ava-labs.atlassian.net/browse/CP-14284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ