### PR TITLE
fix: support p2sh/base58 in btc address validation

### DIFF
--- a/packages/common/src/utils/isAddressValid.ts
+++ b/packages/common/src/utils/isAddressValid.ts
@@ -10,7 +10,7 @@ export const isValidAddress = (address: string) => {
 
 export const isValidBtcAddress = (address: string) => {
   return (
-    // We check for bech32 as well as base58 to cover PS2H + P2PKH addresses
+    // We check for bech32 as well as base58 to cover P2SH + P2PKH addresses
     !!address.length && (isBech32Address(address) || isBase58Address(address))
   );
 };

--- a/packages/common/src/utils/isAddressValid.ts
+++ b/packages/common/src/utils/isAddressValid.ts
@@ -2,14 +2,17 @@ import { isAddress } from 'ethers';
 import { isAddress as isSvmAddress } from '@solana/kit';
 import { stripAddressPrefix } from './stripAddressPrefix';
 import { utils } from '@avalabs/avalanchejs';
-import { isBech32Address } from './address';
+import { isBase58Address, isBech32Address } from './address';
 
 export const isValidAddress = (address: string) => {
   return !!address.length && isAddress(address);
 };
 
 export const isValidBtcAddress = (address: string) => {
-  return !!address.length && isBech32Address(address);
+  return (
+    // We check for bech32 as well as base58 to cover PS2H + P2PKH addresses
+    !!address.length && (isBech32Address(address) || isBase58Address(address))
+  );
 };
 
 export const isValidPvmAddress = (address: string) => {

--- a/packages/common/src/utils/isContactValid.test.ts
+++ b/packages/common/src/utils/isContactValid.test.ts
@@ -2,7 +2,6 @@ import { Contact } from '@avalabs/types';
 import { isContactValid } from './isContactValid';
 import { isAddress } from 'ethers';
 import { isValidBtcAddress, isValidXPAddress } from './isAddressValid';
-import { isBech32Address } from './address';
 
 jest.mock('ethers', () => ({
   isAddress: jest.fn(),
@@ -56,7 +55,7 @@ describe('src/utils/isContactValid.ts', () => {
     expect(result).toEqual({ reason: '', valid: true });
   });
   it('should be valid when addressBTC is not valid', async () => {
-    jest.mocked(isBech32Address).mockImplementation(() => false);
+    jest.mocked(isValidBtcAddress).mockImplementation(() => false);
 
     const result = isContactValid(contactBTC);
     expect(result).toEqual({ reason: 'address is invalid', valid: false });

--- a/packages/common/src/utils/isContactValid.test.ts
+++ b/packages/common/src/utils/isContactValid.test.ts
@@ -1,7 +1,7 @@
 import { Contact } from '@avalabs/types';
 import { isContactValid } from './isContactValid';
 import { isAddress } from 'ethers';
-import { isValidXPAddress } from './isAddressValid';
+import { isValidBtcAddress, isValidXPAddress } from './isAddressValid';
 import { isBech32Address } from './address';
 
 jest.mock('ethers', () => ({
@@ -9,7 +9,7 @@ jest.mock('ethers', () => ({
 }));
 
 jest.mock('./address', () => ({
-  isBech32Address: jest.fn(),
+  isValidBtcAddress: jest.fn(),
 }));
 jest.mock('./isAddressValid', () => ({
   isValidXPAddress: jest.fn(),
@@ -32,7 +32,7 @@ describe('src/utils/isContactValid.ts', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.mocked(isAddress).mockImplementation(() => true);
-    jest.mocked(isBech32Address).mockImplementation(() => true);
+    jest.mocked(isValidBtcAddress).mockImplementation(() => true);
     jest.mocked(isValidXPAddress).mockImplementation(() => true);
   });
 

--- a/packages/common/src/utils/isContactValid.test.ts
+++ b/packages/common/src/utils/isContactValid.test.ts
@@ -7,10 +7,8 @@ jest.mock('ethers', () => ({
   isAddress: jest.fn(),
 }));
 
-jest.mock('./address', () => ({
-  isValidBtcAddress: jest.fn(),
-}));
 jest.mock('./isAddressValid', () => ({
+  isValidBtcAddress: jest.fn(),
   isValidXPAddress: jest.fn(),
 }));
 describe('src/utils/isContactValid.ts', () => {

--- a/packages/common/src/utils/isContactValid.ts
+++ b/packages/common/src/utils/isContactValid.ts
@@ -1,8 +1,11 @@
 import type { Contact } from '@avalabs/types';
 import { isAddress } from 'ethers';
-import { isValidSvmAddress, isValidXPAddress } from './isAddressValid';
+import {
+  isValidBtcAddress,
+  isValidSvmAddress,
+  isValidXPAddress,
+} from './isAddressValid';
 import { PartialBy } from '@core/types';
-import { isBech32Address } from './address';
 
 export const isContactValid = (contact: PartialBy<Contact, 'id'>) => {
   if (
@@ -17,7 +20,7 @@ export const isContactValid = (contact: PartialBy<Contact, 'id'>) => {
 
   const isAddressValid =
     (!contact.address || isAddress(contact.address)) &&
-    (!contact.addressBTC || isBech32Address(contact.addressBTC)) &&
+    (!contact.addressBTC || isValidBtcAddress(contact.addressBTC)) &&
     (!contact.addressXP || isValidXPAddress(contact.addressXP)) &&
     (!contact.addressSVM || isValidSvmAddress(contact.addressSVM));
 

--- a/packages/common/src/utils/isValidAddress.test.ts
+++ b/packages/common/src/utils/isValidAddress.test.ts
@@ -29,6 +29,8 @@ describe('utils/isAddressValid.ts', () => {
         expected: false,
       },
       { address: 'bc1qnat454n4sf7vshtqvz6wtx2pccfct70dpm2sp5', expected: true },
+      // P2SH address
+      { address: '3P14159f73E4gFr7JterCCQh9QjiTjiZrG', expected: true },
     ];
     it.each(addressEntries)(
       'returns $expected for $address',

--- a/packages/common/src/utils/isValidAddress.test.ts
+++ b/packages/common/src/utils/isValidAddress.test.ts
@@ -31,6 +31,8 @@ describe('utils/isAddressValid.ts', () => {
       { address: 'bc1qnat454n4sf7vshtqvz6wtx2pccfct70dpm2sp5', expected: true },
       // P2SH address
       { address: '3P14159f73E4gFr7JterCCQh9QjiTjiZrG', expected: true },
+      // P2PKH address
+      { address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', expected: true },
     ];
     it.each(addressEntries)(
       'returns $expected for $address',


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-14337
Figma: N/A

<!-- Describe the changes -->
<!-- Link the Jira ticket and Figma designs. Prefer listing expectations vs. linking large docs like PRD -->

This PR adds support for P2SH/Base58 BTC addresses via validation for Send & contacts

## Testing Instructions

<!-- Add expected testing steps - be specific about whether or not you have a wallet connected, new routes, etc. -->
1. Visit Send
2. Opt to send Bitcoin
3. Use P2SH address (`3P14159f73E4gFr7JterCCQh9QjiTjiZrG`) - ensure it passes validation - **DO NOT SEND TO THIS ADDRESS, I PULLED IT OFF GOOGLE - IT IS NOT OUR ADDRESS!**
4. Visit contacts
5. Add above address as contact - ensure it passes validation

## Media

<!-- Add screenshots and videos of the feature/changes. Great opportunity to self-QA before sharing PR -->
<!-- Bonus points for including a Loom demoing features and explaining code changes -->

No media.