### PR TITLE
ci: lavamoat policy check+update workflow

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -2,7 +2,7 @@ name: PR checks
 on: pull_request
 jobs:
   lint:
-    name: Lint
+    name: Lint and build
     runs-on: ubuntu-latest
     environment: alpha
     steps:
@@ -39,12 +39,3 @@ jobs:
           if [[ $(git status --short) == '' ]]; then exit 0; else exit 1; fi
       - name: Test
         run: yarn test
-
-  # Production build + LavaMoat policy drift detection live in their own
-  # reusable workflow. It uploads a `.patch` artifact when policies drift,
-  # which `update-lavamoat-policies.yaml` replays back onto the PR branch
-  # when a maintainer comments `/update-lavamoat-policies`.
-  validate-lavamoat-policies:
-    name: Validate LavaMoat policies
-    uses: ./.github/workflows/validate-lavamoat-policies.yaml
-    secrets: inherit

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -2,7 +2,7 @@ name: PR checks
 on: pull_request
 jobs:
   lint:
-    name: Lint and build
+    name: Lint
     runs-on: ubuntu-latest
     environment: alpha
     steps:
@@ -39,18 +39,12 @@ jobs:
           if [[ $(git status --short) == '' ]]; then exit 0; else exit 1; fi
       - name: Test
         run: yarn test
-      - name: Build extension
-        run: yarn build
-      - name: Check LavaMoat policies are up to date
-        run: |
-          # Match every policy.json under any `lavamoat/rspack/` directory
-          # (apps/* and packages/*) so this still covers new bundles when
-          # LavaMoat is wired into them later.
-          POLICY_PATHSPEC=':(glob)**/lavamoat/rspack/policy.json'
-          DRIFTED=$(git status --porcelain -- "$POLICY_PATHSPEC")
-          if [[ -n "$DRIFTED" ]]; then
-            echo "::error::LavaMoat policy drift detected. Run 'yarn build' locally and commit the regenerated policy.json file(s)."
-            echo "$DRIFTED"
-            git --no-pager diff -- "$POLICY_PATHSPEC"
-            exit 1
-          fi
+
+  # Production build + LavaMoat policy drift detection live in their own
+  # reusable workflow. It uploads a `.patch` artifact when policies drift,
+  # which `update-lavamoat-policies.yaml` replays back onto the PR branch
+  # when a maintainer comments `/update-lavamoat-policies`.
+  validate-lavamoat-policies:
+    name: Validate LavaMoat policies
+    uses: ./.github/workflows/validate-lavamoat-policies.yaml
+    secrets: inherit

--- a/.github/workflows/update-lavamoat-policies.yaml
+++ b/.github/workflows/update-lavamoat-policies.yaml
@@ -1,0 +1,179 @@
+name: Update LavaMoat policies
+
+# Comment-driven companion to `validate-lavamoat-policies.yaml`. When a
+# maintainer leaves a `/update-lavamoat-policies` comment on a PR, this
+# workflow looks at the latest `pr-checks` run for the PR's head commit,
+# downloads the `lavamoat-policy-diff` artifact that the validate job
+# uploads on drift, applies it on top of the PR branch, and pushes a
+# commit back.
+#
+# Policy generation itself happens in the validate workflow; this one
+# never runs `yarn build` and never touches secrets — it just replays the
+# diff that CI already produced.
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: update-lavamoat-policies-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Update LavaMoat policies
+    # `issue_comment` fires on both issues and PRs; gate on `pull_request`
+    # to skip plain issues, and on the literal command to skip every
+    # other comment on every PR in the repo.
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/update-lavamoat-policies') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+      COMMENT_ID: ${{ github.event.comment.id }}
+      ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Acknowledge the command
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content='+1'
+
+      - name: Fetch PR metadata
+        id: pr
+        run: |
+          INFO=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json isCrossRepository,headRefOid,headRefName)
+          {
+            echo "is_cross_repo=$(echo "$INFO" | jq -r '.isCrossRepository')"
+            echo "head_sha=$(echo "$INFO" | jq -r '.headRefOid')"
+            echo "head_branch=$(echo "$INFO" | jq -r '.headRefName')"
+          } >> "$GITHUB_OUTPUT"
+
+      # `secrets.GITHUB_TOKEN` cannot push to forks, so bail out early
+      # with a clear message rather than fail mid-push.
+      - name: Reject cross-repo PRs
+        if: ${{ steps.pr.outputs.is_cross_repo == 'true' }}
+        run: |
+          BODY=$'`/update-lavamoat-policies` cannot be used on cross-repository pull requests because GitHub Actions cannot push to fork branches.\n\nPlease regenerate the policy files locally with `yarn build` and push them to the fork manually.'
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
+          exit 1
+
+      - name: Find pr-checks run for the PR head commit
+        id: ci-run
+        run: |
+          HEAD_SHA='${{ steps.pr.outputs.head_sha }}'
+          echo "Looking for a completed pr-checks run for ${HEAD_SHA}..."
+          RUNS_JSON=$(gh run list \
+            --workflow=pr-checks.yaml \
+            --repo "${REPO}" \
+            --commit="${HEAD_SHA}" \
+            --limit=5 \
+            --json databaseId,status,conclusion)
+          RUN_ID=$(echo "$RUNS_JSON" | jq -r '[.[] | select(.status == "completed")] | .[0].databaseId // empty')
+          if [ -z "$RUN_ID" ]; then
+            BODY=$'No completed `pr-checks` run was found for this PR head commit. Wait for CI to finish and try `/update-lavamoat-policies` again.'
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
+            exit 1
+          fi
+          echo "Using pr-checks run ${RUN_ID}"
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine validate-lavamoat-policies job status
+        id: validate-status
+        run: |
+          JOBS_JSON=$(gh api \
+            --paginate \
+            "/repos/${REPO}/actions/runs/${{ steps.ci-run.outputs.run_id }}/jobs" \
+            --jq '[.jobs[] | select(.name | contains("Validate LavaMoat policies"))]')
+          JOB_COUNT=$(echo "$JOBS_JSON" | jq 'length')
+          if [ "$JOB_COUNT" -eq 0 ]; then
+            BODY=$'The `pr-checks` run did not include `Validate LavaMoat policies`. Nothing to update.'
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
+            exit 1
+          fi
+          # If every validate job succeeded there is no artifact to apply.
+          FAILED=$(echo "$JOBS_JSON" | jq '[.[] | select(.conclusion != "success")] | length')
+          echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
+
+      - name: Post comment (no drift)
+        if: ${{ steps.validate-status.outputs.failed == '0' }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "No LavaMoat policy drift detected on the latest \`pr-checks\` run — nothing to update."
+
+      # Stop the job cleanly when the validate workflow passed — there is
+      # no artifact to download and nothing to commit.
+      - name: Stop if no drift
+        if: ${{ steps.validate-status.outputs.failed == '0' }}
+        run: exit 0
+
+      # Download outside the workspace so the next `actions/checkout` step
+      # doesn't wipe the patch files when it cleans the working directory.
+      - name: Download policy diff artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # Pattern + merge-multiple keeps this forward-compatible with a
+          # future split into one validate job per bundle (each uploading
+          # its own `lavamoat-policy-diff-<bundle>` artifact).
+          pattern: lavamoat-policy-diff*
+          merge-multiple: true
+          path: /tmp/lavamoat-policy-diffs
+          run-id: ${{ steps.ci-run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify diff artifacts exist
+        id: artifacts
+        run: |
+          if compgen -G '/tmp/lavamoat-policy-diffs/*.patch' > /dev/null; then
+            echo "Found policy diff artifacts:"
+            ls -la /tmp/lavamoat-policy-diffs/
+          else
+            BODY=$'The `validate-lavamoat-policies` job failed but no policy diff artifact was produced (the job may have crashed before uploading). See the [validation run logs]('"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.ci-run.outputs.run_id }}"$').'
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Switch to PR branch
+        run: gh pr checkout "${PR_NUMBER}"
+
+      # The diff is unconditionally produced from the PR head commit, so
+      # `git apply` should land cleanly. If it doesn't, the PR has moved
+      # forward since the validate run and the patch is stale — surface
+      # that to the user instead of trying to force-apply it.
+      - name: Apply policy diff
+        run: |
+          for patch in /tmp/lavamoat-policy-diffs/*.patch; do
+            echo "Applying ${patch}..."
+            git apply "${patch}"
+          done
+
+      - name: Commit and push
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -am "chore: update LavaMoat policies"
+          git push
+
+      - name: Post success comment
+        run: |
+          BODY=$'LavaMoat policies updated. 👀 Please review the diff for suspicious new powers before approving.\n\n🧠 How to read a policy diff: https://lavamoat.github.io/guides/policy-diff/#what-to-look-for-when-reviewing-a-policy-diff'
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
+
+      - name: Post failure comment
+        if: ${{ failure() && steps.pr.outputs.is_cross_repo != 'true' }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "Policy update failed. [Review the logs or retry the command here](${ACTION_RUN_URL})."

--- a/.github/workflows/update-lavamoat-policies.yaml
+++ b/.github/workflows/update-lavamoat-policies.yaml
@@ -1,15 +1,35 @@
-name: Update LavaMoat policies
+name: LavaMoat
 
 # Comment-driven companion to `validate-lavamoat-policies.yaml`. When a
 # maintainer leaves a `/update-lavamoat-policies` comment on a PR, this
-# workflow looks at the latest `pr-checks` run for the PR's head commit,
-# downloads the `lavamoat-policy-diff` artifact that the validate job
-# uploads on drift, applies it on top of the PR branch, and pushes a
-# commit back.
+# workflow looks at the latest `validate-lavamoat-policies` run for the
+# PR's head commit, downloads the `lavamoat-policy-diff` artifact that
+# the validate workflow uploads on drift, applies it on top of the PR
+# branch, and commits the result back through GitHub's GraphQL API.
 #
 # Policy generation itself happens in the validate workflow; this one
 # never runs `yarn build` and never touches secrets — it just replays the
 # diff that CI already produced.
+#
+# Two non-obvious constraints on how the commit lands:
+#  1. The repo requires signed commits, so we *cannot* `git push` — a
+#     plain CI push produces an unsigned commit that branch protection
+#     rejects. Instead we call the `createCommitOnBranch` GraphQL
+#     mutation, which signs the commit on the server with GitHub's
+#     `web-flow` key and shows it as `Verified` (same mechanism
+#     `dependabot[bot]` uses).
+#  2. `GITHUB_TOKEN`-driven pushes deliberately do not re-trigger
+#     workflows, but `workflow_dispatch` IS one of the two documented
+#     exceptions. After committing we fire `gh workflow run` to
+#     dispatch `validate-lavamoat-policies.yaml` against the PR branch
+#     so the `Validate LavaMoat policies` check refreshes against the
+#     new HEAD without any manual intervention. We intentionally do NOT
+#     re-dispatch `pr-checks.yaml` — lint/typecheck/test already passed
+#     on the original PR run for code that hasn't changed (only
+#     policy.json files differ), and re-running them would just burn CI.
+#     If `Lint` is in your branch protection's required-checks list,
+#     the PR will sit waiting for it until you push another commit or
+#     hit "Re-run all jobs" on the original pr-checks run.
 on:
   issue_comment:
     types: [created]
@@ -20,7 +40,7 @@ concurrency:
 
 jobs:
   update:
-    name: Update LavaMoat policies
+    name: Update policies
     # `issue_comment` fires on both issues and PRs; gate on `pull_request`
     # to skip plain issues, and on the literal command to skip every
     # other comment on every PR in the repo.
@@ -31,7 +51,10 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      actions: read
+      # `read` is enough to list runs and download artifacts; the bump
+      # to `write` is for the `gh workflow run` re-dispatch at the end
+      # of the job, which calls the `actions:write` REST endpoint.
+      actions: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
@@ -67,52 +90,46 @@ jobs:
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
           exit 1
 
-      - name: Find pr-checks run for the PR head commit
+      # The validate workflow is its own top-level workflow now (not a
+      # `workflow_call` from `pr-checks`), so we look at its runs directly
+      # — both the initial `pull_request` run and any subsequent
+      # `workflow_dispatch` re-run land here. `--limit 5` gives us
+      # headroom in case a previous `/update-lavamoat-policies` already
+      # produced a passing dispatched run that we should prefer.
+      - name: Find validate-lavamoat-policies run for the PR head commit
         id: ci-run
         run: |
           HEAD_SHA='${{ steps.pr.outputs.head_sha }}'
-          echo "Looking for a completed pr-checks run for ${HEAD_SHA}..."
-          RUNS_JSON=$(gh run list \
-            --workflow=pr-checks.yaml \
+          echo "Looking for a completed validate-lavamoat-policies run for ${HEAD_SHA}..."
+          RUN=$(gh run list \
+            --workflow=validate-lavamoat-policies.yaml \
             --repo "${REPO}" \
             --commit="${HEAD_SHA}" \
             --limit=5 \
-            --json databaseId,status,conclusion)
-          RUN_ID=$(echo "$RUNS_JSON" | jq -r '[.[] | select(.status == "completed")] | .[0].databaseId // empty')
+            --json databaseId,status,conclusion \
+            --jq '[.[] | select(.status == "completed")] | .[0]')
+          RUN_ID=$(echo "$RUN" | jq -r '.databaseId // empty')
+          CONCLUSION=$(echo "$RUN" | jq -r '.conclusion // empty')
           if [ -z "$RUN_ID" ]; then
-            BODY=$'No completed `pr-checks` run was found for this PR head commit. Wait for CI to finish and try `/update-lavamoat-policies` again.'
+            BODY=$'No completed `validate-lavamoat-policies` run was found for this PR head commit. Wait for CI to finish and try `/update-lavamoat-policies` again.'
             gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
             exit 1
           fi
-          echo "Using pr-checks run ${RUN_ID}"
-          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
-
-      - name: Determine validate-lavamoat-policies job status
-        id: validate-status
-        run: |
-          JOBS_JSON=$(gh api \
-            --paginate \
-            "/repos/${REPO}/actions/runs/${{ steps.ci-run.outputs.run_id }}/jobs" \
-            --jq '[.jobs[] | select(.name | contains("Validate LavaMoat policies"))]')
-          JOB_COUNT=$(echo "$JOBS_JSON" | jq 'length')
-          if [ "$JOB_COUNT" -eq 0 ]; then
-            BODY=$'The `pr-checks` run did not include `Validate LavaMoat policies`. Nothing to update.'
-            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
-            exit 1
-          fi
-          # If every validate job succeeded there is no artifact to apply.
-          FAILED=$(echo "$JOBS_JSON" | jq '[.[] | select(.conclusion != "success")] | length')
-          echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
+          echo "Using validate-lavamoat-policies run ${RUN_ID} (conclusion: ${CONCLUSION})"
+          {
+            echo "run_id=${RUN_ID}"
+            echo "conclusion=${CONCLUSION}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post comment (no drift)
-        if: ${{ steps.validate-status.outputs.failed == '0' }}
+        if: ${{ steps.ci-run.outputs.conclusion == 'success' }}
         run: |
-          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "No LavaMoat policy drift detected on the latest \`pr-checks\` run — nothing to update."
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "No LavaMoat policy drift detected on the latest \`validate-lavamoat-policies\` run — nothing to update."
 
       # Stop the job cleanly when the validate workflow passed — there is
       # no artifact to download and nothing to commit.
       - name: Stop if no drift
-        if: ${{ steps.validate-status.outputs.failed == '0' }}
+        if: ${{ steps.ci-run.outputs.conclusion == 'success' }}
         run: exit 0
 
       # Download outside the workspace so the next `actions/checkout` step
@@ -136,15 +153,21 @@ jobs:
             echo "Found policy diff artifacts:"
             ls -la /tmp/lavamoat-policy-diffs/
           else
-            BODY=$'The `validate-lavamoat-policies` job failed but no policy diff artifact was produced (the job may have crashed before uploading). See the [validation run logs]('"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.ci-run.outputs.run_id }}"$').'
+            BODY=$'`validate-lavamoat-policies` failed but no policy diff artifact was produced (the job may have crashed before uploading). See the [validation run logs]('"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.ci-run.outputs.run_id }}"$').'
             gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
             exit 1
           fi
 
+      # We only need the working tree to apply the patch — we never push
+      # back through git. The commit is created via the
+      # `createCommitOnBranch` GraphQL mutation below so GitHub signs it
+      # with its `web-flow` key and the resulting commit shows up as
+      # `Verified`. The repo's branch protection requires signed commits;
+      # a plain `git push` from CI would produce an unsigned commit and
+      # be rejected.
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Switch to PR branch
@@ -154,23 +177,71 @@ jobs:
       # `git apply` should land cleanly. If it doesn't, the PR has moved
       # forward since the validate run and the patch is stale — surface
       # that to the user instead of trying to force-apply it.
-      - name: Apply policy diff
+      - name: Apply policy diff to the working tree
         run: |
           for patch in /tmp/lavamoat-policy-diffs/*.patch; do
             echo "Applying ${patch}..."
             git apply "${patch}"
           done
 
-      - name: Commit and push
+      # `createCommitOnBranch` requires the SHA the branch currently
+      # points to. `git rev-parse HEAD` gives us the SHA we checked out;
+      # if origin moved in the meantime the mutation will reject the call
+      # with an expected-OID mismatch, which is the right behaviour —
+      # better to fail than to silently overwrite newer work.
+      - name: Create signed commit via createCommitOnBranch
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -am "chore: update LavaMoat policies"
-          git push
+          HEAD_OID=$(git rev-parse HEAD)
+          BRANCH='${{ steps.pr.outputs.head_branch }}'
+
+          # `additions` is `[{path, contents: <base64>}, ...]`. We diff
+          # against HEAD (== the SHA we checked out, before `git apply`)
+          # so the list contains exactly the policy files the patch
+          # touched and nothing else.
+          ADDITIONS_JSON=$(
+            git diff --name-only HEAD -- ':(glob)**/lavamoat/rspack/policy.json' |
+              while IFS= read -r file; do
+                jq -n \
+                  --arg path "$file" \
+                  --arg contents "$(base64 < "$file" | tr -d '\n')" \
+                  '{path: $path, contents: $contents}'
+              done | jq -s '.'
+          )
+
+          if [ "$(echo "$ADDITIONS_JSON" | jq 'length')" -eq 0 ]; then
+            echo "::error::Patch applied but no policy.json files changed — refusing to create an empty commit."
+            exit 1
+          fi
+
+          jq -n \
+            --arg repo "$REPO" \
+            --arg branch "$BRANCH" \
+            --arg headOid "$HEAD_OID" \
+            --argjson additions "$ADDITIONS_JSON" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                  message: { headline: "chore: update LavaMoat policies" },
+                  expectedHeadOid: $headOid,
+                  fileChanges: { additions: $additions }
+                }
+              }
+            }' | gh api graphql --input -
+
+      # `createCommitOnBranch` returns once the commit is on the branch,
+      # so by the time the dispatched run starts `actions/checkout` is
+      # guaranteed to see the new HEAD.
+      - name: Re-dispatch validate-lavamoat-policies against the new HEAD
+        run: |
+          gh workflow run validate-lavamoat-policies.yaml \
+            --repo "${REPO}" \
+            --ref '${{ steps.pr.outputs.head_branch }}'
 
       - name: Post success comment
         run: |
-          BODY=$'LavaMoat policies updated. 👀 Please review the diff for suspicious new powers before approving.\n\n🧠 How to read a policy diff: https://lavamoat.github.io/guides/policy-diff/#what-to-look-for-when-reviewing-a-policy-diff'
+          BODY=$'LavaMoat policies updated in a `Verified` commit, and `validate-lavamoat-policies` has been re-dispatched against the new HEAD — the previously red check should turn green on its own within a few minutes.\n\n👀 Please review the diff for suspicious new powers before approving.\n\n🧠 How to read a policy diff: https://lavamoat.github.io/guides/policy-diff/#what-to-look-for-when-reviewing-a-policy-diff'
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
 
       - name: Post failure comment

--- a/.github/workflows/update-lavamoat-policies.yaml
+++ b/.github/workflows/update-lavamoat-policies.yaml
@@ -1,4 +1,4 @@
-name: LavaMoat
+name: Update LavaMoat policies
 
 # Comment-driven companion to `validate-lavamoat-policies.yaml`. When a
 # maintainer leaves a `/update-lavamoat-policies` comment on a PR, this
@@ -41,10 +41,23 @@ concurrency:
 jobs:
   update:
     name: Update policies
-    # `issue_comment` fires on both issues and PRs; gate on `pull_request`
-    # to skip plain issues, and on the literal command to skip every
-    # other comment on every PR in the repo.
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/update-lavamoat-policies') }}
+    # Gates (all must hold for the workflow to fire):
+    #   1. It's a comment on a PR (not on a plain issue) — `issue_comment`
+    #      fires on both.
+    #   2. The comment body starts with the literal slash command — skips
+    #      every other comment on every PR in the repo.
+    #   3. The comment author has write-equivalent access on the repo.
+    #      Without this last gate, anyone who can comment on a public PR
+    #      could trigger a workflow with `contents: write` and have us
+    #      push a signed commit on their behalf. `author_association`
+    #      is set by GitHub on the event payload and cannot be spoofed
+    #      by the comment author. Accepted roles cover org members, repo
+    #      collaborators, and the org owner — i.e. anyone who already has
+    #      the access to push to the PR branch directly.
+    if: >-
+      ${{ github.event.issue.pull_request
+          && startsWith(github.event.comment.body, '/update-lavamoat-policies')
+          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -194,21 +207,57 @@ jobs:
           HEAD_OID=$(git rev-parse HEAD)
           BRANCH='${{ steps.pr.outputs.head_branch }}'
 
-          # `additions` is `[{path, contents: <base64>}, ...]`. We diff
-          # against HEAD (== the SHA we checked out, before `git apply`)
-          # so the list contains exactly the policy files the patch
-          # touched and nothing else.
-          ADDITIONS_JSON=$(
-            git diff --name-only HEAD -- ':(glob)**/lavamoat/rspack/policy.json' |
-              while IFS= read -r file; do
-                jq -n \
-                  --arg path "$file" \
-                  --arg contents "$(base64 < "$file" | tr -d '\n')" \
-                  '{path: $path, contents: $contents}'
-              done | jq -s '.'
-          )
+          # Walk the diff and partition by file status into the two arrays
+          # `createCommitOnBranch` accepts. Using `--name-status` (vs the
+          # earlier `--name-only`) lets us cope with:
+          #  - bundles being removed (D — a `policy.json` deletion would
+          #    otherwise crash `base64 < $file` because the file is gone),
+          #  - bundles being relocated (R — needs delete-old + add-new).
+          # The diff is taken against HEAD (== the SHA we checked out,
+          # before `git apply`) so the partition contains exactly the
+          # policy files the patch touched, nothing else.
+          ADDITIONS_JSON='[]'
+          DELETIONS_JSON='[]'
 
-          if [ "$(echo "$ADDITIONS_JSON" | jq 'length')" -eq 0 ]; then
+          add_file() {
+            local path="$1"
+            ADDITIONS_JSON=$(echo "$ADDITIONS_JSON" | jq \
+              --arg path "$path" \
+              --arg contents "$(base64 < "$path" | tr -d '\n')" \
+              '. + [{path: $path, contents: $contents}]')
+          }
+
+          delete_file() {
+            local path="$1"
+            DELETIONS_JSON=$(echo "$DELETIONS_JSON" | jq \
+              --arg path "$path" \
+              '. + [{path: $path}]')
+          }
+
+          while IFS=$'\t' read -r status path1 path2; do
+            case "$status" in
+              A|C|M)
+                add_file "$path1"
+                ;;
+              D)
+                delete_file "$path1"
+                ;;
+              R*)
+                # Rename: old path is gone, new path holds the content.
+                delete_file "$path1"
+                add_file "$path2"
+                ;;
+              *)
+                echo "::warning::Unhandled diff status '$status' for '$path1' — skipping"
+                ;;
+            esac
+          done < <(git diff --name-status HEAD -- ':(glob)**/lavamoat/rspack/policy.json')
+
+          TOTAL=$(jq -n \
+            --argjson a "$ADDITIONS_JSON" \
+            --argjson d "$DELETIONS_JSON" \
+            '($a | length) + ($d | length)')
+          if [ "$TOTAL" -eq 0 ]; then
             echo "::error::Patch applied but no policy.json files changed — refusing to create an empty commit."
             exit 1
           fi
@@ -218,6 +267,7 @@ jobs:
             --arg branch "$BRANCH" \
             --arg headOid "$HEAD_OID" \
             --argjson additions "$ADDITIONS_JSON" \
+            --argjson deletions "$DELETIONS_JSON" \
             '{
               query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
               variables: {
@@ -225,7 +275,7 @@ jobs:
                   branch: { repositoryNameWithOwner: $repo, branchName: $branch },
                   message: { headline: "chore: update LavaMoat policies" },
                   expectedHeadOid: $headOid,
-                  fileChanges: { additions: $additions }
+                  fileChanges: { additions: $additions, deletions: $deletions }
                 }
               }
             }' | gh api graphql --input -

--- a/.github/workflows/validate-lavamoat-policies.yaml
+++ b/.github/workflows/validate-lavamoat-policies.yaml
@@ -1,4 +1,4 @@
-name: LavaMoat
+name: Validate LavaMoat policies
 
 # Regenerates every `lavamoat/rspack/policy.json` under apps/* and
 # packages/* by running the production build, then compares the working
@@ -91,8 +91,15 @@ jobs:
         run: |
           yarn install
           yarn allow-scripts
+      # Mirrors `main_branch.yaml`'s shipping command so we're regenerating
+      # under the same rsbuild config that produces the alpha bundles.
+      # Functionally identical to `yarn build` today (both alpha and prod
+      # configs use `generateLavaMoatPolicy: true` + `getEnvVars('production')`),
+      # but parity protects us if the two configs ever diverge.
       - name: Build (regenerates LavaMoat policies)
-        run: yarn build
+        run: yarn build:alpha
+        env:
+          NO_SOURCE_MAPS: 'true'
       - name: Detect policy drift
         id: drift
         # The pathspec matches `policy.json` under any `lavamoat/rspack/`

--- a/.github/workflows/validate-lavamoat-policies.yaml
+++ b/.github/workflows/validate-lavamoat-policies.yaml
@@ -24,11 +24,12 @@ jobs:
     name: Validate policies
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # `alpha` provides the same secrets `pr-checks.yaml` uses for builds.
-    # LavaMoat inlines `process.env.*` literals it sees in source into the
-    # generated policy, so the env-var set here must match every other
-    # workflow that runs `yarn build`, or the policy will drift on the
-    # env-var diff alone.
+    # Uses the `alpha` environment so its secret set matches `main_branch.yaml`
+    # — the env vars resolved here MUST mirror the ones the shipping
+    # workflows (`main_branch.yaml`, `create_release.yaml`) use, or the
+    # policy CI validates against will not match the policy enforced in
+    # production. See the `Create env file` step below for the canonical
+    # list and the reasoning.
     environment: alpha
     permissions:
       contents: read
@@ -43,13 +44,49 @@ jobs:
           node-version: 20.x
       - name: Enable corepack
         run: corepack enable
+      # Env vars must be kept in sync with `main_branch.yaml` and
+      # `create_release.yaml` — those are the workflows that actually ship
+      # builds. LavaMoat's policy generator sees the post-codegen source
+      # (after rsbuild's `define` substitution), so any `process.env.X`
+      # that is NOT defined here stays as a literal `process.env.X` lookup
+      # and ends up in `policy.json` as a global allowlist entry. If this
+      # list diverges from the shipping workflows, the policy validated by
+      # CI will not match the policy that runs in production.
       - name: Create env file
         run: |
           touch .env.production
+          echo RELEASE=alpha >> .env.production
           echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> .env.production
+          echo 'POSTHOG_URL="${{ secrets.POSTHOG_URL }}"' >> .env.production
+          echo 'ANALYTICS_ENCRYPTION_KEY="${{ secrets.ANALYTICS_ENCRYPTION_KEY }}"' >> .env.production
+          echo 'ANALYTICS_ENCRYPTION_KEY_ID="${{ secrets.ANALYTICS_ENCRYPTION_KEY_ID }}"' >> .env.production
+          echo 'COVALENT_API_KEY="${{ secrets.COVALENT_API_KEY }}"' >> .env.production
           echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
           echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
           echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
+          echo 'SENTRY_DSN="${{ secrets.SENTRY_DSN }}"' >> .env.production
+          echo 'CORE_WEB_BASE_URL="${{ secrets.CORE_WEB_BASE_URL }}"' >> .env.production
+          echo 'WALLET_CONNECT_PROJECT_ID="${{ secrets.WALLET_CONNECT_PROJECT_ID }}"' >> .env.production
+          echo 'SEEDLESS_URL="${{ secrets.SEEDLESS_URL }}"' >> .env.production
+          echo 'SEEDLESS_ORG_ID="${{ secrets.SEEDLESS_ORG_ID }}"' >> .env.production
+          echo 'GOOGLE_OAUTH_CLIENT_ID="${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}"' >> .env.production
+          echo 'APPLE_OAUTH_CLIENT_ID="${{ secrets.APPLE_OAUTH_CLIENT_ID }}"' >> .env.production
+          echo 'APPLE_OAUTH_REDIRECT_URL="${{ secrets.APPLE_OAUTH_REDIRECT_URL }}"' >> .env.production
+          echo 'CUBESIGNER_ENV="${{ secrets.CUBESIGNER_ENV }}"' >> .env.production
+          echo 'SEEDLESS_FIDO_IDENTITY_URL="${{ secrets.SEEDLESS_FIDO_IDENTITY_URL }}"' >> .env.production
+          echo 'NEWSLETTER_BASE_URL="${{ secrets.NEWSLETTER_BASE_URL }}"' >> .env.production
+          echo 'NEWSLETTER_PORTAL_ID="${{ secrets.NEWSLETTER_PORTAL_ID }}"' >> .env.production
+          echo 'NEWSLETTER_FORM_ID="${{ secrets.NEWSLETTER_FORM_ID }}"' >> .env.production
+          echo 'FIREBASE_CONFIG="${{ secrets.FIREBASE_CONFIG }}"' >> .env.production
+          echo 'ID_SERVICE_URL="${{ secrets.ID_SERVICE_URL }}"' >> .env.production
+          echo 'GASLESS_SERVICE_URL="${{ secrets.GASLESS_SERVICE_URL }}"' >> .env.production
+          echo 'NOTIFICATION_SENDER_SERVICE_URL="${{ secrets.NOTIFICATION_SENDER_SERVICE_URL }}"' >> .env.production
+          echo 'EXTENSION_PUBLIC_KEY="${{ secrets.EXTENSION_PUBLIC_KEY }}"' >> .env.production
+          echo 'BALANCE_SERVICE_URL="${{ secrets.BALANCE_SERVICE_URL }}"' >> .env.production
+          echo 'PROFILE_SERVICE_URL="${{ secrets.PROFILE_SERVICE_URL }}"' >> .env.production
+          echo 'TOKEN_AGGREGATOR_SERVICE_URL="${{ secrets.TOKEN_AGGREGATOR_SERVICE_URL }}"' >> .env.production
+          echo 'MARKR_API_URL="${{ secrets.MARKR_API_URL }}"' >> .env.production
+          echo 'MARKR_API_TOKEN="${{ secrets.MARKR_API_TOKEN }}"' >> .env.production
       - name: Install dependencies
         run: |
           yarn install

--- a/.github/workflows/validate-lavamoat-policies.yaml
+++ b/.github/workflows/validate-lavamoat-policies.yaml
@@ -1,20 +1,27 @@
-name: Validate LavaMoat policies
+name: LavaMoat
 
-# Reusable workflow that regenerates every `lavamoat/rspack/policy.json`
-# under apps/* and packages/* by running the production build, then
-# compares the working tree against the committed policies. When a diff is
-# found the workflow uploads it as an artifact (so the comment-triggered
-# `update-lavamoat-policies.yaml` workflow can replay it onto the PR
-# branch) and fails the job.
+# Regenerates every `lavamoat/rspack/policy.json` under apps/* and
+# packages/* by running the production build, then compares the working
+# tree against the committed policies. When a diff is found, uploads it
+# as an artifact (so `update-lavamoat-policies.yaml` can replay it onto
+# the PR branch when a maintainer comments `/update-lavamoat-policies`)
+# and fails the job.
 #
-# This is intentionally `workflow_call`-only — `pr-checks.yaml` is the
-# orchestrator that invokes it on every PR.
+# Triggers:
+#  - `pull_request`: runs on every PR alongside `pr-checks.yaml`.
+#  - `workflow_dispatch`: re-invoked by `update-lavamoat-policies.yaml`
+#    against the PR branch after a signed policy commit lands, so the
+#    `Validate LavaMoat policies` check refreshes against the new HEAD
+#    without needing the rest of `pr-checks.yaml` (lint/typecheck/test)
+#    to run again. `workflow_dispatch` is one of the two events
+#    GITHUB_TOKEN is allowed to fire.
 on:
-  workflow_call:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   validate-lavamoat-policies:
-    name: Validate LavaMoat policies
+    name: Validate policies
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # `alpha` provides the same secrets `pr-checks.yaml` uses for builds.

--- a/.github/workflows/validate-lavamoat-policies.yaml
+++ b/.github/workflows/validate-lavamoat-policies.yaml
@@ -1,0 +1,86 @@
+name: Validate LavaMoat policies
+
+# Reusable workflow that regenerates every `lavamoat/rspack/policy.json`
+# under apps/* and packages/* by running the production build, then
+# compares the working tree against the committed policies. When a diff is
+# found the workflow uploads it as an artifact (so the comment-triggered
+# `update-lavamoat-policies.yaml` workflow can replay it onto the PR
+# branch) and fails the job.
+#
+# This is intentionally `workflow_call`-only — `pr-checks.yaml` is the
+# orchestrator that invokes it on every PR.
+on:
+  workflow_call:
+
+jobs:
+  validate-lavamoat-policies:
+    name: Validate LavaMoat policies
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # `alpha` provides the same secrets `pr-checks.yaml` uses for builds.
+    # LavaMoat inlines `process.env.*` literals it sees in source into the
+    # generated policy, so the env-var set here must match every other
+    # workflow that runs `yarn build`, or the policy will drift on the
+    # env-var diff alone.
+    environment: alpha
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Enable corepack
+        run: corepack enable
+      - name: Create env file
+        run: |
+          touch .env.production
+          echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> .env.production
+          echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
+          echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
+          echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
+      - name: Install dependencies
+        run: |
+          yarn install
+          yarn allow-scripts
+      - name: Build (regenerates LavaMoat policies)
+        run: yarn build
+      - name: Detect policy drift
+        id: drift
+        # The pathspec matches `policy.json` under any `lavamoat/rspack/`
+        # directory anywhere in the repo, so this still picks up new
+        # bundles (service worker, content script, offscreen, ...) the
+        # moment they wire LavaMoat in — no workflow change required.
+        run: |
+          POLICY_PATHSPEC=':(glob)**/lavamoat/rspack/policy.json'
+          if git diff --exit-code -- "$POLICY_PATHSPEC" > lavamoat-policy-diff.patch; then
+            rm -f lavamoat-policy-diff.patch
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+            echo "All LavaMoat policies are up to date."
+          else
+            echo "drifted=true" >> "$GITHUB_OUTPUT"
+            echo "::group::Policy diff"
+            cat lavamoat-policy-diff.patch
+            echo "::endgroup::"
+          fi
+      - name: Upload policy diff artifact
+        if: steps.drift.outputs.drifted == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          # Named with a stable prefix so `update-lavamoat-policies.yaml`
+          # can pick it up via a `pattern: lavamoat-policy-diff*` glob and
+          # also tolerate a future split into per-bundle validate jobs
+          # (e.g. `lavamoat-policy-diff-service-worker`).
+          name: lavamoat-policy-diff
+          path: lavamoat-policy-diff.patch
+          retention-days: 7
+          if-no-files-found: error
+      - name: Fail on drift
+        if: steps.drift.outputs.drifted == 'true'
+        run: |
+          echo "::error::LavaMoat policy drift detected. Comment '/update-lavamoat-policies' on the PR to have CI regenerate and commit the updated policy files, or regenerate locally with 'yarn build' and commit the result."
+          exit 1

--- a/apps/next/lavamoat/rspack/policy.json
+++ b/apps/next/lavamoat/rspack/policy.json
@@ -407,7 +407,6 @@
         "@core/ui>ledger-bitcoin": true,
         "@core/ui>lodash": true,
         "@core/ui>micro-signals": true,
-        "@rsbuild/plugin-node-polyfill>process": true,
         "react": true,
         "react-i18next": true,
         "@core/ui>react-router-dom": true,


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-14348
Figma: _not applicable_

1. Sets up CI infrastructure to keep LavaMoat policy files in sync without requiring contributors to run production builds locally. Adds a workflow that detects policy drift on every PR, and a comment-triggered companion that regenerates policies in CI and pushes the fix back to the PR branch as a signed (Verified) commit.

2. Replaces the inline `yarn build` + drift check that used to live in `pr-checks.yaml` with two dedicated workflow files:
- **`validate-lavamoat-policies.yaml`** — runs `yarn build` and diffs every `**/lavamoat/rspack/policy.json` against the committed copy. When the policy drifts it saves a `.patch` artifact and fails the check.
- **`update-lavamoat-policies.yaml`** — triggered by a `/update-lavamoat-policies` comment on a PR. Finds the failed validate run, downloads the diff artifact, applies it, creates a signed commit via the GitHub GraphQL `createCommitOnBranch` mutation (same server-side signing path `dependabot[bot]` and `changesets/action` use in `github-api` mode), and re-dispatches `validate-lavamoat-policies` against the new HEAD so the previously red check turns green on its own.

## Notes
**Why CI instead of local regeneration.** The LavaMoat plugin inlines `process.env.*` literals it sees in source into the generated policy. Without production secrets locally, regenerated policies drift on the env-var diff alone - contributors would either need to hand-edit policy files or hold prod secrets on their dev machines. CI has the secrets already, so this moves the regeneration burden there.

**Why a separate validate workflow.** The validate workflow is its own top-level workflow (rather than a `workflow_call` job inside `pr-checks.yaml`) so the update workflow can re-dispatch *only* it via `gh workflow run`. 

Re-dispatching the full `pr-checks` would re-run lint/typecheck/scanner/test on a `policy.json`-only commit, which is pure waste — a `policy.json` diff cannot break those checks.

⚠️ 
**Branch protection follow-up.** This PR removes the old `Build extension` + inline drift check from `pr-checks`'s `Lint` job. After merge, the branch protection required-checks list needs to be updated to:
- `Lint` (from `pr-checks.yaml`)
- `Validate LavaMoat policies` (from `validate-lavamoat-policies.yaml`)

## Testing

`issue_comment` workflows only fire for workflows already on the default branch, so `update-lavamoat-policies` cannot be exercised on this PR itself. The validate side IS testable here (it uses `pull_request`, which loads from the PR branch).



## Testing Instructions


### On this PR before merge
1. Confirm the `Validate LavaMoat policies` check ran on this PR,   executed `yarn build`, detected no drift, and exited successfully.

### After merge
1. Update branch protection on `main` to require `Lint` and  `Validate LavaMoat policies` (and drop any stale `Lint and build` requirement).
3. Open a throwaway PR that intentionally edits a committed `apps/next/lavamoat/rspack/policy.json` (e.g. delete one entry from a resource's `globals` map).
4. Confirm `Validate LavaMoat policies` fails on that PR and the failed run's Artifacts section contains `lavamoat-policy-diff`.
5. Comment `/update-lavamoat-policies` on the PR.
6. Within a minute, expect:
   - 👍 reaction on the comment.
   - A new commit on the PR branch authored by `github-actions[bot]`, subject `chore: update LavaMoat policies`, showing the green **Verified** badge.
   - A new `validate-lavamoat-policies` run on the new HEAD that turns the check green.
   - A success comment from the bot.
7. Open the new commit and confirm it only touches `policy.json` files
   and the contents match what local `yarn build` would have produced.

<!-- Add expected testing steps - be specific about whether or not you have a wallet connected, new routes, etc. -->

## Media
_not applicable_