### PR TITLE
fix: defer initialization to avoid brave renderer crash

### DIFF
--- a/packages/inpage/src/initializeInpageProvider.ts
+++ b/packages/inpage/src/initializeInpageProvider.ts
@@ -51,25 +51,35 @@ export function initializeProvider(
   );
   const multiWalletProxy = createMultiWalletProxy(evmProvider);
 
-  globalObject.addEventListener('eip6963:announceProvider', (event: any) => {
-    multiWalletProxy.addProvider(
-      new Proxy(
-        {
-          info: { ...event.detail.info },
-          ...event.detail.provider,
-        },
-        {
-          deleteProperty: () => true,
-          set: () => true,
-        },
-      ),
-    );
-  });
-
   setGlobalProvider(evmProvider, globalObject, multiWalletProxy);
   setAvalancheGlobalProvider(evmProvider, globalObject);
-  announceWalletProvider(evmProvider, globalObject);
-  announceChainAgnosticProvider(chainAgnosticProvider, globalObject);
+
+  // EIP-6963 event dispatch and listener registration is deferred to avoid
+  // triggering a renderer UAF crash in Brave's native js_ethereum_provider
+  // (brave/brave-core#36564).  Brave's C++ code listens for these events,
+  // and when they fire synchronously during document_start the RenderFrame
+  // reference can still be stale.  Deferring to the next task gives the
+  // renderer time to fully initialize.
+  // See: https://github.com/brave/brave-core/pull/36564
+  setTimeout(() => {
+    globalObject.addEventListener('eip6963:announceProvider', (event: any) => {
+      multiWalletProxy.addProvider(
+        new Proxy(
+          {
+            info: { ...event.detail.info },
+            ...event.detail.provider,
+          },
+          {
+            deleteProperty: () => true,
+            set: () => true,
+          },
+        ),
+      );
+    });
+
+    announceWalletProvider(evmProvider, globalObject);
+    announceChainAgnosticProvider(chainAgnosticProvider, globalObject);
+  }, 500);
 
   try {
     initializeSolanaProvider(


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-14355
Figma: N/A

<!-- Describe the changes -->
<!-- Link the Jira ticket and Figma designs. Prefer listing expectations vs. linking large docs like PRD -->

This PR attempts to hotfix a crash introduced in Brave v1.90.128 (See: https://github.com/brave/brave-core/pull/36564/changes).

The TL;dr non-computer science-y reason for the crash was that a change was made to Brave's Wallet code to no longer use a raw pointer for the `RenderFrame` reference used in the code. It instead uses an existing reference than appears to sometimes be stale. When the extension announces its presence via `EIP6963`, it triggers a memory fault as the reference becomes stale. This appears to be fixed when differing the announcement by a few frames and giving the code more of a chance to stabilize. 

In testing, this introduction of a timeout appears to have no meaningful effect to the end user (besides the _positive_ effect of allowing extension to properly load on Brave).

## Notes

<!-- Additional notes and context. Explain non-synchronized design, product, or architectural design decisions -->

## Testing

<!-- Add high-level testing information for the reviewer to properly QA (wallet setup, local storage overrides, etc.) -->
1. Download/launch Brave >=1.90.128
2. Install or have Core Extension
3. Ensure Brave Wallet is enabled and added as an Ethereum fallback on your Web3 settings (`brave://settings/web3`)
4. Ensure that you can navigate web pages as expected (previous crash would happen almost instantaneously)
5. Ensure you can connect to Core (or any dApp) and validate functionality
6. Ensure crash does not occur

