### PR TITLE
fix: brave wallet conflicts

### DIFF
--- a/packages/inpage/src/MultiWalletProviderProxy.test.ts
+++ b/packages/inpage/src/MultiWalletProviderProxy.test.ts
@@ -567,6 +567,47 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
 
       expect(result).toEqual(['0x000000']);
       expect(mwpp.defaultProvider).toBe(provider2);
+
+      // Subscribing AFTER the switch on a provider without addListener
+      // (and without `on`) must also be a no-op, not a crash.
+      expect(() => mwpp.on('chainChanged', jest.fn())).not.toThrow();
+    });
+
+    it('falls back to `on` for providers that do not expose addListener', async () => {
+      const provider = new EventEmitter() as EVMProvider & EventEmitter;
+      (provider as any).info = providerInfo;
+      (provider as any).isAvalanche = true;
+      (provider as any).removeAllListeners = jest.fn();
+      (provider as any).request = jest.fn().mockResolvedValue(1); // Select provider2
+
+      // Provider that only implements `on` (typical for EIP-1193-only wallets)
+      const provider2Emitter = new EventEmitter();
+      const provider2 = {
+        info: { ...providerInfo, uuid: 'uuid-2' },
+        request: jest.fn().mockResolvedValue(['0x000000']),
+        on: provider2Emitter.on.bind(provider2Emitter),
+        emit: provider2Emitter.emit.bind(provider2Emitter),
+      };
+
+      const mwpp = new MultiWalletProviderProxy(provider);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 } as any);
+
+      // Subscribe BEFORE the switch; the listener should be migrated to provider2
+      const beforeSwitch = jest.fn();
+      mwpp.on('accountsChanged', beforeSwitch);
+
+      await mwpp.request({ method: 'eth_requestAccounts' });
+      expect(mwpp.defaultProvider).toBe(provider2);
+
+      // Subscribe AFTER the switch; relay should attach via `on` fallback
+      const afterSwitch = jest.fn();
+      expect(() => mwpp.on('chainChanged', afterSwitch)).not.toThrow();
+
+      provider2.emit('accountsChanged', ['0xabc']);
+      provider2.emit('chainChanged', { chainId: '0x1' });
+
+      expect(beforeSwitch).toHaveBeenCalledWith(['0xabc']);
+      expect(afterSwitch).toHaveBeenCalledWith({ chainId: '0x1' });
     });
   });
 

--- a/packages/inpage/src/MultiWalletProviderProxy.test.ts
+++ b/packages/inpage/src/MultiWalletProviderProxy.test.ts
@@ -69,8 +69,8 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
         info: { ...providerInfo, uuid: 'uuid-3' },
       });
 
-      mwpp.addProvider(provider2);
-      mwpp.addProvider(provider3);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 });
+      mwpp.addProvider({ info: provider3.info, provider: provider3 });
 
       expect(mwpp.defaultProvider).toBe(provider);
 
@@ -89,8 +89,8 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
       const provider3 = new EVMProvider({
         info: { ...providerInfo, uuid: 'uuid-2' },
       });
-      mwpp.addProvider(provider2);
-      mwpp.addProvider(provider3);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 });
+      mwpp.addProvider({ info: provider3.info, provider: provider3 });
 
       expect(mwpp.providers.length as any).toBe(2);
       expect((mwpp.providers[0] as any).info.uuid).toBe(EVM_PROVIDER_INFO_UUID);
@@ -111,7 +111,7 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
       } as any);
 
       const mwpp = new MultiWalletProviderProxy(provider);
-      mwpp.addProvider(provider2);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 });
 
       const requestAccountsCallback = jest.fn();
       mwpp
@@ -179,7 +179,7 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
         request: jest.fn(),
       } as any);
       const mwpp = new MultiWalletProviderProxy(provider);
-      mwpp.addProvider(provider2);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 });
 
       // user selects core
       provider.request = jest
@@ -238,7 +238,7 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
         enable: jest.fn().mockResolvedValue(['0x000000']),
       } as any);
       const mwpp = new MultiWalletProviderProxy(provider);
-      mwpp.addProvider(provider2);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 });
 
       // user selects metamask
       provider.request = jest.fn().mockResolvedValue(1);
@@ -282,7 +282,7 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
         request: jest.fn().mockResolvedValue(['0x000000']),
       } as any);
       const mwpp = new MultiWalletProviderProxy(provider);
-      mwpp.addProvider(provider2);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 });
 
       // user selects metamask
       provider.request = jest.fn().mockResolvedValue(1);
@@ -338,7 +338,7 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
         request: jest.fn().mockResolvedValue(['0x000000']),
       } as any);
       const mwpp = new MultiWalletProviderProxy(provider);
-      mwpp.addProvider(provider2);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 });
 
       // user selects metamask
       provider.request = jest.fn().mockResolvedValue(1);
@@ -396,7 +396,7 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
       } as any);
 
       const mwpp = new MultiWalletProviderProxy(provider);
-      mwpp.addProvider(provider2);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 });
 
       const requestPermissionsCallback = jest.fn();
       mwpp
@@ -461,7 +461,7 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
       } as any);
 
       const mwpp = new MultiWalletProviderProxy(provider);
-      mwpp.addProvider(provider2);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 });
 
       // Start first request - this will trigger wallet selection
       mwpp.request({ method: 'eth_requestAccounts' });
@@ -524,7 +524,7 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
       } as any);
 
       const mwpp = new MultiWalletProviderProxy(provider);
-      mwpp.addProvider(provider2);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 });
 
       // First request - wallet selection fails, but request still goes through
       await mwpp.request({ method: 'eth_requestAccounts' });
@@ -556,7 +556,7 @@ describe('src/background/providers/MultiWalletProviderProxy', () => {
       };
 
       const mwpp = new MultiWalletProviderProxy(provider);
-      mwpp.addProvider(provider2 as any);
+      mwpp.addProvider({ info: provider2.info, provider: provider2 } as any);
 
       // Subscribe to an event before switching
       const eventCallback = jest.fn();

--- a/packages/inpage/src/MultiWalletProviderProxy.ts
+++ b/packages/inpage/src/MultiWalletProviderProxy.ts
@@ -9,43 +9,50 @@ import type {
   JsonRpcResponse,
 } from '@core/types';
 
+import type { EIP6963ProviderInfo } from './models';
+
 const CONNECT_METHODS = [
   'eth_requestAccounts',
   'wallet_requestAccountPermission',
   'wallet_requestPermissions',
 ] as const as DAppProviderRequest[];
 
+export type ProviderEntry = {
+  info: EIP6963ProviderInfo;
+  provider: EVMProvider;
+};
+
 export class MultiWalletProviderProxy extends EventEmitter {
-  #_providers: EVMProvider[] = [];
+  #_providers: ProviderEntry[] = [];
   #isWalletSelected = false;
   #isWalletSelectionPending = false;
-  #defaultProvider;
+  #defaultEntry: ProviderEntry;
 
-  public get defaultProvider() {
-    return this.#defaultProvider;
+  public get defaultProvider(): EVMProvider {
+    return this.#defaultEntry.provider;
   }
   get providers() {
     // When the user decides to select the providers and there is more than one provider and EVMProvider is selected, we want to trigger the wallet selection. So we replace EVMProvider with this.
     if (this.#_providers.length > 1) {
-      return [...this.#_providers].map((provider) => {
-        if ((provider as EVMProvider)?.isAvalanche) {
+      return this.#_providers.map((entry) => {
+        if (entry.provider?.isAvalanche) {
           return new Proxy(this, {
             get(target, prop) {
               // eslint-disable-next-line no-prototype-builtins
               if (target.hasOwnProperty(prop)) {
                 return target[prop];
                 // eslint-disable-next-line no-prototype-builtins
-              } else if ((provider as EVMProvider).hasOwnProperty(prop)) {
-                return (provider as EVMProvider)[prop];
+              } else if (entry.provider.hasOwnProperty(prop)) {
+                return entry.provider[prop];
               }
             },
           });
         }
-        return provider;
+        return entry.provider;
       });
     }
 
-    return [...this.#_providers];
+    return this.#_providers.map((entry) => entry.provider);
   }
 
   constructor(private coreProvider: EVMProvider) {
@@ -57,23 +64,22 @@ export class MultiWalletProviderProxy extends EventEmitter {
     this.request = this.request.bind(this);
     this._request = this._request.bind(this);
 
-    this.#defaultProvider = coreProvider;
-
-    this.#_providers.push(coreProvider);
+    this.#defaultEntry = { info: coreProvider.info, provider: coreProvider };
+    this.#_providers.push(this.#defaultEntry);
 
     // Listen for new event subscriptions on the multi wallet provider.
     // We subscribe to those events on the currently used provider so
     // that the they can be re-emitted by the proxy.
     this.addListener('newListener', (event) => {
-      this.#defaultProvider.addListener(event, (...args: any) => {
+      this.#defaultEntry.provider.addListener(event, (...args: any) => {
         this.emit(event, ...args);
       });
     });
   }
 
-  public addProvider(providerDetail) {
-    const isProviderAdded = this.#_providers.find((provider) => {
-      return provider.info.uuid === providerDetail.info.uuid;
+  public addProvider(providerDetail: ProviderEntry) {
+    const isProviderAdded = this.#_providers.find((entry) => {
+      return entry.info.uuid === providerDetail.info.uuid;
     });
 
     if (!isProviderAdded) {
@@ -98,11 +104,10 @@ export class MultiWalletProviderProxy extends EventEmitter {
       .request({
         method: 'avalanche_selectWallet',
         params: [
-          // using any since we don't really know what kind of provider they are
-          this.#_providers.map((p: any, i) => {
+          this.#_providers.map((entry, i) => {
             return {
               index: i,
-              info: p.info,
+              info: entry.info,
             };
           }),
         ],
@@ -119,32 +124,30 @@ export class MultiWalletProviderProxy extends EventEmitter {
       return;
     }
 
+    const selectedEntry = this.#_providers[selectedIndex];
+
     if (selectedIndex !== 0) {
       // Migrate event subscription to the new event provider
-      this.#defaultProvider.removeAllListeners();
+      this.#defaultEntry.provider.removeAllListeners();
       this.eventNames().forEach((event) => {
         if (event === 'newListener') {
           return;
         }
 
-        (this.#_providers[selectedIndex] as any)?.addListener?.(
-          event,
-          (...args: any[]) => {
-            this.emit(event as string, ...args);
-          },
-        );
+        selectedEntry?.provider?.addListener?.(event, (...args: any[]) => {
+          this.emit(event as string, ...args);
+        });
       });
     }
 
     // store selection if successful to prevent showing selection popup multiple times
     // some dApps call eth_requestAccounts multiple times
-    if (this.#_providers[selectedIndex]) {
+    if (selectedEntry) {
       this.#isWalletSelected = true;
     }
 
     // set default wallet for this connection
-    this.#defaultProvider =
-      this.#_providers[selectedIndex] || this.#defaultProvider;
+    this.#defaultEntry = selectedEntry || this.#defaultEntry;
 
     this.#isWalletSelectionPending = false;
   }
@@ -165,13 +168,13 @@ export class MultiWalletProviderProxy extends EventEmitter {
     }
 
     // default provider is selected, let call through
-    return this.defaultProvider.request(args);
+    return this.defaultProvider.request(args) as Promise<Maybe<T>>;
   }
 
   async enable(): Promise<string[]> {
     await this.#toggleWalletSelection();
 
-    return this.#defaultProvider.enable();
+    return this.#defaultEntry.provider.enable() as Promise<string[]>;
   }
 
   // implement request to intercept `eth_requestAccounts`

--- a/packages/inpage/src/MultiWalletProviderProxy.ts
+++ b/packages/inpage/src/MultiWalletProviderProxy.ts
@@ -22,6 +22,33 @@ export type ProviderEntry = {
   provider: EVMProvider;
 };
 
+// Some external EIP-1193 providers only implement `on` (e.g. when their
+// implementation isn't backed by a Node-style EventEmitter). We prefer
+// `addListener` for parity with our own provider but transparently fall
+// back to `on` so subscriptions don't crash the inpage proxy.
+function subscribeToProviderEvent(
+  provider: unknown,
+  event: string | symbol,
+  listener: (...args: any[]) => void,
+): void {
+  const candidate = provider as
+    | {
+        addListener?: (
+          event: string | symbol,
+          fn: (...args: any[]) => void,
+        ) => unknown;
+        on?: (event: string | symbol, fn: (...args: any[]) => void) => unknown;
+      }
+    | null
+    | undefined;
+
+  if (typeof candidate?.addListener === 'function') {
+    candidate.addListener(event, listener);
+  } else if (typeof candidate?.on === 'function') {
+    candidate.on(event, listener);
+  }
+}
+
 export class MultiWalletProviderProxy extends EventEmitter {
   #_providers: ProviderEntry[] = [];
   #isWalletSelected = false;
@@ -71,9 +98,13 @@ export class MultiWalletProviderProxy extends EventEmitter {
     // We subscribe to those events on the currently used provider so
     // that the they can be re-emitted by the proxy.
     this.addListener('newListener', (event) => {
-      this.#defaultEntry.provider.addListener(event, (...args: any) => {
-        this.emit(event, ...args);
-      });
+      subscribeToProviderEvent(
+        this.#defaultEntry.provider,
+        event,
+        (...args: any[]) => {
+          this.emit(event, ...args);
+        },
+      );
     });
   }
 
@@ -134,9 +165,13 @@ export class MultiWalletProviderProxy extends EventEmitter {
           return;
         }
 
-        selectedEntry?.provider?.addListener?.(event, (...args: any[]) => {
-          this.emit(event as string, ...args);
-        });
+        subscribeToProviderEvent(
+          selectedEntry?.provider,
+          event,
+          (...args: any[]) => {
+            this.emit(event as string, ...args);
+          },
+        );
       });
     }
 

--- a/packages/inpage/src/initializeInpageProvider.ts
+++ b/packages/inpage/src/initializeInpageProvider.ts
@@ -63,9 +63,12 @@ export function initializeProvider(
       return;
     }
 
-    // Read each EIP-6963 info field individually with a type guard.
-    // We never spread or enumerate the foreign provider/info objects so a
-    // hostile Proxy's `ownKeys`/`get` traps cannot stall the renderer here.
+    // Read only a fixed, known set of EIP-6963 info fields with a type guard.
+    // Individual property reads still go through any `get` trap on a hostile
+    // Proxy, but we avoid spreading/enumerating the foreign info or provider
+    // object - that would invoke `ownKeys` plus a `get` for every key the
+    // foreign object claims to own, which has been observed to stall the
+    // renderer when another wallet's provider is itself a recursive Proxy.
     const info = {
       uuid: typeof rawInfo.uuid === 'string' ? rawInfo.uuid : '',
       name: typeof rawInfo.name === 'string' ? rawInfo.name : '',

--- a/packages/inpage/src/initializeInpageProvider.ts
+++ b/packages/inpage/src/initializeInpageProvider.ts
@@ -52,18 +52,32 @@ export function initializeProvider(
   const multiWalletProxy = createMultiWalletProxy(evmProvider);
 
   globalObject.addEventListener('eip6963:announceProvider', (event: any) => {
-    multiWalletProxy.addProvider(
-      new Proxy(
-        {
-          info: { ...event.detail.info },
-          ...event.detail.provider,
-        },
-        {
-          deleteProperty: () => true,
-          set: () => true,
-        },
-      ),
-    );
+    const detail = event?.detail;
+    if (!detail || typeof detail !== 'object') {
+      return;
+    }
+
+    const rawInfo = detail.info;
+    const provider = detail.provider;
+    if (!rawInfo || !provider) {
+      return;
+    }
+
+    // Read each EIP-6963 info field individually with a type guard.
+    // We never spread or enumerate the foreign provider/info objects so a
+    // hostile Proxy's `ownKeys`/`get` traps cannot stall the renderer here.
+    const info = {
+      uuid: typeof rawInfo.uuid === 'string' ? rawInfo.uuid : '',
+      name: typeof rawInfo.name === 'string' ? rawInfo.name : '',
+      icon: typeof rawInfo.icon === 'string' ? rawInfo.icon : '',
+      rdns: typeof rawInfo.rdns === 'string' ? rawInfo.rdns : '',
+    };
+
+    if (!info.uuid) {
+      return;
+    }
+
+    multiWalletProxy.addProvider({ info, provider });
   });
 
   setGlobalProvider(evmProvider, globalObject, multiWalletProxy);

--- a/packages/inpage/src/models.ts
+++ b/packages/inpage/src/models.ts
@@ -1,6 +1,6 @@
 import { Eip1193Provider } from 'ethers';
 
-interface EIP6963ProviderInfo {
+export interface EIP6963ProviderInfo {
   uuid: string;
   name: string;
   icon: string;


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-14355
Figma: _n/a_

## Notes
After some debugging I think it's the `...event.details.provider` spread that's causing issues.

My suspicion is that the Brave Wallet is also a `Proxy` object, it has some recursive `get` trap set and when we try to spread it, it hangs the tab.

## Testing
1. Open Brave with Brave Wallet and Core Extension enabled and navigate to any pages/dApps.
2. The browser should not crash.

## Media
_n/a_
