### PR TITLE
ci: improve build workflows security

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -52,9 +52,13 @@ jobs:
           echo 'TOKEN_AGGREGATOR_SERVICE_URL="${{ secrets.TOKEN_AGGREGATOR_SERVICE_URL }}"' >> .env.production
           echo 'MARKR_API_URL="${{ secrets.MARKR_API_URL }}"' >> .env.production
           echo 'MARKR_API_TOKEN="${{ secrets.MARKR_API_TOKEN }}"' >> .env.production
+      # See `main_branch.yaml` for the rationale on `--check-cache`.
+      # Production builds ship to end users with non-custodial wallet
+      # keys, so the same belt-and-suspenders applies — and arguably
+      # more so here.
       - name: Install dependencies
         run: |
-          yarn install
+          yarn install --check-cache
           yarn allow-scripts
       - name: Build library
         run: yarn build

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -55,9 +55,13 @@ jobs:
           echo 'TOKEN_AGGREGATOR_SERVICE_URL="${{ secrets.TOKEN_AGGREGATOR_SERVICE_URL }}"' >> .env.production
           echo 'MARKR_API_URL="${{ secrets.MARKR_API_URL }}"' >> .env.production
           echo 'MARKR_API_TOKEN="${{ secrets.MARKR_API_TOKEN }}"' >> .env.production
+      # `--check-cache` re-validates every tarball checksum against the
+      # registry on each install instead of trusting a possibly poisoned
+      # local Yarn cache. `enableImmutableInstalls` defaults to true in
+      # CI so a malicious transitive dep can't silently rewrite yarn.lock.
       - name: Install dependencies
         run: |
-          yarn install
+          yarn install --check-cache
           yarn allow-scripts
       - name: Run tests
         run: yarn test

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   lint:
-    name: Lint and test
+    name: Lint and build
     runs-on: ubuntu-latest
     # NOTE: deliberately no `environment:` block — this job must never
     # see production secrets. If a future step here ever needs one, it

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,10 +1,24 @@
 name: PR checks
 on: pull_request
+
+# `pr-checks` runs lint, typecheck, scanner, and tests — none of which
+# consume production secrets. The actual build (which does need them)
+# lives in `validate-lavamoat-policies.yaml`, which uses
+# `environment: alpha` to access them under GitHub's environment
+# protection rules. Keeping `pr-checks` secret-free shrinks the blast
+# radius if a PR ever exfiltrates env vars (e.g. via a malicious test
+# or a compromised transitive dep).
+permissions:
+  contents: read
+
 jobs:
   lint:
-    name: Lint and build
+    name: Lint and test
     runs-on: ubuntu-latest
-    environment: alpha
+    # NOTE: deliberately no `environment:` block — this job must never
+    # see production secrets. If a future step here ever needs one, it
+    # belongs in its own job (or in `validate-lavamoat-policies.yaml`)
+    # behind the `alpha` environment gate.
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -14,16 +28,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-      - name: enable corepack
-        run: |
-          corepack enable
-      - name: Create env file
-        run: |
-          touch .env.production
-          echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> .env.production
-          echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
-          echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
-          echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
+      - name: Enable corepack
+        run: corepack enable
       # `--check-cache` re-validates every tarball checksum against the
       # registry on each install instead of trusting a possibly poisoned
       # local Yarn cache. In CI, `enableImmutableInstalls` already

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -2,7 +2,7 @@ name: PR checks
 on: pull_request
 jobs:
   lint:
-    name: Lint
+    name: Lint and build
     runs-on: ubuntu-latest
     environment: alpha
     steps:
@@ -39,12 +39,3 @@ jobs:
           if [[ $(git status --short) == '' ]]; then exit 0; else exit 1; fi
       - name: Test
         run: yarn test
-
-  # Production build + LavaMoat policy drift detection live in their own
-  # reusable workflow. It uploads a `.patch` artifact when policies drift,
-  # which `update-lavamoat-policies.yaml` replays back onto the PR branch
-  # when a maintainer comments `/update-lavamoat-policies`.
-  validate-lavamoat-policies:
-    name: Validate LavaMoat policies
-    uses: ./.github/workflows/validate-lavamoat-policies.yaml
-    secrets: inherit

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -24,9 +24,15 @@ jobs:
           echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
           echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
           echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
+      # `--check-cache` re-validates every tarball checksum against the
+      # registry on each install instead of trusting a possibly poisoned
+      # local Yarn cache. In CI, `enableImmutableInstalls` already
+      # defaults to true (Yarn Berry behaviour when the `CI` env var is
+      # set), so we don't need to pass `--immutable` separately — yarn
+      # rejects any lockfile mutation by default.
       - name: Install dependencies
         run: |
-          yarn install
+          yarn install --check-cache
           yarn allow-scripts
       - name: Lint
         run: yarn lint

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -2,7 +2,7 @@ name: PR checks
 on: pull_request
 jobs:
   lint:
-    name: Lint and build
+    name: Lint
     runs-on: ubuntu-latest
     environment: alpha
     steps:
@@ -39,18 +39,12 @@ jobs:
           if [[ $(git status --short) == '' ]]; then exit 0; else exit 1; fi
       - name: Test
         run: yarn test
-      - name: Build extension
-        run: yarn build
-      - name: Check LavaMoat policies are up to date
-        run: |
-          # Match every policy.json under any `lavamoat/rspack/` directory
-          # (apps/* and packages/*) so this still covers new bundles when
-          # LavaMoat is wired into them later.
-          POLICY_PATHSPEC=':(glob)**/lavamoat/rspack/policy.json'
-          DRIFTED=$(git status --porcelain -- "$POLICY_PATHSPEC")
-          if [[ -n "$DRIFTED" ]]; then
-            echo "::error::LavaMoat policy drift detected. Run 'yarn build' locally and commit the regenerated policy.json file(s)."
-            echo "$DRIFTED"
-            git --no-pager diff -- "$POLICY_PATHSPEC"
-            exit 1
-          fi
+
+  # Production build + LavaMoat policy drift detection live in their own
+  # reusable workflow. It uploads a `.patch` artifact when policies drift,
+  # which `update-lavamoat-policies.yaml` replays back onto the PR branch
+  # when a maintainer comments `/update-lavamoat-policies`.
+  validate-lavamoat-policies:
+    name: Validate LavaMoat policies
+    uses: ./.github/workflows/validate-lavamoat-policies.yaml
+    secrets: inherit

--- a/.github/workflows/update-lavamoat-policies.yaml
+++ b/.github/workflows/update-lavamoat-policies.yaml
@@ -1,0 +1,179 @@
+name: Update LavaMoat policies
+
+# Comment-driven companion to `validate-lavamoat-policies.yaml`. When a
+# maintainer leaves a `/update-lavamoat-policies` comment on a PR, this
+# workflow looks at the latest `pr-checks` run for the PR's head commit,
+# downloads the `lavamoat-policy-diff` artifact that the validate job
+# uploads on drift, applies it on top of the PR branch, and pushes a
+# commit back.
+#
+# Policy generation itself happens in the validate workflow; this one
+# never runs `yarn build` and never touches secrets — it just replays the
+# diff that CI already produced.
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: update-lavamoat-policies-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Update LavaMoat policies
+    # `issue_comment` fires on both issues and PRs; gate on `pull_request`
+    # to skip plain issues, and on the literal command to skip every
+    # other comment on every PR in the repo.
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/update-lavamoat-policies') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+      COMMENT_ID: ${{ github.event.comment.id }}
+      ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Acknowledge the command
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content='+1'
+
+      - name: Fetch PR metadata
+        id: pr
+        run: |
+          INFO=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json isCrossRepository,headRefOid,headRefName)
+          {
+            echo "is_cross_repo=$(echo "$INFO" | jq -r '.isCrossRepository')"
+            echo "head_sha=$(echo "$INFO" | jq -r '.headRefOid')"
+            echo "head_branch=$(echo "$INFO" | jq -r '.headRefName')"
+          } >> "$GITHUB_OUTPUT"
+
+      # `secrets.GITHUB_TOKEN` cannot push to forks, so bail out early
+      # with a clear message rather than fail mid-push.
+      - name: Reject cross-repo PRs
+        if: ${{ steps.pr.outputs.is_cross_repo == 'true' }}
+        run: |
+          BODY=$'`/update-lavamoat-policies` cannot be used on cross-repository pull requests because GitHub Actions cannot push to fork branches.\n\nPlease regenerate the policy files locally with `yarn build` and push them to the fork manually.'
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
+          exit 1
+
+      - name: Find pr-checks run for the PR head commit
+        id: ci-run
+        run: |
+          HEAD_SHA='${{ steps.pr.outputs.head_sha }}'
+          echo "Looking for a completed pr-checks run for ${HEAD_SHA}..."
+          RUNS_JSON=$(gh run list \
+            --workflow=pr-checks.yaml \
+            --repo "${REPO}" \
+            --commit="${HEAD_SHA}" \
+            --limit=5 \
+            --json databaseId,status,conclusion)
+          RUN_ID=$(echo "$RUNS_JSON" | jq -r '[.[] | select(.status == "completed")] | .[0].databaseId // empty')
+          if [ -z "$RUN_ID" ]; then
+            BODY=$'No completed `pr-checks` run was found for this PR head commit. Wait for CI to finish and try `/update-lavamoat-policies` again.'
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
+            exit 1
+          fi
+          echo "Using pr-checks run ${RUN_ID}"
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine validate-lavamoat-policies job status
+        id: validate-status
+        run: |
+          JOBS_JSON=$(gh api \
+            --paginate \
+            "/repos/${REPO}/actions/runs/${{ steps.ci-run.outputs.run_id }}/jobs" \
+            --jq '[.jobs[] | select(.name | contains("Validate LavaMoat policies"))]')
+          JOB_COUNT=$(echo "$JOBS_JSON" | jq 'length')
+          if [ "$JOB_COUNT" -eq 0 ]; then
+            BODY=$'The `pr-checks` run did not include `Validate LavaMoat policies`. Nothing to update.'
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
+            exit 1
+          fi
+          # If every validate job succeeded there is no artifact to apply.
+          FAILED=$(echo "$JOBS_JSON" | jq '[.[] | select(.conclusion != "success")] | length')
+          echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
+
+      - name: Post comment (no drift)
+        if: ${{ steps.validate-status.outputs.failed == '0' }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "No LavaMoat policy drift detected on the latest \`pr-checks\` run — nothing to update."
+
+      # Stop the job cleanly when the validate workflow passed — there is
+      # no artifact to download and nothing to commit.
+      - name: Stop if no drift
+        if: ${{ steps.validate-status.outputs.failed == '0' }}
+        run: exit 0
+
+      # Download outside the workspace so the next `actions/checkout` step
+      # doesn't wipe the patch files when it cleans the working directory.
+      - name: Download policy diff artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # Pattern + merge-multiple keeps this forward-compatible with a
+          # future split into one validate job per bundle (each uploading
+          # its own `lavamoat-policy-diff-<bundle>` artifact).
+          pattern: lavamoat-policy-diff*
+          merge-multiple: true
+          path: /tmp/lavamoat-policy-diffs
+          run-id: ${{ steps.ci-run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify diff artifacts exist
+        id: artifacts
+        run: |
+          if compgen -G '/tmp/lavamoat-policy-diffs/*.patch' > /dev/null; then
+            echo "Found policy diff artifacts:"
+            ls -la /tmp/lavamoat-policy-diffs/
+          else
+            BODY=$'The `validate-lavamoat-policies` job failed but no policy diff artifact was produced (the job may have crashed before uploading). See the [validation run logs]('"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.ci-run.outputs.run_id }}"$').'
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Switch to PR branch
+        run: gh pr checkout "${PR_NUMBER}"
+
+      # The diff is unconditionally produced from the PR head commit, so
+      # `git apply` should land cleanly. If it doesn't, the PR has moved
+      # forward since the validate run and the patch is stale — surface
+      # that to the user instead of trying to force-apply it.
+      - name: Apply policy diff
+        run: |
+          for patch in /tmp/lavamoat-policy-diffs/*.patch; do
+            echo "Applying ${patch}..."
+            git apply "${patch}"
+          done
+
+      - name: Commit and push
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -am "chore: update LavaMoat policies"
+          git push
+
+      - name: Post success comment
+        run: |
+          BODY=$'LavaMoat policies updated. 👀 Please review the diff for suspicious new powers before approving.\n\n🧠 How to read a policy diff: https://lavamoat.github.io/guides/policy-diff/#what-to-look-for-when-reviewing-a-policy-diff'
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
+
+      - name: Post failure comment
+        if: ${{ failure() && steps.pr.outputs.is_cross_repo != 'true' }}
+        run: |
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "Policy update failed. [Review the logs or retry the command here](${ACTION_RUN_URL})."

--- a/.github/workflows/update-lavamoat-policies.yaml
+++ b/.github/workflows/update-lavamoat-policies.yaml
@@ -1,15 +1,35 @@
-name: Update LavaMoat policies
+name: LavaMoat
 
 # Comment-driven companion to `validate-lavamoat-policies.yaml`. When a
 # maintainer leaves a `/update-lavamoat-policies` comment on a PR, this
-# workflow looks at the latest `pr-checks` run for the PR's head commit,
-# downloads the `lavamoat-policy-diff` artifact that the validate job
-# uploads on drift, applies it on top of the PR branch, and pushes a
-# commit back.
+# workflow looks at the latest `validate-lavamoat-policies` run for the
+# PR's head commit, downloads the `lavamoat-policy-diff` artifact that
+# the validate workflow uploads on drift, applies it on top of the PR
+# branch, and commits the result back through GitHub's GraphQL API.
 #
 # Policy generation itself happens in the validate workflow; this one
 # never runs `yarn build` and never touches secrets — it just replays the
 # diff that CI already produced.
+#
+# Two non-obvious constraints on how the commit lands:
+#  1. The repo requires signed commits, so we *cannot* `git push` — a
+#     plain CI push produces an unsigned commit that branch protection
+#     rejects. Instead we call the `createCommitOnBranch` GraphQL
+#     mutation, which signs the commit on the server with GitHub's
+#     `web-flow` key and shows it as `Verified` (same mechanism
+#     `dependabot[bot]` uses).
+#  2. `GITHUB_TOKEN`-driven pushes deliberately do not re-trigger
+#     workflows, but `workflow_dispatch` IS one of the two documented
+#     exceptions. After committing we fire `gh workflow run` to
+#     dispatch `validate-lavamoat-policies.yaml` against the PR branch
+#     so the `Validate LavaMoat policies` check refreshes against the
+#     new HEAD without any manual intervention. We intentionally do NOT
+#     re-dispatch `pr-checks.yaml` — lint/typecheck/test already passed
+#     on the original PR run for code that hasn't changed (only
+#     policy.json files differ), and re-running them would just burn CI.
+#     If `Lint` is in your branch protection's required-checks list,
+#     the PR will sit waiting for it until you push another commit or
+#     hit "Re-run all jobs" on the original pr-checks run.
 on:
   issue_comment:
     types: [created]
@@ -20,7 +40,7 @@ concurrency:
 
 jobs:
   update:
-    name: Update LavaMoat policies
+    name: Update policies
     # `issue_comment` fires on both issues and PRs; gate on `pull_request`
     # to skip plain issues, and on the literal command to skip every
     # other comment on every PR in the repo.
@@ -31,7 +51,10 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      actions: read
+      # `read` is enough to list runs and download artifacts; the bump
+      # to `write` is for the `gh workflow run` re-dispatch at the end
+      # of the job, which calls the `actions:write` REST endpoint.
+      actions: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
@@ -67,52 +90,46 @@ jobs:
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
           exit 1
 
-      - name: Find pr-checks run for the PR head commit
+      # The validate workflow is its own top-level workflow now (not a
+      # `workflow_call` from `pr-checks`), so we look at its runs directly
+      # — both the initial `pull_request` run and any subsequent
+      # `workflow_dispatch` re-run land here. `--limit 5` gives us
+      # headroom in case a previous `/update-lavamoat-policies` already
+      # produced a passing dispatched run that we should prefer.
+      - name: Find validate-lavamoat-policies run for the PR head commit
         id: ci-run
         run: |
           HEAD_SHA='${{ steps.pr.outputs.head_sha }}'
-          echo "Looking for a completed pr-checks run for ${HEAD_SHA}..."
-          RUNS_JSON=$(gh run list \
-            --workflow=pr-checks.yaml \
+          echo "Looking for a completed validate-lavamoat-policies run for ${HEAD_SHA}..."
+          RUN=$(gh run list \
+            --workflow=validate-lavamoat-policies.yaml \
             --repo "${REPO}" \
             --commit="${HEAD_SHA}" \
             --limit=5 \
-            --json databaseId,status,conclusion)
-          RUN_ID=$(echo "$RUNS_JSON" | jq -r '[.[] | select(.status == "completed")] | .[0].databaseId // empty')
+            --json databaseId,status,conclusion \
+            --jq '[.[] | select(.status == "completed")] | .[0]')
+          RUN_ID=$(echo "$RUN" | jq -r '.databaseId // empty')
+          CONCLUSION=$(echo "$RUN" | jq -r '.conclusion // empty')
           if [ -z "$RUN_ID" ]; then
-            BODY=$'No completed `pr-checks` run was found for this PR head commit. Wait for CI to finish and try `/update-lavamoat-policies` again.'
+            BODY=$'No completed `validate-lavamoat-policies` run was found for this PR head commit. Wait for CI to finish and try `/update-lavamoat-policies` again.'
             gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
             exit 1
           fi
-          echo "Using pr-checks run ${RUN_ID}"
-          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
-
-      - name: Determine validate-lavamoat-policies job status
-        id: validate-status
-        run: |
-          JOBS_JSON=$(gh api \
-            --paginate \
-            "/repos/${REPO}/actions/runs/${{ steps.ci-run.outputs.run_id }}/jobs" \
-            --jq '[.jobs[] | select(.name | contains("Validate LavaMoat policies"))]')
-          JOB_COUNT=$(echo "$JOBS_JSON" | jq 'length')
-          if [ "$JOB_COUNT" -eq 0 ]; then
-            BODY=$'The `pr-checks` run did not include `Validate LavaMoat policies`. Nothing to update.'
-            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
-            exit 1
-          fi
-          # If every validate job succeeded there is no artifact to apply.
-          FAILED=$(echo "$JOBS_JSON" | jq '[.[] | select(.conclusion != "success")] | length')
-          echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
+          echo "Using validate-lavamoat-policies run ${RUN_ID} (conclusion: ${CONCLUSION})"
+          {
+            echo "run_id=${RUN_ID}"
+            echo "conclusion=${CONCLUSION}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post comment (no drift)
-        if: ${{ steps.validate-status.outputs.failed == '0' }}
+        if: ${{ steps.ci-run.outputs.conclusion == 'success' }}
         run: |
-          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "No LavaMoat policy drift detected on the latest \`pr-checks\` run — nothing to update."
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "No LavaMoat policy drift detected on the latest \`validate-lavamoat-policies\` run — nothing to update."
 
       # Stop the job cleanly when the validate workflow passed — there is
       # no artifact to download and nothing to commit.
       - name: Stop if no drift
-        if: ${{ steps.validate-status.outputs.failed == '0' }}
+        if: ${{ steps.ci-run.outputs.conclusion == 'success' }}
         run: exit 0
 
       # Download outside the workspace so the next `actions/checkout` step
@@ -136,15 +153,21 @@ jobs:
             echo "Found policy diff artifacts:"
             ls -la /tmp/lavamoat-policy-diffs/
           else
-            BODY=$'The `validate-lavamoat-policies` job failed but no policy diff artifact was produced (the job may have crashed before uploading). See the [validation run logs]('"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.ci-run.outputs.run_id }}"$').'
+            BODY=$'`validate-lavamoat-policies` failed but no policy diff artifact was produced (the job may have crashed before uploading). See the [validation run logs]('"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.ci-run.outputs.run_id }}"$').'
             gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
             exit 1
           fi
 
+      # We only need the working tree to apply the patch — we never push
+      # back through git. The commit is created via the
+      # `createCommitOnBranch` GraphQL mutation below so GitHub signs it
+      # with its `web-flow` key and the resulting commit shows up as
+      # `Verified`. The repo's branch protection requires signed commits;
+      # a plain `git push` from CI would produce an unsigned commit and
+      # be rejected.
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Switch to PR branch
@@ -154,23 +177,71 @@ jobs:
       # `git apply` should land cleanly. If it doesn't, the PR has moved
       # forward since the validate run and the patch is stale — surface
       # that to the user instead of trying to force-apply it.
-      - name: Apply policy diff
+      - name: Apply policy diff to the working tree
         run: |
           for patch in /tmp/lavamoat-policy-diffs/*.patch; do
             echo "Applying ${patch}..."
             git apply "${patch}"
           done
 
-      - name: Commit and push
+      # `createCommitOnBranch` requires the SHA the branch currently
+      # points to. `git rev-parse HEAD` gives us the SHA we checked out;
+      # if origin moved in the meantime the mutation will reject the call
+      # with an expected-OID mismatch, which is the right behaviour —
+      # better to fail than to silently overwrite newer work.
+      - name: Create signed commit via createCommitOnBranch
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -am "chore: update LavaMoat policies"
-          git push
+          HEAD_OID=$(git rev-parse HEAD)
+          BRANCH='${{ steps.pr.outputs.head_branch }}'
+
+          # `additions` is `[{path, contents: <base64>}, ...]`. We diff
+          # against HEAD (== the SHA we checked out, before `git apply`)
+          # so the list contains exactly the policy files the patch
+          # touched and nothing else.
+          ADDITIONS_JSON=$(
+            git diff --name-only HEAD -- ':(glob)**/lavamoat/rspack/policy.json' |
+              while IFS= read -r file; do
+                jq -n \
+                  --arg path "$file" \
+                  --arg contents "$(base64 < "$file" | tr -d '\n')" \
+                  '{path: $path, contents: $contents}'
+              done | jq -s '.'
+          )
+
+          if [ "$(echo "$ADDITIONS_JSON" | jq 'length')" -eq 0 ]; then
+            echo "::error::Patch applied but no policy.json files changed — refusing to create an empty commit."
+            exit 1
+          fi
+
+          jq -n \
+            --arg repo "$REPO" \
+            --arg branch "$BRANCH" \
+            --arg headOid "$HEAD_OID" \
+            --argjson additions "$ADDITIONS_JSON" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                  message: { headline: "chore: update LavaMoat policies" },
+                  expectedHeadOid: $headOid,
+                  fileChanges: { additions: $additions }
+                }
+              }
+            }' | gh api graphql --input -
+
+      # `createCommitOnBranch` returns once the commit is on the branch,
+      # so by the time the dispatched run starts `actions/checkout` is
+      # guaranteed to see the new HEAD.
+      - name: Re-dispatch validate-lavamoat-policies against the new HEAD
+        run: |
+          gh workflow run validate-lavamoat-policies.yaml \
+            --repo "${REPO}" \
+            --ref '${{ steps.pr.outputs.head_branch }}'
 
       - name: Post success comment
         run: |
-          BODY=$'LavaMoat policies updated. 👀 Please review the diff for suspicious new powers before approving.\n\n🧠 How to read a policy diff: https://lavamoat.github.io/guides/policy-diff/#what-to-look-for-when-reviewing-a-policy-diff'
+          BODY=$'LavaMoat policies updated in a `Verified` commit, and `validate-lavamoat-policies` has been re-dispatched against the new HEAD — the previously red check should turn green on its own within a few minutes.\n\n👀 Please review the diff for suspicious new powers before approving.\n\n🧠 How to read a policy diff: https://lavamoat.github.io/guides/policy-diff/#what-to-look-for-when-reviewing-a-policy-diff'
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$BODY"
 
       - name: Post failure comment

--- a/.github/workflows/update-lavamoat-policies.yaml
+++ b/.github/workflows/update-lavamoat-policies.yaml
@@ -216,22 +216,33 @@ jobs:
           # The diff is taken against HEAD (== the SHA we checked out,
           # before `git apply`) so the partition contains exactly the
           # policy files the patch touched, nothing else.
-          ADDITIONS_JSON='[]'
-          DELETIONS_JSON='[]'
+          #
+          # Why temp files instead of shell variables: Linux caps a single
+          # argv string at `MAX_ARG_STRLEN` (~128 KB), so passing a
+          # policy.json's base64 payload via `jq --arg contents "$(...)"`
+          # trips `E2BIG` ("Argument list too long") as soon as the file
+          # is larger than that — service-worker's policy.json is ~250 KB
+          # raw / ~330 KB base64, well past the limit. `--rawfile` reads
+          # each file directly from disk, and we accumulate the per-file
+          # JSON objects in a temp file (newline-delimited) so the final
+          # `--slurpfile` doesn't have to round-trip them through argv
+          # either. The mutation body is piped to `gh api graphql` via
+          # stdin, which has no such limit.
+          ADDITIONS_FILE=$(mktemp)
+          DELETIONS_FILE=$(mktemp)
 
           add_file() {
             local path="$1"
-            ADDITIONS_JSON=$(echo "$ADDITIONS_JSON" | jq \
+            jq -n \
               --arg path "$path" \
-              --arg contents "$(base64 < "$path" | tr -d '\n')" \
-              '. + [{path: $path, contents: $contents}]')
+              --rawfile contents "$path" \
+              '{path: $path, contents: ($contents | @base64)}' \
+              >> "$ADDITIONS_FILE"
           }
 
           delete_file() {
             local path="$1"
-            DELETIONS_JSON=$(echo "$DELETIONS_JSON" | jq \
-              --arg path "$path" \
-              '. + [{path: $path}]')
+            jq -n --arg path "$path" '{path: $path}' >> "$DELETIONS_FILE"
           }
 
           while IFS=$'\t' read -r status path1 path2; do
@@ -253,9 +264,14 @@ jobs:
             esac
           done < <(git diff --name-status HEAD -- ':(glob)**/lavamoat/rspack/policy.json')
 
+          # `--slurpfile` reads the temp file as a stream of JSON values
+          # and binds the array to the variable, so an empty file yields
+          # `[]` and N appended objects yield an N-element array — which
+          # is exactly the shape `createCommitOnBranch` expects for
+          # `fileChanges.{additions,deletions}`.
           TOTAL=$(jq -n \
-            --argjson a "$ADDITIONS_JSON" \
-            --argjson d "$DELETIONS_JSON" \
+            --slurpfile a "$ADDITIONS_FILE" \
+            --slurpfile d "$DELETIONS_FILE" \
             '($a | length) + ($d | length)')
           if [ "$TOTAL" -eq 0 ]; then
             echo "::error::Patch applied but no policy.json files changed — refusing to create an empty commit."
@@ -266,8 +282,8 @@ jobs:
             --arg repo "$REPO" \
             --arg branch "$BRANCH" \
             --arg headOid "$HEAD_OID" \
-            --argjson additions "$ADDITIONS_JSON" \
-            --argjson deletions "$DELETIONS_JSON" \
+            --slurpfile additions "$ADDITIONS_FILE" \
+            --slurpfile deletions "$DELETIONS_FILE" \
             '{
               query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
               variables: {

--- a/.github/workflows/update-lavamoat-policies.yaml
+++ b/.github/workflows/update-lavamoat-policies.yaml
@@ -1,4 +1,4 @@
-name: LavaMoat
+name: Update LavaMoat policies
 
 # Comment-driven companion to `validate-lavamoat-policies.yaml`. When a
 # maintainer leaves a `/update-lavamoat-policies` comment on a PR, this
@@ -41,10 +41,23 @@ concurrency:
 jobs:
   update:
     name: Update policies
-    # `issue_comment` fires on both issues and PRs; gate on `pull_request`
-    # to skip plain issues, and on the literal command to skip every
-    # other comment on every PR in the repo.
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/update-lavamoat-policies') }}
+    # Gates (all must hold for the workflow to fire):
+    #   1. It's a comment on a PR (not on a plain issue) — `issue_comment`
+    #      fires on both.
+    #   2. The comment body starts with the literal slash command — skips
+    #      every other comment on every PR in the repo.
+    #   3. The comment author has write-equivalent access on the repo.
+    #      Without this last gate, anyone who can comment on a public PR
+    #      could trigger a workflow with `contents: write` and have us
+    #      push a signed commit on their behalf. `author_association`
+    #      is set by GitHub on the event payload and cannot be spoofed
+    #      by the comment author. Accepted roles cover org members, repo
+    #      collaborators, and the org owner — i.e. anyone who already has
+    #      the access to push to the PR branch directly.
+    if: >-
+      ${{ github.event.issue.pull_request
+          && startsWith(github.event.comment.body, '/update-lavamoat-policies')
+          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -194,21 +207,57 @@ jobs:
           HEAD_OID=$(git rev-parse HEAD)
           BRANCH='${{ steps.pr.outputs.head_branch }}'
 
-          # `additions` is `[{path, contents: <base64>}, ...]`. We diff
-          # against HEAD (== the SHA we checked out, before `git apply`)
-          # so the list contains exactly the policy files the patch
-          # touched and nothing else.
-          ADDITIONS_JSON=$(
-            git diff --name-only HEAD -- ':(glob)**/lavamoat/rspack/policy.json' |
-              while IFS= read -r file; do
-                jq -n \
-                  --arg path "$file" \
-                  --arg contents "$(base64 < "$file" | tr -d '\n')" \
-                  '{path: $path, contents: $contents}'
-              done | jq -s '.'
-          )
+          # Walk the diff and partition by file status into the two arrays
+          # `createCommitOnBranch` accepts. Using `--name-status` (vs the
+          # earlier `--name-only`) lets us cope with:
+          #  - bundles being removed (D — a `policy.json` deletion would
+          #    otherwise crash `base64 < $file` because the file is gone),
+          #  - bundles being relocated (R — needs delete-old + add-new).
+          # The diff is taken against HEAD (== the SHA we checked out,
+          # before `git apply`) so the partition contains exactly the
+          # policy files the patch touched, nothing else.
+          ADDITIONS_JSON='[]'
+          DELETIONS_JSON='[]'
 
-          if [ "$(echo "$ADDITIONS_JSON" | jq 'length')" -eq 0 ]; then
+          add_file() {
+            local path="$1"
+            ADDITIONS_JSON=$(echo "$ADDITIONS_JSON" | jq \
+              --arg path "$path" \
+              --arg contents "$(base64 < "$path" | tr -d '\n')" \
+              '. + [{path: $path, contents: $contents}]')
+          }
+
+          delete_file() {
+            local path="$1"
+            DELETIONS_JSON=$(echo "$DELETIONS_JSON" | jq \
+              --arg path "$path" \
+              '. + [{path: $path}]')
+          }
+
+          while IFS=$'\t' read -r status path1 path2; do
+            case "$status" in
+              A|C|M)
+                add_file "$path1"
+                ;;
+              D)
+                delete_file "$path1"
+                ;;
+              R*)
+                # Rename: old path is gone, new path holds the content.
+                delete_file "$path1"
+                add_file "$path2"
+                ;;
+              *)
+                echo "::warning::Unhandled diff status '$status' for '$path1' — skipping"
+                ;;
+            esac
+          done < <(git diff --name-status HEAD -- ':(glob)**/lavamoat/rspack/policy.json')
+
+          TOTAL=$(jq -n \
+            --argjson a "$ADDITIONS_JSON" \
+            --argjson d "$DELETIONS_JSON" \
+            '($a | length) + ($d | length)')
+          if [ "$TOTAL" -eq 0 ]; then
             echo "::error::Patch applied but no policy.json files changed — refusing to create an empty commit."
             exit 1
           fi
@@ -218,6 +267,7 @@ jobs:
             --arg branch "$BRANCH" \
             --arg headOid "$HEAD_OID" \
             --argjson additions "$ADDITIONS_JSON" \
+            --argjson deletions "$DELETIONS_JSON" \
             '{
               query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
               variables: {
@@ -225,7 +275,7 @@ jobs:
                   branch: { repositoryNameWithOwner: $repo, branchName: $branch },
                   message: { headline: "chore: update LavaMoat policies" },
                   expectedHeadOid: $headOid,
-                  fileChanges: { additions: $additions }
+                  fileChanges: { additions: $additions, deletions: $deletions }
                 }
               }
             }' | gh api graphql --input -

--- a/.github/workflows/validate-lavamoat-policies.yaml
+++ b/.github/workflows/validate-lavamoat-policies.yaml
@@ -1,4 +1,4 @@
-name: LavaMoat
+name: Validate LavaMoat policies
 
 # Regenerates every `lavamoat/rspack/policy.json` under apps/* and
 # packages/* by running the production build, then compares the working
@@ -91,8 +91,15 @@ jobs:
         run: |
           yarn install
           yarn allow-scripts
+      # Mirrors `main_branch.yaml`'s shipping command so we're regenerating
+      # under the same rsbuild config that produces the alpha bundles.
+      # Functionally identical to `yarn build` today (both alpha and prod
+      # configs use `generateLavaMoatPolicy: true` + `getEnvVars('production')`),
+      # but parity protects us if the two configs ever diverge.
       - name: Build (regenerates LavaMoat policies)
-        run: yarn build
+        run: yarn build:alpha
+        env:
+          NO_SOURCE_MAPS: 'true'
       - name: Detect policy drift
         id: drift
         # The pathspec matches `policy.json` under any `lavamoat/rspack/`

--- a/.github/workflows/validate-lavamoat-policies.yaml
+++ b/.github/workflows/validate-lavamoat-policies.yaml
@@ -24,11 +24,12 @@ jobs:
     name: Validate policies
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # `alpha` provides the same secrets `pr-checks.yaml` uses for builds.
-    # LavaMoat inlines `process.env.*` literals it sees in source into the
-    # generated policy, so the env-var set here must match every other
-    # workflow that runs `yarn build`, or the policy will drift on the
-    # env-var diff alone.
+    # Uses the `alpha` environment so its secret set matches `main_branch.yaml`
+    # — the env vars resolved here MUST mirror the ones the shipping
+    # workflows (`main_branch.yaml`, `create_release.yaml`) use, or the
+    # policy CI validates against will not match the policy enforced in
+    # production. See the `Create env file` step below for the canonical
+    # list and the reasoning.
     environment: alpha
     permissions:
       contents: read
@@ -43,13 +44,49 @@ jobs:
           node-version: 20.x
       - name: Enable corepack
         run: corepack enable
+      # Env vars must be kept in sync with `main_branch.yaml` and
+      # `create_release.yaml` — those are the workflows that actually ship
+      # builds. LavaMoat's policy generator sees the post-codegen source
+      # (after rsbuild's `define` substitution), so any `process.env.X`
+      # that is NOT defined here stays as a literal `process.env.X` lookup
+      # and ends up in `policy.json` as a global allowlist entry. If this
+      # list diverges from the shipping workflows, the policy validated by
+      # CI will not match the policy that runs in production.
       - name: Create env file
         run: |
           touch .env.production
+          echo RELEASE=alpha >> .env.production
           echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> .env.production
+          echo 'POSTHOG_URL="${{ secrets.POSTHOG_URL }}"' >> .env.production
+          echo 'ANALYTICS_ENCRYPTION_KEY="${{ secrets.ANALYTICS_ENCRYPTION_KEY }}"' >> .env.production
+          echo 'ANALYTICS_ENCRYPTION_KEY_ID="${{ secrets.ANALYTICS_ENCRYPTION_KEY_ID }}"' >> .env.production
+          echo 'COVALENT_API_KEY="${{ secrets.COVALENT_API_KEY }}"' >> .env.production
           echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
           echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
           echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
+          echo 'SENTRY_DSN="${{ secrets.SENTRY_DSN }}"' >> .env.production
+          echo 'CORE_WEB_BASE_URL="${{ secrets.CORE_WEB_BASE_URL }}"' >> .env.production
+          echo 'WALLET_CONNECT_PROJECT_ID="${{ secrets.WALLET_CONNECT_PROJECT_ID }}"' >> .env.production
+          echo 'SEEDLESS_URL="${{ secrets.SEEDLESS_URL }}"' >> .env.production
+          echo 'SEEDLESS_ORG_ID="${{ secrets.SEEDLESS_ORG_ID }}"' >> .env.production
+          echo 'GOOGLE_OAUTH_CLIENT_ID="${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}"' >> .env.production
+          echo 'APPLE_OAUTH_CLIENT_ID="${{ secrets.APPLE_OAUTH_CLIENT_ID }}"' >> .env.production
+          echo 'APPLE_OAUTH_REDIRECT_URL="${{ secrets.APPLE_OAUTH_REDIRECT_URL }}"' >> .env.production
+          echo 'CUBESIGNER_ENV="${{ secrets.CUBESIGNER_ENV }}"' >> .env.production
+          echo 'SEEDLESS_FIDO_IDENTITY_URL="${{ secrets.SEEDLESS_FIDO_IDENTITY_URL }}"' >> .env.production
+          echo 'NEWSLETTER_BASE_URL="${{ secrets.NEWSLETTER_BASE_URL }}"' >> .env.production
+          echo 'NEWSLETTER_PORTAL_ID="${{ secrets.NEWSLETTER_PORTAL_ID }}"' >> .env.production
+          echo 'NEWSLETTER_FORM_ID="${{ secrets.NEWSLETTER_FORM_ID }}"' >> .env.production
+          echo 'FIREBASE_CONFIG="${{ secrets.FIREBASE_CONFIG }}"' >> .env.production
+          echo 'ID_SERVICE_URL="${{ secrets.ID_SERVICE_URL }}"' >> .env.production
+          echo 'GASLESS_SERVICE_URL="${{ secrets.GASLESS_SERVICE_URL }}"' >> .env.production
+          echo 'NOTIFICATION_SENDER_SERVICE_URL="${{ secrets.NOTIFICATION_SENDER_SERVICE_URL }}"' >> .env.production
+          echo 'EXTENSION_PUBLIC_KEY="${{ secrets.EXTENSION_PUBLIC_KEY }}"' >> .env.production
+          echo 'BALANCE_SERVICE_URL="${{ secrets.BALANCE_SERVICE_URL }}"' >> .env.production
+          echo 'PROFILE_SERVICE_URL="${{ secrets.PROFILE_SERVICE_URL }}"' >> .env.production
+          echo 'TOKEN_AGGREGATOR_SERVICE_URL="${{ secrets.TOKEN_AGGREGATOR_SERVICE_URL }}"' >> .env.production
+          echo 'MARKR_API_URL="${{ secrets.MARKR_API_URL }}"' >> .env.production
+          echo 'MARKR_API_TOKEN="${{ secrets.MARKR_API_TOKEN }}"' >> .env.production
       - name: Install dependencies
         run: |
           yarn install

--- a/.github/workflows/validate-lavamoat-policies.yaml
+++ b/.github/workflows/validate-lavamoat-policies.yaml
@@ -1,20 +1,27 @@
-name: Validate LavaMoat policies
+name: LavaMoat
 
-# Reusable workflow that regenerates every `lavamoat/rspack/policy.json`
-# under apps/* and packages/* by running the production build, then
-# compares the working tree against the committed policies. When a diff is
-# found the workflow uploads it as an artifact (so the comment-triggered
-# `update-lavamoat-policies.yaml` workflow can replay it onto the PR
-# branch) and fails the job.
+# Regenerates every `lavamoat/rspack/policy.json` under apps/* and
+# packages/* by running the production build, then compares the working
+# tree against the committed policies. When a diff is found, uploads it
+# as an artifact (so `update-lavamoat-policies.yaml` can replay it onto
+# the PR branch when a maintainer comments `/update-lavamoat-policies`)
+# and fails the job.
 #
-# This is intentionally `workflow_call`-only — `pr-checks.yaml` is the
-# orchestrator that invokes it on every PR.
+# Triggers:
+#  - `pull_request`: runs on every PR alongside `pr-checks.yaml`.
+#  - `workflow_dispatch`: re-invoked by `update-lavamoat-policies.yaml`
+#    against the PR branch after a signed policy commit lands, so the
+#    `Validate LavaMoat policies` check refreshes against the new HEAD
+#    without needing the rest of `pr-checks.yaml` (lint/typecheck/test)
+#    to run again. `workflow_dispatch` is one of the two events
+#    GITHUB_TOKEN is allowed to fire.
 on:
-  workflow_call:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   validate-lavamoat-policies:
-    name: Validate LavaMoat policies
+    name: Validate policies
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # `alpha` provides the same secrets `pr-checks.yaml` uses for builds.

--- a/.github/workflows/validate-lavamoat-policies.yaml
+++ b/.github/workflows/validate-lavamoat-policies.yaml
@@ -87,9 +87,13 @@ jobs:
           echo 'TOKEN_AGGREGATOR_SERVICE_URL="${{ secrets.TOKEN_AGGREGATOR_SERVICE_URL }}"' >> .env.production
           echo 'MARKR_API_URL="${{ secrets.MARKR_API_URL }}"' >> .env.production
           echo 'MARKR_API_TOKEN="${{ secrets.MARKR_API_TOKEN }}"' >> .env.production
+      # Same defense-in-depth as `main_branch.yaml` /
+      # `create_release.yaml`: `--check-cache` re-validates tarball
+      # checksums against the registry so a poisoned local Yarn cache
+      # can't influence the policy that PR CI validates against.
       - name: Install dependencies
         run: |
-          yarn install
+          yarn install --check-cache
           yarn allow-scripts
       # Mirrors `main_branch.yaml`'s shipping command so we're regenerating
       # under the same rsbuild config that produces the alpha bundles.

--- a/.github/workflows/validate-lavamoat-policies.yaml
+++ b/.github/workflows/validate-lavamoat-policies.yaml
@@ -1,0 +1,86 @@
+name: Validate LavaMoat policies
+
+# Reusable workflow that regenerates every `lavamoat/rspack/policy.json`
+# under apps/* and packages/* by running the production build, then
+# compares the working tree against the committed policies. When a diff is
+# found the workflow uploads it as an artifact (so the comment-triggered
+# `update-lavamoat-policies.yaml` workflow can replay it onto the PR
+# branch) and fails the job.
+#
+# This is intentionally `workflow_call`-only — `pr-checks.yaml` is the
+# orchestrator that invokes it on every PR.
+on:
+  workflow_call:
+
+jobs:
+  validate-lavamoat-policies:
+    name: Validate LavaMoat policies
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # `alpha` provides the same secrets `pr-checks.yaml` uses for builds.
+    # LavaMoat inlines `process.env.*` literals it sees in source into the
+    # generated policy, so the env-var set here must match every other
+    # workflow that runs `yarn build`, or the policy will drift on the
+    # env-var diff alone.
+    environment: alpha
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Enable corepack
+        run: corepack enable
+      - name: Create env file
+        run: |
+          touch .env.production
+          echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> .env.production
+          echo 'GLACIER_URL="${{ secrets.GLACIER_URL }}"' >> .env.production
+          echo 'PROXY_URL="${{ secrets.PROXY_URL }}"' >> .env.production
+          echo 'CORE_EXTENSION_LANDING_URL="${{ secrets.CORE_EXTENSION_LANDING_URL }}"' >> .env.production
+      - name: Install dependencies
+        run: |
+          yarn install
+          yarn allow-scripts
+      - name: Build (regenerates LavaMoat policies)
+        run: yarn build
+      - name: Detect policy drift
+        id: drift
+        # The pathspec matches `policy.json` under any `lavamoat/rspack/`
+        # directory anywhere in the repo, so this still picks up new
+        # bundles (service worker, content script, offscreen, ...) the
+        # moment they wire LavaMoat in — no workflow change required.
+        run: |
+          POLICY_PATHSPEC=':(glob)**/lavamoat/rspack/policy.json'
+          if git diff --exit-code -- "$POLICY_PATHSPEC" > lavamoat-policy-diff.patch; then
+            rm -f lavamoat-policy-diff.patch
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+            echo "All LavaMoat policies are up to date."
+          else
+            echo "drifted=true" >> "$GITHUB_OUTPUT"
+            echo "::group::Policy diff"
+            cat lavamoat-policy-diff.patch
+            echo "::endgroup::"
+          fi
+      - name: Upload policy diff artifact
+        if: steps.drift.outputs.drifted == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          # Named with a stable prefix so `update-lavamoat-policies.yaml`
+          # can pick it up via a `pattern: lavamoat-policy-diff*` glob and
+          # also tolerate a future split into per-bundle validate jobs
+          # (e.g. `lavamoat-policy-diff-service-worker`).
+          name: lavamoat-policy-diff
+          path: lavamoat-policy-diff.patch
+          retention-days: 7
+          if-no-files-found: error
+      - name: Fail on drift
+        if: steps.drift.outputs.drifted == 'true'
+        run: |
+          echo "::error::LavaMoat policy drift detected. Comment '/update-lavamoat-policies' on the PR to have CI regenerate and commit the updated policy files, or regenerate locally with 'yarn build' and commit the result."
+          exit 1

--- a/apps/next/lavamoat/rspack/policy.json
+++ b/apps/next/lavamoat/rspack/policy.json
@@ -407,7 +407,6 @@
         "@core/ui>ledger-bitcoin": true,
         "@core/ui>lodash": true,
         "@core/ui>micro-signals": true,
-        "@rsbuild/plugin-node-polyfill>process": true,
         "react": true,
         "react-i18next": true,
         "@core/ui>react-router-dom": true,

--- a/packages/content-script/lavamoat/rspack/policy.json
+++ b/packages/content-script/lavamoat/rspack/policy.json
@@ -1,0 +1,1177 @@
+{
+  "resources": {
+    "@avalabs/vm-module-types": {
+      "packages": {
+        "zod": true
+      }
+    },
+    "@ethersproject/bytes": {
+      "packages": {
+        "@ethersproject/logger": true
+      }
+    },
+    "@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@noble/hashes": true
+      }
+    },
+    "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@notabene/pii-sdk": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "@ethersproject/bytes": true,
+        "@noble/curves": true,
+        "@stablelib/ed25519": true,
+        "axios-oauth-client": true,
+        "axios-token-interceptor": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios": true,
+        "base64url": true,
+        "bs58": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "did-jwt": true,
+        "semantic-release>lodash": true,
+        "multibase": true,
+        "multicodec": true
+      }
+    },
+    "@stablelib/binary": {
+      "packages": {
+        "@stablelib/int": true
+      }
+    },
+    "@stablelib/chacha": {
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/chacha20poly1305": {
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/chacha": true,
+        "@stablelib/constant-time": true,
+        "@stablelib/poly1305": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/ed25519": {
+      "packages": {
+        "@stablelib/random": true,
+        "@stablelib/sha512": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/poly1305": {
+      "packages": {
+        "@stablelib/constant-time": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/random": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/sha256": {
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/sha512": {
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/x25519": {
+      "packages": {
+        "@stablelib/random": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/xchacha20": {
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/chacha": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/xchacha20poly1305": {
+      "packages": {
+        "@stablelib/chacha20poly1305": true,
+        "@stablelib/wipe": true,
+        "@stablelib/xchacha20": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true,
+        "@rsbuild/plugin-node-polyfill>vm-browserify": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/sdk>body-parser>iconv-lite>safer-buffer": true
+      }
+    },
+    "eslint-plugin-react>array-includes>es-abstract>available-typed-arrays": {
+      "packages": {
+        "eslint-plugin-react>array-includes>es-abstract>typed-array-length>possible-typed-array-names": true
+      }
+    },
+    "axios-oauth-client": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>url>qs": true
+      }
+    },
+    "axios-token-interceptor": {
+      "packages": {
+        "lock": true
+      }
+    },
+    "@rsdoctor/rspack-plugin>@rsdoctor/core>axios": {
+      "globals": {
+        "Blob": true,
+        "Buffer.from": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "WorkerGlobalScope": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "importScripts": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "base64url": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "big.js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>brorand": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes": {
+      "globals": {
+        "Buffer.concat": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes>buffer-xor": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>cipher-base": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>cipher-base": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des>des.js": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hmac": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "bs58": {
+      "packages": {
+        "base-x": true
+      }
+    },
+    "buffer-equal-constant-time": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes>buffer-xor": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>buffer": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer>base64-js": true,
+        "@rsbuild/plugin-node-polyfill>buffer>ieee754": true
+      }
+    },
+    "eslint-plugin-react>object.values>call-bind>call-bind-apply-helpers": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "eslint-plugin-react>hasown>function-bind": true
+      }
+    },
+    "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>call-bind-apply-helpers": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "eslint-plugin-react>hasown>function-bind": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>function-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>function-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>get-intrinsic": true
+      }
+    },
+    "eslint-plugin-react>object.values>call-bind": {
+      "packages": {
+        "eslint-plugin-react>object.values>call-bind>call-bind-apply-helpers": true,
+        "eslint-plugin-react>object.values>call-bind>es-define-property": true,
+        "eslint-plugin-react>object.values>call-bind>set-function-length": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>call-bind": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>call-bind>function-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound": {
+      "packages": {
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>call-bind-apply-helpers": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>cipher-base": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>stream-browserify": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder": true
+      }
+    },
+    "semantic-release>git-log-parser>through2>readable-stream>core-util-is": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>cipher-base": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>md5.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>ripemd160": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>sha.js": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>create-hash": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hmac": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>cipher-base": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>ripemd160": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>sha.js": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hmac": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randomfill": true
+      }
+    },
+    "eslint-plugin-react>object.values>define-properties>define-data-property": {
+      "packages": {
+        "eslint-plugin-react>object.values>call-bind>es-define-property": true,
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "eslint-plugin-react>es-iterator-helpers>gopd": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des>des.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true
+      }
+    },
+    "did-jwt": {
+      "packages": {
+        "@stablelib/ed25519": true,
+        "@stablelib/random": true,
+        "@stablelib/sha256": true,
+        "@stablelib/x25519": true,
+        "@stablelib/xchacha20poly1305": true,
+        "bech32": true,
+        "canonicalize": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic": true,
+        "js-sha3": true,
+        "multiformats": true,
+        "uint8arrays": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true
+      }
+    },
+    "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto>dunder-proto": {
+      "packages": {
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>call-bind-apply-helpers": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto>dunder-proto>gopd": true
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>brorand": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>hash.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>hmac-drbg": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>es-abstract": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>get-intrinsic": true
+      }
+    },
+    "eslint-plugin-react>object.values>call-bind>es-define-property": {
+      "packages": {
+        "eslint-plugin-react>array-includes>get-intrinsic": true
+      }
+    },
+    "eth-rpc-errors": {
+      "packages": {
+        "fast-safe-stringify": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>events": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>md5.js": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "fireblocks-sdk": {
+      "globals": {
+        "URLSearchParams": true
+      },
+      "packages": {
+        "@notabene/pii-sdk": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "jsonwebtoken": true,
+        "@rsbuild/plugin-node-polyfill>os-browserify": true,
+        "platform": true,
+        "@rsbuild/plugin-node-polyfill>url>qs": true,
+        "query-string": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>request>uuid": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each": {
+      "packages": {
+        "eslint-plugin-react>jsx-ast-utils>array-includes>es-abstract>is-callable": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each>is-callable": true
+      }
+    },
+    "eslint-plugin-react>array-includes>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "eslint-plugin-react>hasown>function-bind": true,
+        "eslint-plugin-react>array-includes>get-intrinsic>has-proto": true,
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true,
+        "eslint-plugin-react>hasown": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>function-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true,
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>function-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true,
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "Float16Array": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>call-bind-apply-helpers": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic>es-define-property": true,
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic>es-object-atoms": true,
+        "eslint-plugin-react>hasown>function-bind": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic>gopd": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic>has-symbols": true,
+        "eslint-plugin-react>hasown": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>math-intrinsics": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>gopd>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>gopd>get-intrinsic>function-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true,
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>call-bind>function-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true,
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has": true
+      }
+    },
+    "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": {
+      "packages": {
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto>dunder-proto": true,
+        "eslint-plugin-react>object.values>es-object-atoms": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>gopd": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>gopd>get-intrinsic": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>has-property-descriptors": {
+      "packages": {
+        "eslint-plugin-react>object.values>call-bind>es-define-property": true
+      }
+    },
+    "eslint-plugin-react>array-includes>is-string>has-tostringtag": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>has-tostringtag": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true
+      }
+    },
+    "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has": {
+      "packages": {
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has>function-bind": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>md5.js>hash-base": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>readable-stream": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>ripemd160>hash-base": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>readable-stream": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>ripemd160>hash-base": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>stream-browserify": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>hash.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true
+      }
+    },
+    "eslint-plugin-react>hasown": {
+      "packages": {
+        "eslint-plugin-react>hasown>function-bind": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>hmac-drbg": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>hash.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-arguments": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind": true,
+        "eslint-plugin-react>array-includes>is-string>has-tostringtag": true
+      }
+    },
+    "eslint-plugin-react>jsx-ast-utils>array-includes>es-abstract>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-generator-function": {
+      "packages": {
+        "eslint-plugin-react>array-includes>is-string>has-tostringtag": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>available-typed-arrays": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>es-abstract": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each": true,
+        "eslint-plugin-react>array-includes>is-string>has-tostringtag": true
+      }
+    },
+    "joi": {
+      "globals": {
+        "TextEncoder": true,
+        "URL": true,
+        "define": true
+      }
+    },
+    "js-sha3": {
+      "globals": {
+        "define": true,
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "jsonwebtoken": {
+      "globals": {
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "process.version": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "jws": true,
+        "semantic-release>lodash": true,
+        "semantic-release>@semantic-release/npm>npm>ms": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "semantic-release>semver": true
+      }
+    },
+    "jwa": {
+      "packages": {
+        "buffer-equal-constant-time": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "ecdsa-sig-formatter": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "jws": {
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "jwa": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>stream-browserify": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "lock": {
+      "globals": {
+        "setImmediate": true,
+        "setTimeout": true
+      }
+    },
+    "semantic-release>lodash": {
+      "globals": {
+        "define": true
+      }
+    },
+    "semantic-release>semver>lru-cache": {
+      "packages": {
+        "semantic-release>semver>lru-cache>yallist": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>md5.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>md5.js>hash-base": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>brorand": true
+      }
+    },
+    "multibase": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@multiformats/base-x": true
+      }
+    },
+    "multicodec": {
+      "packages": {
+        "uint8arrays": true,
+        "varint": true
+      }
+    },
+    "multiformats": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "console.warn": true,
+        "crypto.subtle.digest": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>object-inspect": {
+      "globals": {
+        "HTMLElement": true,
+        "WeakRef": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>os-browserify": {
+      "globals": {
+        "location": true,
+        "navigator": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2": {
+      "globals": {
+        "crypto": true,
+        "process": true,
+        "queueMicrotask": true,
+        "setImmediate": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>ripemd160": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>sha.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer": true
+      }
+    },
+    "platform": {
+      "globals": {
+        "define": true
+      }
+    },
+    "semantic-release>git-log-parser>through2>readable-stream>process-nextick-args": {
+      "globals": {
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>process": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel": true
+      }
+    },
+    "query-string": {
+      "packages": {
+        "decode-uri-component": true,
+        "filter-obj": true,
+        "split-on-first": true,
+        "strict-uri-encode": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "process.nextTick": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>randomfill": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "process.browser": true,
+        "process.nextTick": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream": {
+      "globals": {
+        "process.browser": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "semantic-release>git-log-parser>through2>readable-stream>core-util-is": true,
+        "@rsbuild/plugin-node-polyfill>events": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>isarray": true,
+        "semantic-release>git-log-parser>through2>readable-stream>process-nextick-args": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>readable-stream>util-deprecate": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>stream-http>readable-stream": {
+      "globals": {
+        "process.nextTick": true,
+        "process.stderr": true,
+        "process.stdout": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>events": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>readable-stream>util-deprecate": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>ripemd160": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>ripemd160>hash-base": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>ripemd160": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>ripemd160>hash-base": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>safe-buffer": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder>safe-buffer": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsdoctor/rspack-plugin>@rsdoctor/sdk>body-parser>iconv-lite>safer-buffer": {
+      "globals": {
+        "process.binding": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "semantic-release>semver": {
+      "globals": {
+        "console.error": true,
+        "process": true
+      },
+      "packages": {
+        "semantic-release>semver>lru-cache": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "eslint-plugin-react>object.values>call-bind>set-function-length": {
+      "packages": {
+        "eslint-plugin-react>object.values>define-properties>define-data-property": true,
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "eslint-plugin-react>array-includes>get-intrinsic": true,
+        "eslint-plugin-react>es-iterator-helpers>gopd": true,
+        "eslint-plugin-react>es-iterator-helpers>has-property-descriptors": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>sha.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>call-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>get-intrinsic": true,
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>object-inspect": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>stream-browserify": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>events": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>readable-stream": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>string_decoder": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>safe-array-concat>isarray": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound": true,
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array": true
+      }
+    },
+    "uint8arrays": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "multiformats": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>stream-http>readable-stream>util-deprecate": {
+      "globals": {
+        "console.trace": true,
+        "console.warn": true,
+        "localStorage": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true,
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>util>is-arguments": true,
+        "@rsbuild/plugin-node-polyfill>util>is-generator-function": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>util>which-typed-array": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>request>uuid": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>vm-browserify": {
+      "globals": {
+        "document.body.appendChild": true,
+        "document.body.removeChild": true,
+        "document.createElement": true
+      }
+    },
+    "webextension-polyfill": {
+      "globals": {
+        "browser": true,
+        "chrome": true,
+        "console.error": true,
+        "console.warn": true,
+        "define": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array": {
+      "packages": {
+        "eslint-plugin-react>array-includes>es-abstract>available-typed-arrays": true,
+        "eslint-plugin-react>object.values>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>gopd": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>has-tostringtag": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>which-typed-array": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>available-typed-arrays": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>es-abstract": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each": true,
+        "eslint-plugin-react>array-includes>is-string>has-tostringtag": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array": true
+      }
+    },
+    "zod": {
+      "globals": {
+        "File": true,
+        "JSONSchema": true,
+        "SuppressedError": true,
+        "URL": true,
+        "__zod_globalRegistry": true,
+        "atob": true,
+        "btoa": true,
+        "coerce": true,
+        "core": true,
+        "iso": true,
+        "locales": true,
+        "navigator": true,
+        "regexes": true,
+        "util": true
+      }
+    }
+  }
+}

--- a/packages/content-script/package.json
+++ b/packages/content-script/package.json
@@ -16,6 +16,7 @@
     "@core/messaging": "workspace:*"
   },
   "devDependencies": {
+    "@core/lavamoat-rspack": "workspace:*",
     "@rsbuild/core": "1.3.3",
     "@rsbuild/plugin-node-polyfill": "1.3.0",
     "@rsbuild/plugin-react": "1.1.1",

--- a/packages/content-script/rsbuild.content-script.common.ts
+++ b/packages/content-script/rsbuild.content-script.common.ts
@@ -1,66 +1,105 @@
+import LavaMoatRspackPlugin from '@core/lavamoat-rspack';
 import path from 'path';
 import { defineConfig } from '@rsbuild/core';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 
-export default defineConfig(() => {
-  const distSubdirectory = 'dist';
+export interface CommonConfigOptions {
+  /**
+   * When true, LavaMoat regenerates `policy.json` during the build. Enabled
+   * for shippable builds (prod) so CI can flag policy drift; disabled for
+   * local dev so editing app code can't silently widen permissions.
+   */
+  generateLavaMoatPolicy: boolean;
+}
 
-  return {
-    environments: {
-      'web-worker': {
-        source: {
-          decorators: {
-            version: 'legacy',
+export default ({ generateLavaMoatPolicy }: CommonConfigOptions) =>
+  defineConfig(() => {
+    const distSubdirectory = 'dist';
+
+    return {
+      environments: {
+        'web-worker': {
+          source: {
+            decorators: {
+              version: 'legacy',
+            },
+            entry: {
+              contentscript: path.join(__dirname, 'src/contentscript.ts'),
+            },
           },
-          entry: {
-            contentscript: path.join(__dirname, 'src/contentscript.ts'),
+          output: {
+            target: 'web-worker',
           },
         },
-        output: {
-          target: 'web-worker',
+      },
+      output: {
+        cleanDistPath: true,
+        filename: {
+          js: '[name].js', // this is the default, but just to make sure
+        },
+        distPath: {
+          root: path.join(__dirname, '../..', distSubdirectory, 'cs'),
+          js: 'js',
+          jsAsync: 'js',
         },
       },
-    },
-    output: {
-      cleanDistPath: true,
-      filename: {
-        js: '[name].js', // this is the default, but just to make sure
+      resolve: {
+        extensions: ['.ts', '.tsx', '.js'],
+        fallback: {
+          path: false,
+          fs: false,
+          Buffer: false,
+          process: false,
+        },
       },
-      distPath: {
-        root: path.join(__dirname, '../..', distSubdirectory, 'cs'),
-        js: 'js',
-        jsAsync: 'js',
-      },
-    },
-    resolve: {
-      extensions: ['.ts', '.tsx', '.js'],
-      fallback: {
-        path: false,
-        fs: false,
-        Buffer: false,
-        process: false,
-      },
-    },
-    plugins: [pluginNodePolyfill()],
-    tools: {
-      rspack: (_, { appendPlugins, appendRules }) => {
-        if (process.env.RSDOCTOR === 'true') {
-          appendPlugins(new RsdoctorRspackPlugin({}));
-        }
+      plugins: [pluginNodePolyfill()],
+      tools: {
+        rspack: (_, { appendPlugins, appendRules }) => {
+          if (process.env.RSDOCTOR === 'true') {
+            appendPlugins(new RsdoctorRspackPlugin({}));
+          }
 
-        appendRules({
-          test: /\.wasm$/,
-          // Tells WebPack that this module should be included as
-          // base64-encoded binary file and not as code
-          loader: 'base64-loader',
-          // Disables WebPack's opinion where WebAssembly should be,
-          // makes it think that it's not WebAssembly
-          //
-          // Error: WebAssembly module is included in initial chunk.
-          type: 'javascript/auto',
-        });
+          appendRules({
+            test: /\.wasm$/,
+            // Tells WebPack that this module should be included as
+            // base64-encoded binary file and not as code
+            loader: 'base64-loader',
+            // Disables WebPack's opinion where WebAssembly should be,
+            // makes it think that it's not WebAssembly
+            //
+            // Error: WebAssembly module is included in initial chunk.
+            type: 'javascript/auto',
+          });
+
+          appendPlugins(
+            new LavaMoatRspackPlugin({
+              // Driven per build target: prod regenerates so PR CI can fail
+              // on policy drift, dev loads the checked-in policy so local
+              // edits can't silently widen permissions without a code review.
+              generatePolicy: generateLavaMoatPolicy,
+              policyLocation: path.join(__dirname, 'lavamoat/rspack'),
+              // Walk the dependency tree from the monorepo root rather than
+              // this package. Content script's package.json only declares
+              // `@core/*` workspace deps, so @lavamoat/aa would otherwise
+              // miss every transitive npm dep that `@core/common` re-exports
+              // (e.g. fireblocks-sdk → @notabene/pii-sdk → did-jwt) and emit
+              // them as `external:` placeholder names that aren't useful.
+              rootDir: path.join(__dirname, '../..'),
+              // Content script is injected by the browser as raw JS — there
+              // is no host HTML to drop a <script src="./lockdown"> tag
+              // into. Prepend SES lockdown to the entry bundle so it
+              // executes before any wrapped module in the isolated world.
+              inlineLockdown: /contentscript\.js$/,
+              // Same primordial-mutation pattern as in service-worker /
+              // apps/next: both packages reach the content script via
+              // `@core/common`'s `unifiedTransfer/` re-exports (fusion-sdk
+              // → … → js-sha3, fireblocks-sdk → … → did-jwt). Walking from
+              // the monorepo root flattens them to top-level npm names.
+              knownIncompatiblePackages: ['did-jwt', 'js-sha3'],
+            }),
+          );
+        },
       },
-    },
-  };
-});
+    };
+  });

--- a/packages/content-script/rsbuild.content-script.dev.ts
+++ b/packages/content-script/rsbuild.content-script.dev.ts
@@ -1,8 +1,11 @@
 import { defineConfig, mergeRsbuildConfig } from '@rsbuild/core';
-import commonConfig from './rsbuild.content-script.common';
+import buildCommonConfig from './rsbuild.content-script.common';
 import { getEnvVars } from '../../build-scripts/getEnvVars';
 
 const skipSourceMap = process.env.NO_SOURCE_MAPS === 'true';
+// Local dev never regenerates the LavaMoat policy — keep app edits from
+// silently widening permissions. Use `yarn build` (or CI) to refresh it.
+const commonConfig = buildCommonConfig({ generateLavaMoatPolicy: false });
 
 export default defineConfig((...args) =>
   mergeRsbuildConfig(commonConfig(...args), {

--- a/packages/content-script/rsbuild.content-script.prod.ts
+++ b/packages/content-script/rsbuild.content-script.prod.ts
@@ -1,6 +1,10 @@
 import { defineConfig, mergeRsbuildConfig } from '@rsbuild/core';
-import commonConfig from './rsbuild.content-script.common';
+import buildCommonConfig from './rsbuild.content-script.common';
 import { getEnvVars } from '../../build-scripts/getEnvVars';
+
+// Production builds regenerate the policy so PR CI can detect drift between
+// the checked-in policy.json and what the actual bundle would need.
+const commonConfig = buildCommonConfig({ generateLavaMoatPolicy: true });
 
 export default defineConfig((...args) =>
   mergeRsbuildConfig(commonConfig(...args), {

--- a/packages/offscreen/lavamoat/rspack/policy.json
+++ b/packages/offscreen/lavamoat/rspack/policy.json
@@ -1,0 +1,1179 @@
+{
+  "resources": {
+    "@avalabs/core-gasless-sdk": {
+      "globals": {
+        "Buffer.from": true,
+        "fetch": true,
+        "performance.now": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "zod": true
+      }
+    },
+    "@avalabs/vm-module-types": {
+      "packages": {
+        "zod": true
+      }
+    },
+    "@ethersproject/bytes": {
+      "packages": {
+        "@ethersproject/logger": true
+      }
+    },
+    "@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@noble/hashes": true
+      }
+    },
+    "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@notabene/pii-sdk": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "@ethersproject/bytes": true,
+        "@noble/curves": true,
+        "@stablelib/ed25519": true,
+        "axios-oauth-client": true,
+        "axios-token-interceptor": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios": true,
+        "base64url": true,
+        "bs58": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "did-jwt": true,
+        "semantic-release>lodash": true,
+        "multibase": true,
+        "multicodec": true
+      }
+    },
+    "@stablelib/binary": {
+      "packages": {
+        "@stablelib/int": true
+      }
+    },
+    "@stablelib/chacha": {
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/chacha20poly1305": {
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/chacha": true,
+        "@stablelib/constant-time": true,
+        "@stablelib/poly1305": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/ed25519": {
+      "packages": {
+        "@stablelib/random": true,
+        "@stablelib/sha512": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/poly1305": {
+      "packages": {
+        "@stablelib/constant-time": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/random": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/sha256": {
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/sha512": {
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/x25519": {
+      "packages": {
+        "@stablelib/random": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/xchacha20": {
+      "packages": {
+        "@stablelib/binary": true,
+        "@stablelib/chacha": true,
+        "@stablelib/wipe": true
+      }
+    },
+    "@stablelib/xchacha20poly1305": {
+      "packages": {
+        "@stablelib/chacha20poly1305": true,
+        "@stablelib/wipe": true,
+        "@stablelib/xchacha20": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true,
+        "@rsbuild/plugin-node-polyfill>vm-browserify": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/sdk>body-parser>iconv-lite>safer-buffer": true
+      }
+    },
+    "eslint-plugin-react>array-includes>es-abstract>available-typed-arrays": {
+      "packages": {
+        "eslint-plugin-react>array-includes>es-abstract>typed-array-length>possible-typed-array-names": true
+      }
+    },
+    "axios-oauth-client": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>url>qs": true
+      }
+    },
+    "axios-token-interceptor": {
+      "packages": {
+        "lock": true
+      }
+    },
+    "@rsdoctor/rspack-plugin>@rsdoctor/core>axios": {
+      "globals": {
+        "Blob": true,
+        "Buffer.from": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "WorkerGlobalScope": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "importScripts": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "base64url": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>brorand": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes": {
+      "globals": {
+        "Buffer.concat": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes>buffer-xor": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>cipher-base": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>cipher-base": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des>des.js": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hmac": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "bs58": {
+      "packages": {
+        "base-x": true
+      }
+    },
+    "buffer-equal-constant-time": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes>buffer-xor": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>buffer": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer>base64-js": true,
+        "@rsbuild/plugin-node-polyfill>buffer>ieee754": true
+      }
+    },
+    "eslint-plugin-react>object.values>call-bind>call-bind-apply-helpers": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "eslint-plugin-react>hasown>function-bind": true
+      }
+    },
+    "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>call-bind-apply-helpers": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "eslint-plugin-react>hasown>function-bind": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>function-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>function-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>get-intrinsic": true
+      }
+    },
+    "eslint-plugin-react>object.values>call-bind": {
+      "packages": {
+        "eslint-plugin-react>object.values>call-bind>call-bind-apply-helpers": true,
+        "eslint-plugin-react>object.values>call-bind>es-define-property": true,
+        "eslint-plugin-react>object.values>call-bind>set-function-length": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>call-bind": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>call-bind>function-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound": {
+      "packages": {
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>call-bind-apply-helpers": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>cipher-base": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>stream-browserify": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder": true
+      }
+    },
+    "semantic-release>git-log-parser>through2>readable-stream>core-util-is": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>cipher-base": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>md5.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>ripemd160": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>sha.js": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>create-hash": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hmac": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>cipher-base": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>ripemd160": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>sha.js": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hmac": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randomfill": true
+      }
+    },
+    "eslint-plugin-react>object.values>define-properties>define-data-property": {
+      "packages": {
+        "eslint-plugin-react>object.values>call-bind>es-define-property": true,
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "eslint-plugin-react>es-iterator-helpers>gopd": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des>des.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true
+      }
+    },
+    "did-jwt": {
+      "packages": {
+        "@stablelib/ed25519": true,
+        "@stablelib/random": true,
+        "@stablelib/sha256": true,
+        "@stablelib/x25519": true,
+        "@stablelib/xchacha20poly1305": true,
+        "bech32": true,
+        "canonicalize": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic": true,
+        "js-sha3": true,
+        "multiformats": true,
+        "uint8arrays": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true
+      }
+    },
+    "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto>dunder-proto": {
+      "packages": {
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>call-bind-apply-helpers": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto>dunder-proto>gopd": true
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>brorand": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>hash.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>hmac-drbg": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>es-abstract": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>get-intrinsic": true
+      }
+    },
+    "eslint-plugin-react>object.values>call-bind>es-define-property": {
+      "packages": {
+        "eslint-plugin-react>array-includes>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>events": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>md5.js": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "fireblocks-sdk": {
+      "globals": {
+        "URLSearchParams": true
+      },
+      "packages": {
+        "@notabene/pii-sdk": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "jsonwebtoken": true,
+        "@rsbuild/plugin-node-polyfill>os-browserify": true,
+        "platform": true,
+        "@rsbuild/plugin-node-polyfill>url>qs": true,
+        "query-string": true,
+        "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>request>uuid": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each": {
+      "packages": {
+        "eslint-plugin-react>jsx-ast-utils>array-includes>es-abstract>is-callable": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each>is-callable": true
+      }
+    },
+    "eslint-plugin-react>array-includes>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "eslint-plugin-react>hasown>function-bind": true,
+        "eslint-plugin-react>array-includes>get-intrinsic>has-proto": true,
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true,
+        "eslint-plugin-react>hasown": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>function-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true,
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>function-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true,
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "Float16Array": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>call-bind-apply-helpers": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic>es-define-property": true,
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic>es-object-atoms": true,
+        "eslint-plugin-react>hasown>function-bind": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic>gopd": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound>get-intrinsic>has-symbols": true,
+        "eslint-plugin-react>hasown": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>math-intrinsics": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>gopd>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>gopd>get-intrinsic>function-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true,
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>call-bind>function-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true,
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has": true
+      }
+    },
+    "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": {
+      "packages": {
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto>dunder-proto": true,
+        "eslint-plugin-react>object.values>es-object-atoms": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>gopd": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>gopd>get-intrinsic": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>has-property-descriptors": {
+      "packages": {
+        "eslint-plugin-react>object.values>call-bind>es-define-property": true
+      }
+    },
+    "eslint-plugin-react>array-includes>is-string>has-tostringtag": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>has-tostringtag": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>has-symbols": true
+      }
+    },
+    "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has": {
+      "packages": {
+        "eslint-plugin-react>array.prototype.flatmap>es-shim-unscopables>has>function-bind": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>md5.js>hash-base": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>readable-stream": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>ripemd160>hash-base": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>readable-stream": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>ripemd160>hash-base": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>stream-browserify": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>hash.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true
+      }
+    },
+    "eslint-plugin-react>hasown": {
+      "packages": {
+        "eslint-plugin-react>hasown>function-bind": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>hmac-drbg": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>hash.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-assert": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-arguments": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind": true,
+        "eslint-plugin-react>array-includes>is-string>has-tostringtag": true
+      }
+    },
+    "eslint-plugin-react>jsx-ast-utils>array-includes>es-abstract>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-generator-function": {
+      "packages": {
+        "eslint-plugin-react>array-includes>is-string>has-tostringtag": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>available-typed-arrays": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>es-abstract": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each": true,
+        "eslint-plugin-react>array-includes>is-string>has-tostringtag": true
+      }
+    },
+    "joi": {
+      "globals": {
+        "TextEncoder": true,
+        "URL": true,
+        "define": true
+      }
+    },
+    "js-sha3": {
+      "globals": {
+        "define": true,
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "jsonwebtoken": {
+      "globals": {
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "process.version": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "jws": true,
+        "semantic-release>lodash": true,
+        "semantic-release>@semantic-release/npm>npm>ms": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "semantic-release>semver": true
+      }
+    },
+    "jwa": {
+      "packages": {
+        "buffer-equal-constant-time": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "ecdsa-sig-formatter": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "jws": {
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "jwa": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>stream-browserify": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "lock": {
+      "globals": {
+        "setImmediate": true,
+        "setTimeout": true
+      }
+    },
+    "semantic-release>lodash": {
+      "globals": {
+        "define": true
+      }
+    },
+    "semantic-release>semver>lru-cache": {
+      "packages": {
+        "semantic-release>semver>lru-cache>yallist": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>md5.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>md5.js>hash-base": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh>elliptic>brorand": true
+      }
+    },
+    "multibase": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@multiformats/base-x": true
+      }
+    },
+    "multicodec": {
+      "packages": {
+        "uint8arrays": true,
+        "varint": true
+      }
+    },
+    "multiformats": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "console.warn": true,
+        "crypto.subtle.digest": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>object-inspect": {
+      "globals": {
+        "HTMLElement": true,
+        "WeakRef": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>os-browserify": {
+      "globals": {
+        "location": true,
+        "navigator": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-aes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2": {
+      "globals": {
+        "crypto": true,
+        "process": true,
+        "queueMicrotask": true,
+        "setImmediate": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>ripemd160": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>sha.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer": true
+      }
+    },
+    "platform": {
+      "globals": {
+        "define": true
+      }
+    },
+    "semantic-release>git-log-parser>through2>readable-stream>process-nextick-args": {
+      "globals": {
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>process": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel": true
+      }
+    },
+    "query-string": {
+      "packages": {
+        "decode-uri-component": true,
+        "filter-obj": true,
+        "split-on-first": true,
+        "strict-uri-encode": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "process.nextTick": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>randomfill": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "process.browser": true,
+        "process.nextTick": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream": {
+      "globals": {
+        "process.browser": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "semantic-release>git-log-parser>through2>readable-stream>core-util-is": true,
+        "@rsbuild/plugin-node-polyfill>events": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>isarray": true,
+        "semantic-release>git-log-parser>through2>readable-stream>process-nextick-args": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>readable-stream>util-deprecate": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>stream-http>readable-stream": {
+      "globals": {
+        "process.nextTick": true,
+        "process.stderr": true,
+        "process.stdout": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>events": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>readable-stream>util-deprecate": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>ripemd160": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-hash>ripemd160>hash-base": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>ripemd160": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>ripemd160>hash-base": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>safe-buffer": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder>safe-buffer": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true
+      }
+    },
+    "@rsdoctor/rspack-plugin>@rsdoctor/sdk>body-parser>iconv-lite>safer-buffer": {
+      "globals": {
+        "process.binding": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>buffer": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "semantic-release>semver": {
+      "globals": {
+        "console.error": true,
+        "process": true
+      },
+      "packages": {
+        "semantic-release>semver>lru-cache": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "eslint-plugin-react>object.values>call-bind>set-function-length": {
+      "packages": {
+        "eslint-plugin-react>object.values>define-properties>define-data-property": true,
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "eslint-plugin-react>array-includes>get-intrinsic": true,
+        "eslint-plugin-react>es-iterator-helpers>gopd": true,
+        "eslint-plugin-react>es-iterator-helpers>has-property-descriptors": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>sha.js": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer": true
+      }
+    },
+    "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>call-bind": true,
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>get-intrinsic": true,
+        "eslint-plugin-react>es-iterator-helpers>internal-slot>side-channel>object-inspect": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>stream-browserify": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>events": true,
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>readable-stream": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>string_decoder": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer": {
+      "packages": {
+        "eslint-plugin-react>es-iterator-helpers>safe-array-concat>isarray": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound": true,
+        "eslint-plugin-react>es-iterator-helpers>es-errors": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array": true
+      }
+    },
+    "uint8arrays": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "multiformats": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>stream-http>readable-stream>util-deprecate": {
+      "globals": {
+        "console.trace": true,
+        "console.warn": true,
+        "localStorage": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true,
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>inherits": true,
+        "@rsbuild/plugin-node-polyfill>util>is-arguments": true,
+        "@rsbuild/plugin-node-polyfill>util>is-generator-function": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>util>which-typed-array": true
+      }
+    },
+    "@lavamoat/allow-scripts>@npmcli/run-script>node-gyp>request>uuid": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>vm-browserify": {
+      "globals": {
+        "document.body.appendChild": true,
+        "document.body.removeChild": true,
+        "document.createElement": true
+      }
+    },
+    "webextension-polyfill": {
+      "globals": {
+        "browser": true,
+        "chrome": true,
+        "console.error": true,
+        "console.warn": true,
+        "define": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array": {
+      "packages": {
+        "eslint-plugin-react>array-includes>es-abstract>available-typed-arrays": true,
+        "eslint-plugin-react>object.values>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>call-bound": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each": true,
+        "@rsdoctor/rspack-plugin>@rsdoctor/core>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>gopd": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>has-tostringtag": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>which-typed-array": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>available-typed-arrays": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>es-abstract": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each": true,
+        "eslint-plugin-react>array-includes>is-string>has-tostringtag": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array": true
+      }
+    },
+    "zod": {
+      "globals": {
+        "File": true,
+        "JSONSchema": true,
+        "SuppressedError": true,
+        "URL": true,
+        "__zod_globalRegistry": true,
+        "atob": true,
+        "btoa": true,
+        "coerce": true,
+        "core": true,
+        "iso": true,
+        "locales": true,
+        "navigator": true,
+        "regexes": true,
+        "util": true
+      }
+    }
+  }
+}

--- a/packages/offscreen/package.json
+++ b/packages/offscreen/package.json
@@ -17,6 +17,7 @@
     "@core/types": "workspace:*"
   },
   "devDependencies": {
+    "@core/lavamoat-rspack": "workspace:*",
     "@rsbuild/core": "1.3.3",
     "@rsbuild/plugin-node-polyfill": "1.3.0",
     "@rsbuild/plugin-react": "1.1.1",

--- a/packages/offscreen/rsbuild.offscreen.common.ts
+++ b/packages/offscreen/rsbuild.offscreen.common.ts
@@ -1,70 +1,110 @@
+import LavaMoatRspackPlugin from '@core/lavamoat-rspack';
 import { defineConfig } from '@rsbuild/core';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import path from 'path';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 
-export default defineConfig(() => {
-  const distSubdirectory = 'dist';
+export interface CommonConfigOptions {
+  /**
+   * When true, LavaMoat regenerates `policy.json` during the build. Enabled
+   * for shippable builds (prod) so CI can flag policy drift; disabled for
+   * local dev so editing app code can't silently widen permissions.
+   */
+  generateLavaMoatPolicy: boolean;
+}
 
-  return {
-    environments: {
-      web: {
-        html: {
-          template: 'src/offscreen.html',
-        },
-        source: {
-          decorators: {
-            version: 'legacy',
-          },
-          entry: {
-            offscreen: path.join(__dirname, 'src/offscreen.ts'),
-          },
-        },
-        output: {
-          target: 'web',
-        },
-      },
-    },
-    output: {
-      cleanDistPath: true,
-      assetPrefix: './',
-      filename: {
-        js: '[name].js', // this is the default, but just to make sure
-      },
-      distPath: {
-        root: path.join(__dirname, '../..', distSubdirectory, 'offscreen'),
-        js: 'js',
-        jsAsync: 'js',
-      },
-    },
-    resolve: {
-      extensions: ['.ts', '.tsx', '.js'],
-      fallback: {
-        path: false,
-        fs: false,
-        Buffer: false,
-        process: false,
-      },
-    },
-    plugins: [pluginNodePolyfill()],
-    tools: {
-      rspack: (_, { appendPlugins, appendRules }) => {
-        if (process.env.RSDOCTOR === 'true') {
-          appendPlugins(new RsdoctorRspackPlugin({}));
-        }
+export default ({ generateLavaMoatPolicy }: CommonConfigOptions) =>
+  defineConfig(() => {
+    const distSubdirectory = 'dist';
 
-        appendRules({
-          test: /\.wasm$/,
-          // Tells WebPack that this module should be included as
-          // base64-encoded binary file and not as code
-          loader: 'base64-loader',
-          // Disables WebPack's opinion where WebAssembly should be,
-          // makes it think that it's not WebAssembly
-          //
-          // Error: WebAssembly module is included in initial chunk.
-          type: 'javascript/auto',
-        });
+    return {
+      environments: {
+        web: {
+          html: {
+            template: 'src/offscreen.html',
+          },
+          source: {
+            decorators: {
+              version: 'legacy',
+            },
+            entry: {
+              offscreen: path.join(__dirname, 'src/offscreen.ts'),
+            },
+          },
+          output: {
+            target: 'web',
+          },
+        },
       },
-    },
-  };
-});
+      output: {
+        cleanDistPath: true,
+        assetPrefix: './',
+        filename: {
+          js: '[name].js', // this is the default, but just to make sure
+        },
+        distPath: {
+          root: path.join(__dirname, '../..', distSubdirectory, 'offscreen'),
+          js: 'js',
+          jsAsync: 'js',
+        },
+      },
+      resolve: {
+        extensions: ['.ts', '.tsx', '.js'],
+        fallback: {
+          path: false,
+          fs: false,
+          Buffer: false,
+          process: false,
+        },
+      },
+      plugins: [pluginNodePolyfill()],
+      tools: {
+        rspack: (_, { appendPlugins, appendRules }) => {
+          if (process.env.RSDOCTOR === 'true') {
+            appendPlugins(new RsdoctorRspackPlugin({}));
+          }
+
+          appendRules({
+            test: /\.wasm$/,
+            // Tells WebPack that this module should be included as
+            // base64-encoded binary file and not as code
+            loader: 'base64-loader',
+            // Disables WebPack's opinion where WebAssembly should be,
+            // makes it think that it's not WebAssembly
+            //
+            // Error: WebAssembly module is included in initial chunk.
+            type: 'javascript/auto',
+          });
+
+          appendPlugins(
+            new LavaMoatRspackPlugin({
+              // Driven per build target: prod regenerates so PR CI can fail
+              // on policy drift, dev loads the checked-in policy so local
+              // edits can't silently widen permissions without a code review.
+              generatePolicy: generateLavaMoatPolicy,
+              policyLocation: path.join(__dirname, 'lavamoat/rspack'),
+              // Walk the dependency tree from the monorepo root rather than
+              // this package. Offscreen's package.json only declares
+              // `@core/*` workspace deps, so @lavamoat/aa would otherwise
+              // miss every transitive npm dep that `@core/common` re-exports
+              // (e.g. fireblocks-sdk → @notabene/pii-sdk → did-jwt) and emit
+              // them as `external:` placeholder names that aren't useful.
+              rootDir: path.join(__dirname, '../..'),
+              // The offscreen document has its own HTML host, but we still
+              // prepend SES into the entry bundle rather than emitting a
+              // separate `lockdown` asset: keeps the document to a single
+              // request and matches how service-worker / content-script are
+              // wired in this repo.
+              inlineLockdown: /offscreen\.js$/,
+              // Same primordial-mutation pattern as in service-worker /
+              // content-script: both packages reach the offscreen entry via
+              // `@core/common`'s `unifiedTransfer/` re-exports (fusion-sdk
+              // → … → js-sha3, fireblocks-sdk → … → did-jwt). Walking from
+              // the monorepo root flattens them to top-level npm names.
+              knownIncompatiblePackages: ['did-jwt', 'js-sha3'],
+            }),
+          );
+        },
+      },
+    };
+  });

--- a/packages/offscreen/rsbuild.offscreen.dev.ts
+++ b/packages/offscreen/rsbuild.offscreen.dev.ts
@@ -1,8 +1,11 @@
 import { defineConfig, mergeRsbuildConfig } from '@rsbuild/core';
-import commonConfig from './rsbuild.offscreen.common';
+import buildCommonConfig from './rsbuild.offscreen.common';
 import { getEnvVars } from '../../build-scripts/getEnvVars';
 
 const skipSourceMap = process.env.NO_SOURCE_MAPS === 'true';
+// Local dev never regenerates the LavaMoat policy — keep app edits from
+// silently widening permissions. Use `yarn build` (or CI) to refresh it.
+const commonConfig = buildCommonConfig({ generateLavaMoatPolicy: false });
 
 export default defineConfig((...args) =>
   mergeRsbuildConfig(commonConfig(...args), {

--- a/packages/offscreen/rsbuild.offscreen.prod.ts
+++ b/packages/offscreen/rsbuild.offscreen.prod.ts
@@ -1,6 +1,10 @@
 import { defineConfig, mergeRsbuildConfig } from '@rsbuild/core';
-import commonConfig from './rsbuild.offscreen.common';
+import buildCommonConfig from './rsbuild.offscreen.common';
 import { getEnvVars } from '../../build-scripts/getEnvVars';
+
+// Production builds regenerate the policy so PR CI can detect drift between
+// the checked-in policy.json and what the actual bundle would need.
+const commonConfig = buildCommonConfig({ generateLavaMoatPolicy: true });
 
 export default defineConfig((...args) =>
   mergeRsbuildConfig(commonConfig(...args), {

--- a/packages/service-worker/lavamoat/rspack/policy.json
+++ b/packages/service-worker/lavamoat/rspack/policy.json
@@ -1,0 +1,6661 @@
+{
+  "resources": {
+    "@avalabs/avalanche-module": {
+      "globals": {
+        "Buffer.from": true,
+        "URLSearchParams": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "fetch": true,
+        "process.env.GLACIER_API_KEY": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@avalabs/avalanchejs": true,
+        "@avalabs/core-coingecko-sdk": true,
+        "@avalabs/avalanche-module>@avalabs/core-utils-sdk": true,
+        "@avalabs/core-wallets-sdk": true,
+        "@avalabs/glacier-sdk": true,
+        "@avalabs/vm-module-types": true,
+        "@metamask/rpc-errors": true,
+        "@avalabs/avalanche-module>big.js": true,
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@avalabs/avalanche-module>zod": true
+      }
+    },
+    "@avalabs/avalanchejs": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "console.log": true,
+        "crypto": true,
+        "fetch": true
+      },
+      "packages": {
+        "@avalabs/avalanchejs>@noble/hashes": true,
+        "@avalabs/avalanchejs>@scure/base": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "@avalabs/bitcoin-module": {
+      "globals": {
+        "Buffer.from": true,
+        "URLSearchParams": true,
+        "console.error": true,
+        "fetch": true,
+        "process.env.GLACIER_API_KEY": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@avalabs/core-coingecko-sdk": true,
+        "@avalabs/bitcoin-module>@avalabs/core-utils-sdk": true,
+        "@avalabs/core-wallets-sdk": true,
+        "@avalabs/vm-module-types": true,
+        "@metamask/rpc-errors": true,
+        "bitcoinjs-lib": true,
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@avalabs/bitcoin-module>zod": true
+      }
+    },
+    "@avalabs/bridge-unified": {
+      "globals": {
+        "console.error": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@avalabs/bridge-unified>@lombard.finance/sdk": true,
+        "@avalabs/bridge-unified>@noble/hashes": true,
+        "@avalabs/bridge-unified>@scure/base": true,
+        "@avalabs/fusion-sdk>coinselect": true,
+        "lodash": true,
+        "@avalabs/bridge-unified>viem": true,
+        "@avalabs/bridge-unified>zod": true
+      }
+    },
+    "@avalabs/core-chains-sdk": {
+      "packages": {
+        "@avalabs/core-utils-sdk": true
+      }
+    },
+    "@avalabs/core-coingecko-sdk": {
+      "globals": {
+        "URLSearchParams": true
+      },
+      "packages": {
+        "@avalabs/core-utils-sdk": true
+      }
+    },
+    "@avalabs/core-gasless-sdk": {
+      "globals": {
+        "Buffer.from": true,
+        "fetch": true,
+        "performance.now": true
+      },
+      "packages": {
+        "@avalabs/core-gasless-sdk>@noble/hashes": true,
+        "buffer": true,
+        "@avalabs/core-gasless-sdk>zod": true
+      }
+    },
+    "@avalabs/core-utils-sdk": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearTimeout": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@avalabs/core-utils-sdk>big.js": true,
+        "bn.js": true,
+        "@avalabs/core-utils-sdk>is-ipfs": true
+      }
+    },
+    "@avalabs/avalanche-module>@avalabs/core-utils-sdk": {
+      "packages": {
+        "@avalabs/avalanche-module>big.js": true,
+        "bn.js": true
+      }
+    },
+    "@avalabs/bitcoin-module>@avalabs/core-utils-sdk": {
+      "packages": {
+        "@avalabs/bitcoin-module>big.js": true,
+        "bn.js": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@avalabs/core-utils-sdk": {
+      "globals": {
+        "AbortController": true,
+        "URLSearchParams": true,
+        "clearTimeout": true,
+        "fetch": true,
+        "setTimeout": true
+      }
+    },
+    "@avalabs/core-wallets-sdk": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "console.log": true,
+        "setTimeout": true
+      },
+      "meta": {
+        "graph-optimization": [
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/addresses' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/keys' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/rpc' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/rpc-types' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/transaction-messages' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/transactions' and the bundler collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@avalabs/avalanchejs": true,
+        "@avalabs/core-wallets-sdk>@avalabs/core-chains-sdk": true,
+        "@avalabs/core-wallets-sdk>@avalabs/core-utils-sdk": true,
+        "@avalabs/core-wallets-sdk>@avalabs/glacier-sdk": true,
+        "@avalabs/hw-app-avalanche": true,
+        "@ledgerhq/hw-app-btc": true,
+        "@ledgerhq/hw-app-eth": true,
+        "@ledgerhq/hw-app-solana": true,
+        "ledger-bitcoin>@ledgerhq/hw-transport": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util": true,
+        "@noble/curves": true,
+        "@avalabs/core-wallets-sdk>@noble/hashes": true,
+        "@scure/base": true,
+        "@avalabs/svm-module>@solana-program/system": true,
+        "@avalabs/core-wallets-sdk>@solana-program/token-2022": true,
+        "@avalabs/svm-module>@solana-program/token": true,
+        "@avalabs/svm-module>@solana/kit>@solana/addresses": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys": true,
+        "@avalabs/svm-module>@solana/kit": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc-types": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc": true,
+        "@avalabs/svm-module>@solana/kit>@solana/transaction-messages": true,
+        "@avalabs/svm-module>@solana/kit>@solana/transactions": true,
+        "bip32": true,
+        "ledger-bitcoin>bip32-path": true,
+        "@avalabs/core-wallets-sdk>bip39": true,
+        "bitcoinjs-lib": true,
+        "buffer": true,
+        "@avalabs/fusion-sdk>coinselect": true,
+        "bip32>create-hash": true,
+        "ethers": true,
+        "@avalabs/core-wallets-sdk>hdkey": true,
+        "ledger-bitcoin": true,
+        "micro-key-producer": true,
+        "@avalabs/core-wallets-sdk>xss": true
+      }
+    },
+    "@avalabs/evm-module": {
+      "globals": {
+        "AbortController": true,
+        "Buffer.from": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "fetch": true,
+        "process.env.GLACIER_API_KEY": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@avalabs/core-chains-sdk": true,
+        "@avalabs/core-coingecko-sdk": true,
+        "@avalabs/core-utils-sdk": true,
+        "@avalabs/core-wallets-sdk": true,
+        "@avalabs/glacier-sdk": true,
+        "@avalabs/vm-module-types": true,
+        "@avalabs/evm-module>@blockaid/client": true,
+        "@metamask/rpc-errors": true,
+        "@openzeppelin/contracts": true,
+        "buffer": true,
+        "ethers": true,
+        "@avalabs/evm-module>lodash.startcase": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "xss": true,
+        "@avalabs/evm-module>zod": true
+      }
+    },
+    "@avalabs/fusion-sdk": {
+      "globals": {
+        "AbortController": true,
+        "TextDecoder": true,
+        "URL": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "console.debug": true,
+        "console.error": true,
+        "crypto.randomUUID": true,
+        "fetch": true,
+        "queueMicrotask": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "structuredClone": true
+      },
+      "meta": {
+        "graph-optimization": [
+          "Dependency '@solana/kit' reexports from '@solana/kit>@solana/addresses' and the bundler collapsed that to a direct import.",
+          "Dependency '@solana/kit' reexports from '@solana/kit>@solana/keys' and the bundler collapsed that to a direct import.",
+          "Dependency '@solana/kit' reexports from '@solana/kit>@solana/keys>@solana/codecs-strings' and the bundler collapsed that to a direct import.",
+          "Dependency '@solana/kit' reexports from '@solana/kit>@solana/rpc' and the bundler collapsed that to a direct import.",
+          "Dependency '@solana/kit' reexports from '@solana/kit>@solana/transaction-messages' and the bundler collapsed that to a direct import.",
+          "Dependency '@solana/kit' reexports from '@solana/kit>@solana/transactions' and the bundler collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@avalabs/avalanchejs": true,
+        "@avalabs/fusion-sdk>@lombard.finance/sdk": true,
+        "@avalabs/fusion-sdk>@scure/base": true,
+        "@solana/kit>@solana/addresses": true,
+        "@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@solana/kit>@solana/keys": true,
+        "@solana/kit": true,
+        "@solana/kit>@solana/rpc": true,
+        "@solana/kit>@solana/transaction-messages": true,
+        "@solana/kit>@solana/transactions": true,
+        "@avalabs/fusion-sdk>coinselect": true,
+        "@avalabs/fusion-sdk>es-toolkit": true,
+        "viem": true,
+        "zod": true
+      }
+    },
+    "@avalabs/glacier-sdk": {
+      "globals": {
+        "AbortController": true,
+        "Buffer.from": true,
+        "FormData": true,
+        "Headers": true,
+        "btoa": true,
+        "console.error": true,
+        "console.warn": true,
+        "fetch": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@avalabs/glacier-sdk": {
+      "globals": {
+        "AbortController": true,
+        "Buffer.from": true,
+        "FormData": true,
+        "Headers": true,
+        "btoa": true,
+        "console.error": true,
+        "console.warn": true,
+        "fetch": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@avalabs/hvm-module": {
+      "globals": {
+        "process.env.GLACIER_API_KEY": true
+      },
+      "packages": {
+        "@avalabs/core-utils-sdk": true,
+        "@avalabs/vm-module-types": true,
+        "@metamask/rpc-errors": true,
+        "@avalabs/hvm-module>@noble/hashes": true,
+        "@scure/base": true,
+        "hypersdk-client": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@avalabs/hvm-module>zod": true
+      }
+    },
+    "@avalabs/hw-app-avalanche": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.byteLength": true,
+        "Buffer.concat": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "@ledgerhq/hw-app-eth": true,
+        "@avalabs/hw-app-avalanche>bs58": true,
+        "buffer": true
+      }
+    },
+    "@avalabs/svm-module": {
+      "globals": {
+        "TextDecoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "console.error": true,
+        "fetch": true,
+        "process.env.GLACIER_API_KEY": true,
+        "setTimeout": true
+      },
+      "meta": {
+        "graph-optimization": [
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/addresses' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/instructions' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/keys' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/transaction-messages' and the bundler collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@avalabs/core-coingecko-sdk": true,
+        "@avalabs/core-utils-sdk": true,
+        "@avalabs/core-wallets-sdk": true,
+        "@avalabs/vm-module-types": true,
+        "@avalabs/svm-module>@blockaid/client": true,
+        "@metamask/rpc-errors": true,
+        "@scure/base": true,
+        "@avalabs/svm-module>@solana-program/system": true,
+        "@avalabs/svm-module>@solana-program/token": true,
+        "@avalabs/svm-module>@solana/kit>@solana/addresses": true,
+        "@avalabs/svm-module>@solana/kit>@solana/instructions": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys": true,
+        "@avalabs/svm-module>@solana/kit": true,
+        "@avalabs/svm-module>@solana/kit>@solana/transaction-messages": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@avalabs/svm-module>zod": true
+      }
+    },
+    "@avalabs/vm-module-types": {
+      "packages": {
+        "@avalabs/vm-module-types>zod": true
+      }
+    },
+    "@avalabs/fusion-sdk>@bitcoinerlab/secp256k1": {
+      "packages": {
+        "@avalabs/fusion-sdk>@bitcoinerlab/secp256k1>@noble/curves": true
+      }
+    },
+    "@blockaid/client": {
+      "globals": {
+        "AbortController": true,
+        "Blob": true,
+        "Buffer": true,
+        "Deno": true,
+        "EdgeRuntime": true,
+        "File": true,
+        "FormData": true,
+        "Headers": true,
+        "ReadableStream": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "console.log": true,
+        "console.warn": true,
+        "document": true,
+        "fetch": true,
+        "navigator": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@avalabs/evm-module>@blockaid/client": {
+      "globals": {
+        "AbortController": true,
+        "Blob": true,
+        "Buffer": true,
+        "Deno": true,
+        "EdgeRuntime": true,
+        "File": true,
+        "FormData": true,
+        "Headers": true,
+        "ReadableStream": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "console.log": true,
+        "console.warn": true,
+        "document": true,
+        "fetch": true,
+        "navigator": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@avalabs/svm-module>@blockaid/client": {
+      "globals": {
+        "AbortController": true,
+        "Blob": true,
+        "Buffer": true,
+        "Deno": true,
+        "EdgeRuntime": true,
+        "File": true,
+        "FormData": true,
+        "Headers": true,
+        "ReadableStream": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "console.log": true,
+        "console.warn": true,
+        "document": true,
+        "fetch": true,
+        "navigator": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@chainsafe/ssz>@chainsafe/as-sha256": {
+      "globals": {
+        "WebAssembly.Instance": true,
+        "WebAssembly.Module": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@chainsafe/ssz>@chainsafe/persistent-merkle-tree": {
+      "globals": {
+        "WeakRef": true
+      },
+      "packages": {
+        "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@chainsafe/ssz>@chainsafe/as-sha256": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@chainsafe/ssz": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@chainsafe/ssz>@chainsafe/as-sha256": true,
+        "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@chainsafe/ssz>@chainsafe/persistent-merkle-tree": true,
+        "buffer": true,
+        "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@chainsafe/ssz>case": true
+      }
+    },
+    "@cubist-labs/cubesigner-sdk": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true,
+        "clearInterval": true,
+        "crypto": true,
+        "navigator.credentials.create": true,
+        "navigator.credentials.get": true,
+        "process.platform": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@hpke/core": true,
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "@cubist-labs/cubesigner-sdk>openapi-fetch": true
+      }
+    },
+    "@cubist-labs/cubesigner-sdk-ethers-v6": {
+      "packages": {
+        "@cubist-labs/cubesigner-sdk": true,
+        "ethers": true
+      }
+    },
+    "@ethereumjs/common": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.concat": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "buffer": true,
+        "@ethereumjs/common>crc-32": true,
+        "@ethereumjs/tx>ethereumjs-util": true,
+        "events": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@ethereumjs/rlp": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "@ethereumjs/tx": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "@ethereumjs/common": true,
+        "buffer": true,
+        "@ethereumjs/tx>ethereumjs-util": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@ethereumjs/util": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.allocUnsafe": true,
+        "Buffer.byteLength": true,
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@chainsafe/ssz": true,
+        "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@ethereumjs/rlp": true,
+        "buffer": true,
+        "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>ethereum-cryptography": true,
+        "events": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.allocUnsafe": true,
+        "Buffer.byteLength": true,
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>@ethereumjs/rlp": true,
+        "buffer": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util>ethereum-cryptography": true,
+        "events": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util>micro-ftch": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi": {
+      "globals": {
+        "console.log": true
+      },
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bignumber": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/keccak256": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/logger": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/properties": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/strings": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/bignumber": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/keccak256": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/logger": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/rlp": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bignumber": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/logger": true,
+        "bn.js": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/bignumber": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/logger": true,
+        "bn.js": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": true,
+        "bn.js": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/bignumber": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/logger": true,
+        "bn.js": true
+      }
+    },
+    "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/bignumber": {
+      "packages": {
+        "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/bytes": true,
+        "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/bytes>@ethersproject/logger": true,
+        "bn.js": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bytes": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/bytes": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/bytes": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash>@ethersproject/bytes": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/rlp>@ethersproject/bytes": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/rlp>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key>@ethersproject/bytes": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/bytes": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/logger": true
+      }
+    },
+    "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/bytes": {
+      "packages": {
+        "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/bytes>@ethersproject/logger": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>@ethersproject/bytes": {
+      "packages": {
+        "fireblocks-sdk>@notabene/pii-sdk>@ethersproject/bytes>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash>@ethersproject/keccak256": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash>@ethersproject/strings": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/keccak256": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bytes": true,
+        "web3>web3-utils>ethereum-bloom-filters>js-sha3": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/keccak256": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/bytes": true,
+        "web3>web3-utils>ethereum-bloom-filters>js-sha3": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash>@ethersproject/keccak256": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash>@ethersproject/bytes": true,
+        "web3>web3-utils>ethereum-bloom-filters>js-sha3": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/keccak256": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/bytes": true,
+        "web3>web3-utils>ethereum-bloom-filters>js-sha3": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/bytes>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>@ethersproject/bytes>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/properties>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/rlp>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/properties": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/properties>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/rlp": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/rlp>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/rlp>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key>@ethersproject/logger": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/properties": true,
+        "bn.js": true,
+        "bip32>tiny-secp256k1>elliptic>hash.js": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/strings": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash>@ethersproject/strings": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash>@ethersproject/logger": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ethersproject/transactions": {
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/bignumber": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/bytes": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/keccak256": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/logger": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/properties": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/rlp": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key": true
+      }
+    },
+    "firebase>@firebase/app-check": {
+      "globals": {
+        "console.log": true,
+        "crypto.randomUUID": true,
+        "document.body.appendChild": true,
+        "document.createElement": true,
+        "fetch": true,
+        "grecaptcha": true,
+        "indexedDB.open": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "firebase>@firebase/app": true,
+        "firebase>@firebase/app>@firebase/component": true,
+        "firebase>@firebase/app>@firebase/logger": true,
+        "firebase>@firebase/util": true
+      }
+    },
+    "firebase>@firebase/app": {
+      "globals": {
+        "FinalizationRegistry": true,
+        "console.error": true,
+        "console.warn": true
+      },
+      "packages": {
+        "firebase>@firebase/app>@firebase/component": true,
+        "firebase>@firebase/app>@firebase/logger": true,
+        "firebase>@firebase/util": true,
+        "firebase>@firebase/app>idb": true
+      }
+    },
+    "firebase>@firebase/app>@firebase/component": {
+      "packages": {
+        "firebase>@firebase/util": true
+      }
+    },
+    "firebase>@firebase/installations": {
+      "globals": {
+        "BroadcastChannel": true,
+        "Headers": true,
+        "btoa": true,
+        "console.error": true,
+        "crypto": true,
+        "fetch": true,
+        "msCrypto": true,
+        "navigator.onLine": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "firebase>@firebase/app": true,
+        "firebase>@firebase/app>@firebase/component": true,
+        "firebase>@firebase/util": true,
+        "firebase>@firebase/app>idb": true
+      }
+    },
+    "firebase>@firebase/app>@firebase/logger": {
+      "globals": {
+        "console": true
+      }
+    },
+    "firebase>@firebase/messaging": {
+      "globals": {
+        "Headers": true,
+        "Notification.maxActions": true,
+        "Notification.permission": true,
+        "Notification.requestPermission": true,
+        "PushSubscription.prototype.hasOwnProperty": true,
+        "ServiceWorkerRegistration": true,
+        "URL": true,
+        "addEventListener": true,
+        "atob": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "clients.matchAll": true,
+        "clients.openWindow": true,
+        "console.warn": true,
+        "document": true,
+        "fetch": true,
+        "indexedDB": true,
+        "location.href": true,
+        "location.origin": true,
+        "navigator": true,
+        "origin.replace": true,
+        "registration.showNotification": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "firebase>@firebase/app": true,
+        "firebase>@firebase/app>@firebase/component": true,
+        "firebase>@firebase/installations": true,
+        "firebase>@firebase/util": true,
+        "firebase>@firebase/app>idb": true
+      }
+    },
+    "firebase>@firebase/util": {
+      "globals": {
+        "WorkerGlobalScope": true,
+        "atob": true,
+        "browser": true,
+        "btoa": true,
+        "chrome": true,
+        "console": true,
+        "document": true,
+        "indexedDB": true,
+        "navigator": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "firebase>@firebase/vertexai": {
+      "globals": {
+        "AbortController": true,
+        "Headers": true,
+        "ReadableStream": true,
+        "TextDecoderStream": true,
+        "clearTimeout": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "firebase>@firebase/app": true,
+        "firebase>@firebase/app>@firebase/component": true,
+        "firebase>@firebase/app>@firebase/logger": true,
+        "firebase>@firebase/util": true,
+        "rxjs>tslib": true
+      }
+    },
+    "joi>@hapi/hoek": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "joi>@hapi/topo": {
+      "packages": {
+        "joi>@hapi/hoek": true
+      }
+    },
+    "@hpke/core>@hpke/common": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true,
+        "crypto": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true
+      }
+    },
+    "@hpke/core": {
+      "packages": {
+        "@hpke/core>@hpke/common": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth": {
+      "globals": {
+        "Buffer.from": true,
+        "process.env.NODE_ENV": true
+      },
+      "packages": {
+        "@keystonehq/bc-ur-registry-eth>@ethereumjs/util": true,
+        "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": true,
+        "buffer": true,
+        "@keystonehq/bc-ur-registry-eth>hdkey": true,
+        "fireblocks-sdk>uuid": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@keystonehq/bc-ur-registry": {
+      "globals": {
+        "Buffer": true,
+        "define": true
+      },
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "bip32>bs58check": true,
+        "buffer": true,
+        "rxjs>tslib": true
+      }
+    },
+    "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.from": true,
+        "console.error": true
+      },
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/address": true,
+        "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/bignumber": true,
+        "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/bytes": true,
+        "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/keccak256": true,
+        "@avalabs/fusion-sdk>@layerzerolabs/lz-v2-utilities>@ethersproject/solidity": true,
+        "fireblocks-sdk>@notabene/pii-sdk>bs58": true,
+        "buffer": true,
+        "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>tiny-invariant": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ledgerhq/domain-service": {
+      "packages": {
+        "@ledgerhq/hw-app-btc>@ledgerhq/logs": true,
+        "@ledgerhq/hw-app-eth>axios": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ledgerhq/errors": {
+      "globals": {
+        "console.warn": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": {
+      "globals": {
+        "Intl.DateTimeFormat": true
+      },
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/hash": true,
+        "@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
+        "@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": true,
+        "@ledgerhq/hw-app-eth>axios": true,
+        "@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>crypto-js": true
+      }
+    },
+    "@ledgerhq/hw-app-btc": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "ledger-bitcoin>bip32-path": true,
+        "bip32>bs58check": true,
+        "buffer": true
+      }
+    },
+    "@ledgerhq/hw-app-eth": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ethersproject/abi": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/rlp": true,
+        "@ledgerhq/hw-app-eth>@ethersproject/transactions": true,
+        "@ledgerhq/hw-app-eth>@ledgerhq/cryptoassets-evm-signatures": true,
+        "@ledgerhq/hw-app-eth>@ledgerhq/domain-service": true,
+        "@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
+        "@ledgerhq/hw-app-eth>@ledgerhq/evm-tools": true,
+        "@ledgerhq/hw-app-btc>@ledgerhq/logs": true,
+        "@ledgerhq/hw-app-eth>axios": true,
+        "@ledgerhq/hw-app-eth>bignumber.js": true,
+        "buffer": true,
+        "semver": true
+      }
+    },
+    "@ledgerhq/hw-app-solana": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.concat": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
+        "ledger-bitcoin>bip32-path": true,
+        "buffer": true
+      }
+    },
+    "ledger-bitcoin>@ledgerhq/hw-transport": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "clearTimeout": true,
+        "console.warn": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ledgerhq/errors": true,
+        "@ledgerhq/hw-app-btc>@ledgerhq/logs": true,
+        "buffer": true,
+        "events": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env": {
+      "globals": {
+        "console.warn": true
+      },
+      "packages": {
+        "@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env>rxjs": true
+      }
+    },
+    "@ledgerhq/hw-app-btc>@ledgerhq/logs": {
+      "globals": {
+        "__ledgerLogsListen": "write",
+        "console.error": true
+      }
+    },
+    "@avalabs/bridge-unified>@lombard.finance/sdk": {
+      "globals": {
+        "AbortController": true,
+        "Buffer.from": true,
+        "Image": true,
+        "Request": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "atob": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "console.debug": true,
+        "console.error": true,
+        "console.info": true,
+        "console.warn": true,
+        "crypto": true,
+        "document": true,
+        "fetch": true,
+        "performance.now": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@avalabs/fusion-sdk>@bitcoinerlab/secp256k1": true,
+        "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities": true,
+        "@ledgerhq/hw-app-eth>axios": true,
+        "web3>web3-core>bignumber.js": true,
+        "@avalabs/bridge-unified>bitcoinjs-lib": true,
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@avalabs/fusion-sdk>@lombard.finance/sdk": {
+      "globals": {
+        "Buffer.from": true,
+        "URL": true,
+        "console.error": true,
+        "console.info": true
+      },
+      "packages": {
+        "@avalabs/fusion-sdk>@bitcoinerlab/secp256k1": true,
+        "@paraswap/sdk>axios": true,
+        "@avalabs/fusion-sdk>bignumber.js": true,
+        "@avalabs/fusion-sdk>bitcoinjs-lib": true,
+        "buffer": true,
+        "viem": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/abi-utils": {
+      "packages": {
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/abi-utils>@metamask/utils": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/utils>superstruct": true
+      }
+    },
+    "@metamask/eth-sig-util": {
+      "globals": {
+        "Buffer.byteLength": true,
+        "Buffer.concat": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "buffer": true,
+        "@metamask/eth-sig-util>ethereumjs-abi": true,
+        "@metamask/eth-sig-util>ethereumjs-util": true,
+        "@metamask/eth-sig-util>ethjs-util": true,
+        "tweetnacl": true,
+        "@metamask/eth-sig-util>tweetnacl-util": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util": {
+      "globals": {
+        "Buffer.byteLength": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/abi-utils": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/utils": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@scure/base": true,
+        "buffer": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>ethereum-cryptography": true,
+        "tweetnacl": true
+      }
+    },
+    "@metamask/rpc-errors": {
+      "packages": {
+        "@metamask/rpc-errors>@metamask/utils": true,
+        "eth-rpc-errors>fast-safe-stringify": true
+      }
+    },
+    "eth-json-rpc-middleware>@metamask/safe-event-emitter": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "events": true
+      }
+    },
+    "json-rpc-engine>@metamask/safe-event-emitter": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "events": true
+      }
+    },
+    "hypersdk-client>@metamask/sdk": {
+      "globals": {
+        "Blob": true,
+        "Buffer": true,
+        "Event": true,
+        "File": true,
+        "FileReader": true,
+        "FormData": true,
+        "IS_REACT_ACT_ENVIRONMENT": true,
+        "Image": true,
+        "Intl": true,
+        "MSApp": true,
+        "MessageChannel": true,
+        "ReactNativeWebView": true,
+        "SuppressedError": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URLSearchParams.prototype.isPrototypeOf": true,
+        "WebTransport": true,
+        "XMLHttpRequest": true,
+        "XMLSerializer": true,
+        "__REACT_DEVTOOLS_GLOBAL_HOOK__": true,
+        "addEventListener": true,
+        "alert": true,
+        "attachEvent": true,
+        "btoa": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "clipboardData": true,
+        "console": true,
+        "crypto": true,
+        "define": true,
+        "dispatchEvent": true,
+        "document": true,
+        "ethereum": "write",
+        "event": "write",
+        "extension": "write",
+        "jest": true,
+        "localStorage": true,
+        "location": true,
+        "mmsdk": "write",
+        "msCrypto": true,
+        "navigator": true,
+        "open": true,
+        "performance": true,
+        "process": true,
+        "queueMicrotask": true,
+        "removeEventListener": true,
+        "reportError": true,
+        "self": true,
+        "sessionStorage": true,
+        "setImmediate": true,
+        "setInterval": true,
+        "setTimeout": true,
+        "top": true,
+        "web3": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/abi-utils>@metamask/utils": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/abi-utils>@metamask/utils>@noble/hashes": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/abi-utils>@metamask/utils>@scure/base": true,
+        "buffer": true,
+        "eslint>debug": true,
+        "@metamask/rpc-errors>@metamask/utils>pony-cause": true,
+        "semver": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/utils>superstruct": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/utils": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/utils>@noble/hashes": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/utils>@scure/base": true,
+        "buffer": true,
+        "eslint>debug": true,
+        "@metamask/rpc-errors>@metamask/utils>pony-cause": true,
+        "semver": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/utils>superstruct": true
+      }
+    },
+    "@metamask/rpc-errors>@metamask/utils": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@metamask/rpc-errors>@metamask/utils>@metamask/superstruct": true,
+        "@metamask/rpc-errors>@metamask/utils>pony-cause": true
+      }
+    },
+    "@keystonehq/ur-decoder>@ngraveio/bc-ur": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.allocUnsafe": true,
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur>@apocentre/alias-sampling": true,
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur>assert": true,
+        "web3>web3-core>bignumber.js": true,
+        "buffer": true,
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur>cbor-sync": true,
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur>crc": true,
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur>jsbi": true,
+        "@ledgerhq/hw-app-btc>sha.js": true
+      }
+    },
+    "@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@noble/curves>@noble/hashes": true
+      }
+    },
+    "@avalabs/fusion-sdk>@bitcoinerlab/secp256k1>@noble/curves": {
+      "packages": {
+        "@avalabs/fusion-sdk>@bitcoinerlab/secp256k1>@noble/curves>@noble/hashes": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@noble/hashes": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util>ethereum-cryptography>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util>ethereum-cryptography>@noble/curves>@noble/hashes": true
+      }
+    },
+    "ethers>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@noble/hashes": true
+      }
+    },
+    "hypersdk-client>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "hypersdk-client>@noble/curves>@noble/hashes": true
+      }
+    },
+    "micro-key-producer>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "micro-key-producer>@noble/hashes": true
+      }
+    },
+    "viem>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "viem>@noble/hashes": true
+      }
+    },
+    "@avalabs/bridge-unified>viem>@noble/curves": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "@noble/hashes": true
+      }
+    },
+    "@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/avalanchejs>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/bridge-unified>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "@avalabs/core-gasless-sdk>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "@avalabs/hvm-module>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/abi-utils>@metamask/utils>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/utils>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@noble/curves>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/fusion-sdk>@bitcoinerlab/secp256k1>@noble/curves>@noble/hashes": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util>ethereum-cryptography>@noble/curves>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "hypersdk-client>@noble/curves>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>bip39>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/bridge-unified>bitcoinjs-lib>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/bridge-unified>bitcoinjs-lib>bs58check>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>ethereum-cryptography>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "hypersdk-client>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "micro-key-producer>@noble/hashes": {
+      "globals": {
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "viem>ox>@noble/hashes": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "viem>@noble/hashes": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "crypto": true
+      }
+    },
+    "ledger-bitcoin>@bitcoinerlab/secp256k1>@noble/secp256k1": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "fireblocks-sdk>@notabene/pii-sdk>@ethersproject/bytes": true,
+        "fireblocks-sdk>@notabene/pii-sdk>@noble/curves": true,
+        "fireblocks-sdk>@notabene/pii-sdk>@stablelib/ed25519": true,
+        "fireblocks-sdk>@notabene/pii-sdk>axios-oauth-client": true,
+        "fireblocks-sdk>@notabene/pii-sdk>axios-token-interceptor": true,
+        "fireblocks-sdk>@notabene/pii-sdk>axios": true,
+        "fireblocks-sdk>@notabene/pii-sdk>base64url": true,
+        "fireblocks-sdk>@notabene/pii-sdk>bs58": true,
+        "buffer": true,
+        "fireblocks-sdk>@notabene/pii-sdk>did-jwt": true,
+        "lodash": true,
+        "fireblocks-sdk>@notabene/pii-sdk>multibase": true,
+        "fireblocks-sdk>@notabene/pii-sdk>multicodec": true
+      }
+    },
+    "@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@avalabs/avalanchejs>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@avalabs/bridge-unified>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@avalabs/fusion-sdk>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/abi-utils>@metamask/utils>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/utils>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "hypersdk-client>@scure/base": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      }
+    },
+    "@sentry/browser": {
+      "globals": {
+        "XMLHttpRequest": true,
+        "__SENTRY_DEBUG__": true,
+        "__SENTRY_RELEASE__": true,
+        "setTimeout": true
+      },
+      "meta": {
+        "graph-optimization": [
+          "Dependency '@sentry/browser>@sentry/core' reexports from '@sentry/browser>@sentry/utils' and the bundler collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@sentry/browser>@sentry-internal/tracing": true,
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/browser>@sentry/replay": true,
+        "@sentry/browser>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/core": {
+      "globals": {
+        "__SENTRY_DEBUG__": true,
+        "__SENTRY_TRACING__": true,
+        "clearInterval": true,
+        "console.warn": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "__SENTRY_DEBUG__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "module": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "joi>@sideway/address": {
+      "globals": {
+        "TextEncoder": true,
+        "URL": true
+      },
+      "packages": {
+        "joi>@hapi/hoek": true,
+        "@rsbuild/plugin-node-polyfill>url": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "@avalabs/svm-module>@solana-program/system": {
+      "globals": {
+        "process.env.NODE_ENV": true
+      },
+      "meta": {
+        "graph-optimization": [
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/accounts' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/addresses' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-data-structures' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-numbers' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/instructions' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/programs' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/signers' and the bundler collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/accounts": true,
+        "@avalabs/svm-module>@solana/kit>@solana/addresses": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-data-structures": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-numbers": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@avalabs/svm-module>@solana/kit>@solana/instructions": true,
+        "@avalabs/svm-module>@solana/kit": true,
+        "@avalabs/svm-module>@solana/kit>@solana/programs": true,
+        "@avalabs/svm-module>@solana/kit>@solana/signers": true
+      }
+    },
+    "@avalabs/svm-module>@solana-program/token": {
+      "globals": {
+        "process.env.NODE_ENV": true
+      },
+      "meta": {
+        "graph-optimization": [
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/accounts' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/addresses' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-data-structures' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-numbers' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/options' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/instructions' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/programs' and the bundler collapsed that to a direct import.",
+          "Dependency '@avalabs/svm-module>@solana/kit' reexports from '@avalabs/svm-module>@solana/kit>@solana/signers' and the bundler collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/accounts": true,
+        "@avalabs/svm-module>@solana/kit>@solana/addresses": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-data-structures": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-numbers": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@avalabs/svm-module>@solana/kit>@solana/instructions": true,
+        "@avalabs/svm-module>@solana/kit": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/options": true,
+        "@avalabs/svm-module>@solana/kit>@solana/programs": true,
+        "@avalabs/svm-module>@solana/kit>@solana/signers": true
+      }
+    },
+    "@solana/kit>@solana/accounts": {
+      "packages": {
+        "@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@solana/kit>@solana/errors": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/accounts": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true
+      }
+    },
+    "@solana/kit>@solana/addresses": {
+      "globals": {
+        "Intl.Collator": true,
+        "TextEncoder": true,
+        "crypto.subtle.digest": true,
+        "crypto.subtle.exportKey": true,
+        "crypto.subtle.importKey": true
+      },
+      "packages": {
+        "@solana/kit>@solana/keys>@solana/assertions": true,
+        "@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@solana/kit>@solana/errors": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/addresses": {
+      "globals": {
+        "Intl.Collator": true,
+        "TextEncoder": true,
+        "crypto.subtle.digest": true,
+        "crypto.subtle.exportKey": true,
+        "crypto.subtle.importKey": true
+      },
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/assertions": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true
+      }
+    },
+    "@solana/kit>@solana/keys>@solana/codecs-core": {
+      "packages": {
+        "@solana/kit>@solana/errors": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true
+      }
+    },
+    "@solana/kit>@solana/codecs>@solana/codecs-data-structures": {
+      "packages": {
+        "@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@solana/kit>@solana/codecs>@solana/codecs-numbers": true,
+        "@solana/kit>@solana/errors": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-data-structures": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-numbers": true,
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true
+      }
+    },
+    "@solana/kit>@solana/codecs>@solana/codecs-numbers": {
+      "packages": {
+        "@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@solana/kit>@solana/errors": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-numbers": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true
+      }
+    },
+    "@solana/kit>@solana/keys>@solana/codecs-strings": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true
+      },
+      "packages": {
+        "@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@solana/kit>@solana/errors": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true
+      },
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true
+      }
+    },
+    "@solana/kit>@solana/errors": {
+      "globals": {
+        "btoa": true,
+        "process.env.NODE_ENV": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/errors": {
+      "globals": {
+        "btoa": true,
+        "process.env.NODE_ENV": true
+      }
+    },
+    "@solana/kit>@solana/instructions": {
+      "packages": {
+        "@solana/kit>@solana/errors": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/instructions": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true
+      }
+    },
+    "@solana/kit>@solana/keys": {
+      "globals": {
+        "crypto.getRandomValues": true,
+        "crypto.subtle.exportKey": true,
+        "crypto.subtle.generateKey": true,
+        "crypto.subtle.importKey": true,
+        "crypto.subtle.sign": true,
+        "crypto.subtle.verify": true
+      },
+      "packages": {
+        "@solana/kit>@solana/keys>@solana/assertions": true,
+        "@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@solana/kit>@solana/errors": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/keys": {
+      "globals": {
+        "crypto.getRandomValues": true,
+        "crypto.subtle.exportKey": true,
+        "crypto.subtle.generateKey": true,
+        "crypto.subtle.importKey": true,
+        "crypto.subtle.sign": true,
+        "crypto.subtle.verify": true
+      },
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/assertions": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true
+      }
+    },
+    "@solana/kit": {
+      "packages": {
+        "@solana/kit>@solana/accounts": true,
+        "@solana/kit>@solana/addresses": true,
+        "@solana/kit>@solana/codecs": true,
+        "@solana/kit>@solana/errors": true,
+        "@solana/kit>@solana/functional": true,
+        "@solana/kit>@solana/instruction-plans": true,
+        "@solana/kit>@solana/instructions": true,
+        "@solana/kit>@solana/keys": true,
+        "@solana/kit>@solana/offchain-messages": true,
+        "@solana/kit>@solana/plugin-core": true,
+        "@solana/kit>@solana/programs": true,
+        "@solana/kit>@solana/rpc-parsed-types": true,
+        "@solana/kit>@solana/rpc-spec-types": true,
+        "@solana/kit>@solana/rpc-subscriptions": true,
+        "@solana/kit>@solana/rpc-types": true,
+        "@solana/kit>@solana/rpc": true,
+        "@solana/kit>@solana/signers": true,
+        "@solana/kit>@solana/transaction-confirmation": true,
+        "@solana/kit>@solana/transaction-messages": true,
+        "@solana/kit>@solana/transactions": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/accounts": true,
+        "@avalabs/svm-module>@solana/kit>@solana/addresses": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs": true,
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true,
+        "@avalabs/svm-module>@solana/kit>@solana/functional": true,
+        "@avalabs/svm-module>@solana/kit>@solana/instruction-plans": true,
+        "@avalabs/svm-module>@solana/kit>@solana/instructions": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys": true,
+        "@avalabs/svm-module>@solana/kit>@solana/offchain-messages": true,
+        "@avalabs/svm-module>@solana/kit>@solana/plugin-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/programs": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc-parsed-types": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc-spec-types": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc-subscriptions": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc-types": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc": true,
+        "@avalabs/svm-module>@solana/kit>@solana/signers": true,
+        "@avalabs/svm-module>@solana/kit>@solana/transaction-confirmation": true,
+        "@avalabs/svm-module>@solana/kit>@solana/transaction-messages": true,
+        "@avalabs/svm-module>@solana/kit>@solana/transactions": true
+      }
+    },
+    "@solana/kit>@solana/rpc-api": {
+      "packages": {
+        "@solana/kit>@solana/rpc>@solana/rpc-spec": true,
+        "@solana/kit>@solana/rpc>@solana/rpc-transformers": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/rpc-api": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/rpc>@solana/rpc-spec": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc>@solana/rpc-transformers": true
+      }
+    },
+    "@solana/kit>@solana/rpc>@solana/rpc-spec": {
+      "packages": {
+        "@solana/kit>@solana/errors": true,
+        "@solana/kit>@solana/rpc-spec-types": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/rpc>@solana/rpc-spec": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc-spec-types": true
+      }
+    },
+    "@solana/kit>@solana/rpc>@solana/rpc-transformers": {
+      "packages": {
+        "@solana/kit>@solana/errors": true,
+        "@solana/kit>@solana/functional": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/rpc>@solana/rpc-transformers": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true,
+        "@avalabs/svm-module>@solana/kit>@solana/functional": true
+      }
+    },
+    "@solana/kit>@solana/rpc>@solana/rpc-transport-http": {
+      "globals": {
+        "console.warn": true,
+        "fetch": true,
+        "process.env.NODE_ENV": true
+      },
+      "packages": {
+        "@solana/kit>@solana/errors": true,
+        "@solana/kit>@solana/rpc-spec-types": true,
+        "@solana/kit>@solana/rpc>@solana/rpc-spec": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/rpc>@solana/rpc-transport-http": {
+      "globals": {
+        "console.warn": true,
+        "fetch": true,
+        "process.env.NODE_ENV": true
+      },
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc-spec-types": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc>@solana/rpc-spec": true
+      }
+    },
+    "@solana/kit>@solana/rpc-types": {
+      "globals": {
+        "Intl.Collator": true
+      },
+      "packages": {
+        "@solana/kit>@solana/addresses": true,
+        "@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@solana/kit>@solana/codecs>@solana/codecs-numbers": true,
+        "@solana/kit>@solana/errors": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/rpc-types": {
+      "globals": {
+        "Intl.Collator": true
+      },
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/addresses": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-numbers": true,
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true
+      }
+    },
+    "@solana/kit>@solana/rpc": {
+      "globals": {
+        "AbortController": true,
+        "process.env.NODE_ENV": true,
+        "queueMicrotask": true
+      },
+      "packages": {
+        "@solana/kit>@solana/errors": true,
+        "@solana/kit>@solana/rpc>@solana/fast-stable-stringify": true,
+        "@solana/kit>@solana/functional": true,
+        "@solana/kit>@solana/rpc-api": true,
+        "@solana/kit>@solana/rpc>@solana/rpc-spec": true,
+        "@solana/kit>@solana/rpc>@solana/rpc-transport-http": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/rpc": {
+      "globals": {
+        "AbortController": true,
+        "process.env.NODE_ENV": true,
+        "queueMicrotask": true
+      },
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc>@solana/fast-stable-stringify": true,
+        "@avalabs/svm-module>@solana/kit>@solana/functional": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc-api": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc>@solana/rpc-spec": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc>@solana/rpc-transport-http": true
+      }
+    },
+    "@solana/kit>@solana/transaction-messages": {
+      "packages": {
+        "@solana/kit>@solana/addresses": true,
+        "@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@solana/kit>@solana/codecs>@solana/codecs-data-structures": true,
+        "@solana/kit>@solana/codecs>@solana/codecs-numbers": true,
+        "@solana/kit>@solana/errors": true,
+        "@solana/kit>@solana/functional": true,
+        "@solana/kit>@solana/instructions": true,
+        "@solana/kit>@solana/rpc-types": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/transaction-messages": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/addresses": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-data-structures": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-numbers": true,
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true,
+        "@avalabs/svm-module>@solana/kit>@solana/functional": true,
+        "@avalabs/svm-module>@solana/kit>@solana/instructions": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc-types": true
+      }
+    },
+    "@solana/kit>@solana/transactions": {
+      "packages": {
+        "@solana/kit>@solana/addresses": true,
+        "@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@solana/kit>@solana/codecs>@solana/codecs-data-structures": true,
+        "@solana/kit>@solana/codecs>@solana/codecs-numbers": true,
+        "@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@solana/kit>@solana/errors": true,
+        "@solana/kit>@solana/keys": true,
+        "@solana/kit>@solana/rpc-types": true,
+        "@solana/kit>@solana/transaction-messages": true
+      }
+    },
+    "@avalabs/svm-module>@solana/kit>@solana/transactions": {
+      "packages": {
+        "@avalabs/svm-module>@solana/kit>@solana/addresses": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-core": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-data-structures": true,
+        "@avalabs/svm-module>@solana/kit>@solana/codecs>@solana/codecs-numbers": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys>@solana/codecs-strings": true,
+        "@avalabs/svm-module>@solana/kit>@solana/errors": true,
+        "@avalabs/svm-module>@solana/kit>@solana/keys": true,
+        "@avalabs/svm-module>@solana/kit>@solana/rpc-types": true,
+        "@avalabs/svm-module>@solana/kit>@solana/transaction-messages": true
+      }
+    },
+    "@walletconnect/utils>@stablelib/random>@stablelib/binary": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/random>@stablelib/binary>@stablelib/int": true
+      }
+    },
+    "@walletconnect/utils>@stablelib/chacha20poly1305": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/random>@stablelib/binary": true,
+        "@walletconnect/utils>@stablelib/chacha20poly1305>@stablelib/chacha": true,
+        "@walletconnect/utils>@stablelib/chacha20poly1305>@stablelib/constant-time": true,
+        "@walletconnect/utils>@stablelib/chacha20poly1305>@stablelib/poly1305": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "@walletconnect/utils>@stablelib/chacha20poly1305>@stablelib/chacha": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/random>@stablelib/binary": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>@stablelib/ed25519": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/random": true,
+        "fireblocks-sdk>@notabene/pii-sdk>@stablelib/ed25519>@stablelib/sha512": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "@walletconnect/utils>@stablelib/hkdf": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/hmac": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "@walletconnect/utils>@stablelib/hkdf>@stablelib/hmac": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/chacha20poly1305>@stablelib/constant-time": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/hash": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "@walletconnect/utils>@stablelib/chacha20poly1305>@stablelib/poly1305": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/chacha20poly1305>@stablelib/constant-time": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "@walletconnect/utils>@stablelib/random": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      },
+      "packages": {
+        "@walletconnect/utils>@stablelib/random>@stablelib/binary": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "@walletconnect/utils>@stablelib/sha256": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/random>@stablelib/binary": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>@stablelib/ed25519>@stablelib/sha512": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/random>@stablelib/binary": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "@walletconnect/utils>@stablelib/x25519": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/random": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>did-jwt>@stablelib/xchacha20poly1305>@stablelib/xchacha20": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/random>@stablelib/binary": true,
+        "@walletconnect/utils>@stablelib/chacha20poly1305>@stablelib/chacha": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>did-jwt>@stablelib/xchacha20poly1305": {
+      "packages": {
+        "@walletconnect/utils>@stablelib/chacha20poly1305": true,
+        "@walletconnect/utils>@stablelib/hkdf>@stablelib/wipe": true,
+        "fireblocks-sdk>@notabene/pii-sdk>did-jwt>@stablelib/xchacha20poly1305>@stablelib/xchacha20": true
+      }
+    },
+    "@walletconnect/core": {
+      "globals": {
+        "AbortController": true,
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "clearInterval": true,
+        "clearTimeout": true,
+        "crypto.subtle.digest": true,
+        "document.body.append": true,
+        "document.createElement": true,
+        "document.getElementById": true,
+        "fetch": true,
+        "process.env.IS_VITEST": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@walletconnect/core>@walletconnect/heartbeat": true,
+        "@walletconnect/core>@walletconnect/jsonrpc-provider": true,
+        "@walletconnect/core>@walletconnect/jsonrpc-utils": true,
+        "@walletconnect/core>@walletconnect/jsonrpc-ws-connection": true,
+        "@walletconnect/core>@walletconnect/keyvaluestorage": true,
+        "@walletconnect/core>@walletconnect/logger": true,
+        "@walletconnect/core>@walletconnect/relay-auth": true,
+        "@walletconnect/core>@walletconnect/safe-json": true,
+        "@walletconnect/core>@walletconnect/time": true,
+        "@walletconnect/types": true,
+        "@walletconnect/core>@walletconnect/utils": true,
+        "events": true,
+        "@walletconnect/core>lodash.isequal": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@walletconnect/core>uint8arrays": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/jsonrpc-utils>@walletconnect/environment": {
+      "globals": {
+        "crypto": true,
+        "document": true,
+        "msCrypto": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@walletconnect/core>@walletconnect/jsonrpc-utils>@walletconnect/environment>tslib": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/heartbeat": {
+      "globals": {
+        "clearInterval": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@walletconnect/types>@walletconnect/events": true,
+        "@walletconnect/core>@walletconnect/time": true,
+        "events": true,
+        "@walletconnect/core>@walletconnect/heartbeat>tslib": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/jsonrpc-provider": {
+      "packages": {
+        "@walletconnect/core>@walletconnect/jsonrpc-utils": true,
+        "events": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/jsonrpc-utils": {
+      "packages": {
+        "@walletconnect/core>@walletconnect/jsonrpc-utils>@walletconnect/environment": true,
+        "@walletconnect/core>@walletconnect/jsonrpc-types": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/jsonrpc-ws-connection": {
+      "globals": {
+        "WebSocket": true,
+        "require": true
+      },
+      "packages": {
+        "@walletconnect/core>@walletconnect/jsonrpc-utils": true,
+        "@walletconnect/core>@walletconnect/safe-json": true,
+        "events": true,
+        "@walletconnect/core>@walletconnect/jsonrpc-ws-connection>ws": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/keyvaluestorage": {
+      "globals": {
+        "localStorage": true
+      },
+      "packages": {
+        "@walletconnect/core>@walletconnect/keyvaluestorage>safe-json-utils": true,
+        "@walletconnect/core>@walletconnect/keyvaluestorage>tslib": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/logger": {
+      "packages": {
+        "@walletconnect/core>@walletconnect/logger>pino": true,
+        "@walletconnect/core>@walletconnect/logger>tslib": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/relay-auth": {
+      "packages": {
+        "fireblocks-sdk>@notabene/pii-sdk>@stablelib/ed25519": true,
+        "@walletconnect/utils>@stablelib/random": true,
+        "@walletconnect/core>@walletconnect/safe-json": true,
+        "@walletconnect/core>@walletconnect/time": true,
+        "@walletconnect/core>uint8arrays": true
+      }
+    },
+    "@walletconnect/sign-client": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "@walletconnect/core": true,
+        "@walletconnect/core>@walletconnect/jsonrpc-utils": true,
+        "@walletconnect/core>@walletconnect/logger": true,
+        "@walletconnect/core>@walletconnect/time": true,
+        "@walletconnect/types": true,
+        "@walletconnect/sign-client>@walletconnect/utils": true,
+        "events": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/time": {
+      "globals": {
+        "setTimeout": true
+      },
+      "packages": {
+        "@walletconnect/core>@walletconnect/time>tslib": true
+      }
+    },
+    "@walletconnect/types": {
+      "packages": {
+        "@walletconnect/types>@walletconnect/events": true,
+        "events": true
+      }
+    },
+    "@walletconnect/utils": {
+      "globals": {
+        "Linking": true,
+        "Platform": true,
+        "URL": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "navigator.product": true,
+        "open": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@walletconnect/utils>@stablelib/chacha20poly1305": true,
+        "@walletconnect/utils>@stablelib/hkdf": true,
+        "@walletconnect/utils>@stablelib/random": true,
+        "@walletconnect/utils>@stablelib/sha256": true,
+        "@walletconnect/utils>@stablelib/x25519": true,
+        "@walletconnect/core>@walletconnect/relay-api": true,
+        "@walletconnect/core>@walletconnect/time": true,
+        "@walletconnect/utils>@walletconnect/window-getters": true,
+        "@walletconnect/utils>@walletconnect/window-metadata": true,
+        "detect-browser": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "fireblocks-sdk>query-string": true,
+        "@walletconnect/core>uint8arrays": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/utils": {
+      "globals": {
+        "Linking": true,
+        "Platform": true,
+        "URL": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "navigator.product": true,
+        "open": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@walletconnect/utils>@stablelib/chacha20poly1305": true,
+        "@walletconnect/utils>@stablelib/hkdf": true,
+        "@walletconnect/utils>@stablelib/random": true,
+        "@walletconnect/utils>@stablelib/sha256": true,
+        "@walletconnect/utils>@stablelib/x25519": true,
+        "@walletconnect/core>@walletconnect/relay-api": true,
+        "@walletconnect/core>@walletconnect/time": true,
+        "@walletconnect/utils>@walletconnect/window-getters": true,
+        "@walletconnect/utils>@walletconnect/window-metadata": true,
+        "detect-browser": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "fireblocks-sdk>query-string": true,
+        "@walletconnect/core>uint8arrays": true
+      }
+    },
+    "@walletconnect/sign-client>@walletconnect/utils": {
+      "globals": {
+        "Linking": true,
+        "Platform": true,
+        "URL": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "navigator.product": true,
+        "open": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@walletconnect/utils>@stablelib/chacha20poly1305": true,
+        "@walletconnect/utils>@stablelib/hkdf": true,
+        "@walletconnect/utils>@stablelib/random": true,
+        "@walletconnect/utils>@stablelib/sha256": true,
+        "@walletconnect/utils>@stablelib/x25519": true,
+        "@walletconnect/core>@walletconnect/relay-api": true,
+        "@walletconnect/core>@walletconnect/time": true,
+        "@walletconnect/utils>@walletconnect/window-getters": true,
+        "@walletconnect/utils>@walletconnect/window-metadata": true,
+        "detect-browser": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "fireblocks-sdk>query-string": true,
+        "@walletconnect/core>uint8arrays": true
+      }
+    },
+    "@walletconnect/utils>@walletconnect/window-metadata": {
+      "packages": {
+        "@walletconnect/utils>@walletconnect/window-getters": true
+      }
+    },
+    "argon2-browser": {
+      "globals": {
+        "Buffer": true,
+        "Module": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "WebAssembly": true,
+        "XMLHttpRequest": true,
+        "__dirname": true,
+        "atob": true,
+        "clearInterval": true,
+        "console": "write",
+        "define": true,
+        "document": true,
+        "fetch": true,
+        "importScripts": true,
+        "location.href": true,
+        "print": true,
+        "printErr": true,
+        "process": true,
+        "quit": true,
+        "read": true,
+        "readbuffer": true,
+        "scriptArgs": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "path-browserify": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js": {
+      "packages": {
+        "bn.js": true,
+        "buffer": true,
+        "bip32>create-hash>inherits": true,
+        "bip32>tiny-secp256k1>elliptic>minimalistic-assert": true,
+        "@rsbuild/plugin-node-polyfill>vm-browserify": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1>asn1.js": {
+      "packages": {
+        "bn.js": true,
+        "bip32>create-hash>inherits": true,
+        "bip32>tiny-secp256k1>elliptic>minimalistic-assert": true,
+        "@blockaid/client>node-fetch>encoding>iconv-lite>safer-buffer": true
+      }
+    },
+    "@keystonehq/ur-decoder>@ngraveio/bc-ur>assert": {
+      "globals": {
+        "console": true,
+        "process.emitWarning": true,
+        "process.stderr": true
+      },
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur>assert>es6-object-assign": true,
+        "@rsbuild/plugin-node-polyfill>assert>is-nan": true,
+        "@rsbuild/plugin-node-polyfill>assert>object-is": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert": {
+      "globals": {
+        "console": true,
+        "process.emitWarning": true,
+        "process.stderr": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>assert>is-nan": true,
+        "@rsbuild/plugin-node-polyfill>assert>object-is": true,
+        "i18next-scanner>vinyl-fs>object.assign": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>available-typed-arrays": {
+      "packages": {
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>available-typed-arrays>possible-typed-array-names": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>axios-oauth-client": {
+      "packages": {
+        "fireblocks-sdk>@notabene/pii-sdk>axios-oauth-client>qs": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>axios-token-interceptor": {
+      "packages": {
+        "fireblocks-sdk>@notabene/pii-sdk>axios-token-interceptor>lock": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>axios": {
+      "globals": {
+        "AbortController": true,
+        "Blob": true,
+        "Buffer.from": true,
+        "FormData": true,
+        "ReadableStream": true,
+        "Request": true,
+        "Response": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "WorkerGlobalScope": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "console.warn": true,
+        "document": true,
+        "fetch": true,
+        "importScripts": true,
+        "location.href": true,
+        "navigator": true,
+        "process": true,
+        "queueMicrotask": true,
+        "setImmediate": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>axios": {
+      "globals": {
+        "Blob": true,
+        "Buffer.from": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "WorkerGlobalScope": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "importScripts": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@paraswap/sdk>axios": {
+      "globals": {
+        "AbortController": true,
+        "Blob": true,
+        "Buffer.from": true,
+        "FormData": true,
+        "ReadableStream": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "WorkerGlobalScope": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "console.warn": true,
+        "document": true,
+        "fetch": true,
+        "importScripts": true,
+        "location.href": true,
+        "navigator": true,
+        "process": true,
+        "queueMicrotask": true,
+        "setImmediate": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "fireblocks-sdk>axios": {
+      "globals": {
+        "Blob": true,
+        "Buffer.from": true,
+        "FormData": true,
+        "URLSearchParams": true,
+        "WorkerGlobalScope": true,
+        "XMLHttpRequest": true,
+        "btoa": true,
+        "console.warn": true,
+        "document": true,
+        "importScripts": true,
+        "location.href": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@ledgerhq/hw-app-btc>bs58>base-x": {
+      "packages": {
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>base64url": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@avalabs/core-utils-sdk>big.js": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@avalabs/fusion-sdk>bignumber.js": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>bignumber.js": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "web3>web3-core>bignumber.js": {
+      "globals": {
+        "crypto": true,
+        "define": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>bip174": {
+      "globals": {
+        "Buffer.allocUnsafe": true,
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "Buffer.of": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "bitcoinjs-lib>bip174": {
+      "globals": {
+        "Buffer.allocUnsafe": true,
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "Buffer.of": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "bip32": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.allocUnsafe": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "bip32>bs58check": true,
+        "buffer": true,
+        "bip32>create-hash": true,
+        "bip32>create-hmac": true,
+        "bip32>tiny-secp256k1": true,
+        "bip32>typeforce": true,
+        "bip32>wif": true
+      }
+    },
+    "bip39": {
+      "globals": {
+        "Buffer.from": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "buffer": true,
+        "bip32>create-hash": true,
+        "bip39>pbkdf2": true,
+        "bip39>randombytes": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>bip39": {
+      "globals": {
+        "Buffer.from": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "@avalabs/core-wallets-sdk>bip39>@noble/hashes": true,
+        "buffer": true
+      }
+    },
+    "bitcoinjs-lib>bip66": {
+      "packages": {
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "bitcoinjs-lib": {
+      "globals": {
+        "Buffer": true,
+        "console.warn": true
+      },
+      "packages": {
+        "bitcoinjs-lib>bech32": true,
+        "bitcoinjs-lib>bip174": true,
+        "bip32": true,
+        "bitcoinjs-lib>bip66": true,
+        "bitcoinjs-lib>bitcoin-ops": true,
+        "bip32>bs58check": true,
+        "buffer": true,
+        "bip32>create-hash": true,
+        "bitcoinjs-lib>merkle-lib": true,
+        "bitcoinjs-lib>pushdata-bitcoin": true,
+        "bip39>randombytes": true,
+        "bip32>tiny-secp256k1": true,
+        "bip32>typeforce": true,
+        "bitcoinjs-lib>varuint-bitcoin": true,
+        "bip32>wif": true
+      }
+    },
+    "@avalabs/bridge-unified>bitcoinjs-lib": {
+      "globals": {
+        "Buffer": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@avalabs/bridge-unified>bitcoinjs-lib>@noble/hashes": true,
+        "ledger-bitcoin>bitcoinjs-lib>bech32": true,
+        "@avalabs/core-wallets-sdk>bip174": true,
+        "@avalabs/bridge-unified>bitcoinjs-lib>bs58check": true,
+        "buffer": true,
+        "bip32>typeforce": true,
+        "bitcoinjs-lib>varuint-bitcoin": true
+      }
+    },
+    "@avalabs/fusion-sdk>bitcoinjs-lib": {
+      "globals": {
+        "Buffer": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "ledger-bitcoin>bitcoinjs-lib>bech32": true,
+        "@avalabs/core-wallets-sdk>bip174": true,
+        "@avalabs/fusion-sdk>bitcoinjs-lib>bs58check": true,
+        "buffer": true,
+        "bip32>typeforce": true,
+        "bitcoinjs-lib>varuint-bitcoin": true
+      }
+    },
+    "ledger-bitcoin>bitcoinjs-lib": {
+      "globals": {
+        "Buffer": true,
+        "console.warn": true
+      },
+      "packages": {
+        "@noble/hashes": true,
+        "ledger-bitcoin>bitcoinjs-lib>bech32": true,
+        "@avalabs/core-wallets-sdk>bip174": true,
+        "ledger-bitcoin>bitcoinjs-lib>bs58check": true,
+        "buffer": true,
+        "bip32>typeforce": true,
+        "bitcoinjs-lib>varuint-bitcoin": true
+      }
+    },
+    "bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "bip32>tiny-secp256k1>elliptic>brorand": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      }
+    },
+    "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography>browserify-aes": {
+      "globals": {
+        "Buffer.concat": true
+      },
+      "packages": {
+        "buffer": true,
+        "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": true,
+        "bip32>create-hash>cipher-base": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "bip32>create-hash>inherits": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher": {
+      "packages": {
+        "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des": {
+      "packages": {
+        "bip32>create-hash>cipher-base": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des>des.js": true,
+        "bip32>create-hash>inherits": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "bn.js": true,
+        "buffer": true,
+        "bip39>randombytes": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign": {
+      "packages": {
+        "bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa": true,
+        "bip32>create-hash": true,
+        "bip32>create-hmac": true,
+        "bip32>tiny-secp256k1>elliptic": true,
+        "bip32>create-hash>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>browserify-zlib": {
+      "globals": {
+        "Buffer.alloc": true,
+        "process.nextTick": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert": true,
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>browserify-zlib>pako": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>stream-browserify": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "@avalabs/hw-app-avalanche>bs58": {
+      "packages": {
+        "@avalabs/hw-app-avalanche>bs58>base-x": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>bs58": {
+      "packages": {
+        "fireblocks-sdk>@notabene/pii-sdk>bs58>base-x": true
+      }
+    },
+    "bip32>bs58check>bs58": {
+      "packages": {
+        "@ledgerhq/hw-app-btc>bs58>base-x": true
+      }
+    },
+    "bip32>bs58check": {
+      "packages": {
+        "bip32>bs58check>bs58": true,
+        "bip32>create-hash": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@avalabs/bridge-unified>bitcoinjs-lib>bs58check": {
+      "packages": {
+        "@avalabs/bridge-unified>bitcoinjs-lib>bs58check>@noble/hashes": true,
+        "fireblocks-sdk>@notabene/pii-sdk>bs58": true
+      }
+    },
+    "@avalabs/fusion-sdk>bitcoinjs-lib>bs58check": {
+      "packages": {
+        "@noble/hashes": true,
+        "fireblocks-sdk>@notabene/pii-sdk>bs58": true
+      }
+    },
+    "ledger-bitcoin>bitcoinjs-lib>bs58check": {
+      "packages": {
+        "@noble/hashes": true,
+        "fireblocks-sdk>@notabene/pii-sdk>bs58": true
+      }
+    },
+    "buffer": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "buffer>base64-js": true,
+        "buffer>ieee754": true
+      }
+    },
+    "fireblocks-sdk>jsonwebtoken>jws>jwa>buffer-equal-constant-time": {
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography>browserify-aes>buffer-xor": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@keystonehq/ur-decoder>@ngraveio/bc-ur>crc>buffer": {
+      "globals": {
+        "console": true
+      },
+      "packages": {
+        "buffer>base64-js": true,
+        "buffer>ieee754": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>call-bind-apply-helpers": {
+      "packages": {
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@paraswap/sdk>axios>form-data>hasown>function-bind": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>call-bind-apply-helpers": {
+      "packages": {
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@paraswap/sdk>axios>form-data>hasown>function-bind": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>call-bind": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>call-bind>function-bind": true,
+        "@rsbuild/plugin-node-polyfill>assert>call-bind>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>function-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>is-nan>call-bind": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>is-nan>call-bind>function-bind": true,
+        "@rsbuild/plugin-node-polyfill>assert>is-nan>call-bind>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>function-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>get-intrinsic": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>call-bind-apply-helpers": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>es-define-property": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>object-is>call-bind": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>object-is>call-bind>function-bind": true,
+        "@rsbuild/plugin-node-polyfill>assert>object-is>call-bind>get-intrinsic": true
+      }
+    },
+    "i18next-scanner>vinyl-fs>object.assign>call-bind": {
+      "packages": {
+        "i18next-scanner>vinyl-fs>object.assign>call-bind>function-bind": true,
+        "i18next-scanner>vinyl-fs>object.assign>call-bind>get-intrinsic": true
+      }
+    },
+    "fireblocks-sdk>qs>side-channel>call-bind": {
+      "packages": {
+        "fireblocks-sdk>qs>side-channel>call-bind>function-bind": true,
+        "fireblocks-sdk>qs>side-channel>get-intrinsic": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>call-bind-apply-helpers": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>get-intrinsic": true
+      }
+    },
+    "@keystonehq/ur-decoder>@ngraveio/bc-ur>cbor-sync": {
+      "globals": {
+        "Buffer": true,
+        "define": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "bip32>create-hash>cipher-base": {
+      "packages": {
+        "bip32>create-hash>inherits": true,
+        "bip32>bs58check>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>stream-browserify": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder": true
+      }
+    },
+    "eth-json-rpc-middleware>clone": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "i18next-scanner>vinyl-fs>readable-stream>core-util-is": {
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@ethereumjs/common>crc-32": {
+      "globals": {
+        "DO_NOT_EXPORT_CRC": true,
+        "define": true
+      }
+    },
+    "@keystonehq/ur-decoder>@ngraveio/bc-ur>crc": {
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur>crc>buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "bn.js": true,
+        "buffer": true,
+        "bip32>tiny-secp256k1>elliptic": true
+      }
+    },
+    "bip32>create-hash": {
+      "packages": {
+        "bip32>create-hash>cipher-base": true,
+        "bip32>create-hash>inherits": true,
+        "bip32>create-hash>md5.js": true,
+        "@ledgerhq/hw-app-btc>ripemd160": true,
+        "@ledgerhq/hw-app-btc>sha.js": true
+      }
+    },
+    "bip39>pbkdf2>create-hash": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "bip32>create-hmac": {
+      "packages": {
+        "bip32>create-hash>cipher-base": true,
+        "bip32>create-hash": true,
+        "bip32>create-hash>inherits": true,
+        "@ledgerhq/hw-app-btc>ripemd160": true,
+        "bip32>bs58check>safe-buffer": true,
+        "@ledgerhq/hw-app-btc>sha.js": true
+      }
+    },
+    "i18next-http-backend>cross-fetch": {
+      "globals": {
+        "Blob": true,
+        "FileReader": true,
+        "FormData": true,
+        "URLSearchParams.prototype.isPrototypeOf": true,
+        "XMLHttpRequest": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>create-ecdh": true,
+        "bip32>create-hash": true,
+        "bip32>create-hmac": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman": true,
+        "bip39>pbkdf2": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt": true,
+        "bip39>randombytes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>randomfill": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>crypto-js": {
+      "globals": {
+        "crypto": true,
+        "define": true,
+        "msCrypto": true
+      }
+    },
+    "xss>cssfilter": {
+      "globals": {
+        "filterCSS": "write"
+      }
+    },
+    "eslint>debug": {
+      "globals": {
+        "console": true,
+        "document": true,
+        "localStorage": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "eslint>debug>ms": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length>define-data-property": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>es-define-property": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length>gopd": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>is-nan>define-properties": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>is-nan>define-properties>has-property-descriptors": true,
+        "i18next-scanner>vinyl-fs>object.assign>object-keys": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>object-is>define-properties": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>object-is>define-properties>has-property-descriptors": true,
+        "i18next-scanner>vinyl-fs>object.assign>object-keys": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>browserify-des>des.js": {
+      "packages": {
+        "bip32>create-hash>inherits": true,
+        "bip32>tiny-secp256k1>elliptic>minimalistic-assert": true
+      }
+    },
+    "detect-browser": {
+      "globals": {
+        "document": true,
+        "navigator": true,
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>did-jwt": {
+      "packages": {
+        "fireblocks-sdk>@notabene/pii-sdk>@stablelib/ed25519": true,
+        "@walletconnect/utils>@stablelib/random": true,
+        "@walletconnect/utils>@stablelib/sha256": true,
+        "@walletconnect/utils>@stablelib/x25519": true,
+        "fireblocks-sdk>@notabene/pii-sdk>did-jwt>@stablelib/xchacha20poly1305": true,
+        "ledger-bitcoin>bitcoinjs-lib>bech32": true,
+        "fireblocks-sdk>@notabene/pii-sdk>did-jwt>canonicalize": true,
+        "bip32>tiny-secp256k1>elliptic": true,
+        "web3>web3-utils>ethereum-bloom-filters>js-sha3": true,
+        "@walletconnect/core>uint8arrays>multiformats": true,
+        "@walletconnect/core>uint8arrays": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "bn.js": true,
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin": true,
+        "bip39>randombytes": true
+      }
+    },
+    "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto>dunder-proto": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>call-bind-apply-helpers": true,
+        "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto>dunder-proto>gopd": true
+      }
+    },
+    "fireblocks-sdk>jsonwebtoken>jws>jwa>ecdsa-sig-formatter": {
+      "packages": {
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "bip32>tiny-secp256k1>elliptic": {
+      "packages": {
+        "bn.js": true,
+        "bip32>tiny-secp256k1>elliptic>brorand": true,
+        "bip32>tiny-secp256k1>elliptic>hash.js": true,
+        "bip32>tiny-secp256k1>elliptic>hmac-drbg": true,
+        "bip32>create-hash>inherits": true,
+        "bip32>tiny-secp256k1>elliptic>minimalistic-assert": true,
+        "bip32>tiny-secp256k1>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>es-abstract": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>get-intrinsic": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>es-define-property": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>get-intrinsic": true
+      }
+    },
+    "@avalabs/fusion-sdk>es-toolkit": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "eth-json-rpc-middleware": {
+      "globals": {
+        "URL": true,
+        "btoa": true,
+        "console.error": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "eth-json-rpc-middleware>@metamask/safe-event-emitter": true,
+        "eth-json-rpc-middleware>clone": true,
+        "eth-rpc-errors": true,
+        "eth-json-rpc-middleware>eth-sig-util": true,
+        "json-rpc-engine": true,
+        "eth-json-rpc-middleware>json-stable-stringify": true,
+        "eth-json-rpc-middleware>pify": true
+      }
+    },
+    "eth-rpc-errors": {
+      "packages": {
+        "eth-rpc-errors>fast-safe-stringify": true
+      }
+    },
+    "eth-json-rpc-middleware>eth-sig-util": {
+      "packages": {
+        "eth-json-rpc-middleware>eth-sig-util>ethereumjs-abi": true,
+        "eth-json-rpc-middleware>eth-sig-util>ethereumjs-util": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true
+      },
+      "packages": {
+        "@keystonehq/bc-ur-registry-eth>@ethereumjs/util>ethereum-cryptography>@noble/hashes": true,
+        "ledger-bitcoin>@bitcoinerlab/secp256k1>@noble/secp256k1": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true
+      },
+      "packages": {
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util>ethereum-cryptography>@noble/curves": true,
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>ethereum-cryptography": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true
+      },
+      "packages": {
+        "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>ethereum-cryptography>@noble/hashes": true
+      }
+    },
+    "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "buffer": true,
+        "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography>keccak": true,
+        "bip39>randombytes": true,
+        "@avalabs/core-wallets-sdk>hdkey>secp256k1": true
+      }
+    },
+    "@metamask/eth-sig-util>ethereumjs-abi": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "bn.js": true,
+        "buffer": true,
+        "@metamask/eth-sig-util>ethereumjs-abi>ethereumjs-util": true
+      }
+    },
+    "eth-json-rpc-middleware>eth-sig-util>ethereumjs-abi": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "bn.js": true,
+        "buffer": true,
+        "eth-json-rpc-middleware>eth-sig-util>ethereumjs-abi>ethereumjs-util": true
+      }
+    },
+    "@ethereumjs/tx>ethereumjs-util": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert": true,
+        "bn.js": true,
+        "buffer": true,
+        "bip32>create-hash": true,
+        "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography": true,
+        "@ethereumjs/tx>ethereumjs-util>rlp": true
+      }
+    },
+    "@metamask/eth-sig-util>ethereumjs-util": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert": true,
+        "bn.js": true,
+        "buffer": true,
+        "bip32>create-hash": true,
+        "bip32>tiny-secp256k1>elliptic": true,
+        "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>ethjs-util": true,
+        "@ethereumjs/tx>ethereumjs-util>rlp": true
+      }
+    },
+    "eth-json-rpc-middleware>eth-sig-util>ethereumjs-util": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert": true,
+        "bn.js": true,
+        "buffer": true,
+        "bip32>create-hash": true,
+        "bip32>tiny-secp256k1>elliptic": true,
+        "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>ethjs-util": true,
+        "@ethereumjs/tx>ethereumjs-util>rlp": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@metamask/eth-sig-util>ethereumjs-abi>ethereumjs-util": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert": true,
+        "bn.js": true,
+        "buffer": true,
+        "bip32>create-hash": true,
+        "bip32>tiny-secp256k1>elliptic": true,
+        "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>ethjs-util": true,
+        "@ethereumjs/tx>ethereumjs-util>rlp": true
+      }
+    },
+    "eth-json-rpc-middleware>eth-sig-util>ethereumjs-abi>ethereumjs-util": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert": true,
+        "bn.js": true,
+        "buffer": true,
+        "bip32>create-hash": true,
+        "bip32>tiny-secp256k1>elliptic": true,
+        "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography": true,
+        "@metamask/eth-sig-util>ethjs-util": true,
+        "@ethereumjs/tx>ethereumjs-util>rlp": true
+      }
+    },
+    "ethers": {
+      "globals": {
+        "AbortController": true,
+        "Headers": true,
+        "atob": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "console.log": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "ethers>@adraffy/ens-normalize": true,
+        "ethers>@noble/curves": true,
+        "@noble/hashes": true,
+        "ethers>aes-js": true,
+        "ethers>tslib": true
+      }
+    },
+    "@metamask/eth-sig-util>ethjs-util": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "buffer": true,
+        "@metamask/eth-sig-util>ethjs-util>is-hex-prefixed": true,
+        "@metamask/eth-sig-util>ethjs-util>strip-hex-prefix": true
+      }
+    },
+    "events": {
+      "globals": {
+        "console": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": {
+      "packages": {
+        "bip32>create-hash>md5.js": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/AvalancheSignRequest.cjs": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/AvalancheUtxo.cjs": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/RegistryType.cjs": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/index.js": true,
+        "fireblocks-sdk>uuid": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/AvalancheSignature.cjs": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/RegistryType.cjs": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/AvalancheUtxo.cjs": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/RegistryType.cjs": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/RegistryType.cjs": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/index.cjs": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/AvalancheSignRequest.cjs": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/AvalancheSignature.cjs": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/RegistryType.cjs": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/Bytes.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoAccount.js": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/index.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoCoinInfo.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.concat": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "bip32>bs58check": true,
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoCoinInfo.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/PathComponent.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoOutput.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/MultiKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/ScriptExpression.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoPSBT.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/Decoder/index.js": {
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/errors/index.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/MultiKey.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/DataItem.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": {
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/extended/CryptoMultiAccounts.js": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/extended/DerivationSchema.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/extended/KeyDerivation.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/extended/DerivationSchema.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/extended/QRHardwareCall.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/extended/KeyDerivation.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/index.js": {
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/Bytes.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoAccount.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoCoinInfo.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoOutput.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/CryptoPSBT.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/Decoder/index.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/MultiKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/PathComponent.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/ScriptExpression.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/errors/index.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/extended/CryptoMultiAccounts.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/extended/DerivationSchema.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/extended/KeyDerivation.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/extended/QRHardwareCall.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/patchCBOR.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/types.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/utils.js": true,
+        "rxjs>tslib": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/cbor-sync.js": {
+      "globals": {
+        "Buffer": true,
+        "define": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/DataItem.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/DataItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/cbor-sync.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/patchCBOR.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/ScriptExpression.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/utils.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/Bytes.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoAccount.js": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/index.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoCoinInfo.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.concat": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "bip32>bs58check": true,
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoCoinInfo.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/PathComponent.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoOutput.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/MultiKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/ScriptExpression.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoPSBT.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/Decoder/index.js": {
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/errors/index.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/MultiKey.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/DataItem.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": {
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/extended/CryptoMultiAccounts.js": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/extended/DerivationSchema.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/extended/KeyDerivation.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/extended/DerivationSchema.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/extended/QRHardwareCall.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/extended/KeyDerivation.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/index.js": {
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/Bytes.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoAccount.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoCoinInfo.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoOutput.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/CryptoPSBT.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/Decoder/index.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/MultiKey.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/PathComponent.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/ScriptExpression.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/errors/index.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/extended/CryptoMultiAccounts.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/extended/DerivationSchema.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/extended/KeyDerivation.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/extended/QRHardwareCall.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/patchCBOR.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/types.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/utils.js": true,
+        "rxjs>tslib": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/cbor-sync.js": {
+      "globals": {
+        "Buffer": true,
+        "define": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/DataItem.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/DataItem.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/cbor-sync.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/patchCBOR.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/ScriptExpression.js": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/bc-ur-registry/dist/utils.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-avalanche/lib/index.js": {
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry-avalanche/dist/index.cjs": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/lib/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-base/lib/index.js": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/lib/util.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-base/lib/util.js": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/constants.js": {
+      "globals": {
+        "process.env.KEYSTONE_USB_ENV": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/decorators.js": {
+      "globals": {
+        "console.log": true,
+        "process.env.KEYSTONE_USB_ENV": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/frame.js": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/helper.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/index.js": {
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "console.log": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/actions.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/chain.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/decorators.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/frame.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/helper.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/webusb.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/webusb.js": {
+      "globals": {
+        "console.warn": true,
+        "navigator": true
+      },
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-base/node_modules/@keystonehq/hw-transport-webusb/lib/helper.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/lib/index.js": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/lib/new.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/lib/path-type.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/lib/request.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/lib/serializer.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/lib/ur-parser.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/dist/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true,
+        "@ethereumjs/tx>ethereumjs-util>rlp": true,
+        "fireblocks-sdk>uuid": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/lib/new.js": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/bc-ur-registry/dist/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/lib/util.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/dist/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true,
+        "fireblocks-sdk>uuid": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/lib/ur-parser.js": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/dist/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/lib/util.js": {
+      "packages": {
+        "bip32>tiny-secp256k1>elliptic": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/rlp/dist/cjs/index.js": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/baseTransaction.js": {
+      "packages": {
+        "@ethereumjs/common": true,
+        "@ethereumjs/tx>ethereumjs-util": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/types.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/eip1559Transaction.js": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "buffer": true,
+        "@ethereumjs/tx>ethereumjs-util": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/baseTransaction.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/types.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/util.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/eip2930Transaction.js": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "buffer": true,
+        "@ethereumjs/tx>ethereumjs-util": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/baseTransaction.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/types.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/util.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/index.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/eip1559Transaction.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/eip2930Transaction.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/legacyTransaction.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/transactionFactory.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/types.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/legacyTransaction.js": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "buffer": true,
+        "@ethereumjs/tx>ethereumjs-util": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/baseTransaction.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/types.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/util.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/transactionFactory.js": {
+      "globals": {
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "buffer": true,
+        "@ethereumjs/tx>ethereumjs-util": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/types.js": {
+      "packages": {
+        "@ethereumjs/tx>ethereumjs-util": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/util.js": {
+      "packages": {
+        "@ethereumjs/tx>ethereumjs-util": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/tx/dist.browser/types.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/account.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/rlp/dist/cjs/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/helpers.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/internal.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/keccak.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/secp256k1.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/address.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/account.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/constants.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/asyncEventEmitter.js": {
+      "packages": {
+        "events": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/blobs.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/sha256.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/helpers.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/internal.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/random.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/constants.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/secp256k1.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/genesis.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/internal.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/helpers.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/internal.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/index.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/account.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/address.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/asyncEventEmitter.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/blobs.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/db.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/genesis.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/internal.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/kzg.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/lock.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/mapDB.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/provider.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/requests.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/signature.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/types.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/units.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/verkle.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/withdrawal.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/internal.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/lock.js": {
+      "globals": {
+        "console.warn": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/mapDB.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/provider.js": {
+      "globals": {
+        "fetch": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/requests.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/rlp/dist/cjs/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/signature.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/helpers.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/keccak.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/secp256k1.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/types.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/internal.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/units.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/constants.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/verkle.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/withdrawal.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/address.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@ethereumjs/util/dist/cjs/types.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/dist/bc-ur-registry-eth.cjs.production.min.js": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "buffer": true,
+        "@ethereumjs/tx>ethereumjs-util": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/index.js": true,
+        "@keystonehq/bc-ur-registry-eth>hdkey": true,
+        "fireblocks-sdk>uuid": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/dist/index.js": {
+      "globals": {
+        "process.env.NODE_ENV": true
+      },
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/dist/bc-ur-registry-eth.cjs.production.min.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/Bytes.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoAccount.js": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoCoinInfo.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.concat": true,
+        "Buffer.from": true
+      },
+      "packages": {
+        "bip32>bs58check": true,
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoCoinInfo.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/PathComponent.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoOutput.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/MultiKey.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/ScriptExpression.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoPSBT.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/Decoder/index.js": {
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/errors/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/MultiKey.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/DataItem.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": {
+      "packages": {
+        "@keystonehq/ur-decoder>@ngraveio/bc-ur": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/extended/CryptoMultiAccounts.js": {
+      "globals": {
+        "Buffer.alloc": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/extended/KeyDerivation.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/extended/QRHardwareCall.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/extended/KeyDerivation.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/index.js": {
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/Bytes.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoAccount.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoCoinInfo.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoECKey.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoHDKey.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoKeypath.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoOutput.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/CryptoPSBT.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/Decoder/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/MultiKey.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/PathComponent.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/ScriptExpression.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/errors/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/extended/CryptoMultiAccounts.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/extended/KeyDerivation.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/extended/QRHardwareCall.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/patchCBOR.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/types.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/utils.js": true,
+        "rxjs>tslib": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/cbor-sync.js": {
+      "globals": {
+        "Buffer": true,
+        "define": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/DataItem.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/DataItem.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/cbor-sync.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/patchCBOR.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/RegistryType.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/ScriptExpression.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/utils.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/bc-ur-registry-eth/node_modules/@keystonehq/bc-ur-registry/dist/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/decorators.js": {
+      "globals": {
+        "console.log": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/frame.js": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/helper.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/index.js": {
+      "globals": {
+        "clearTimeout": true,
+        "console.error": true,
+        "console.log": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/actions.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/chain.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/decorators.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/frame.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/helper.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/webusb.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/webusb.js": {
+      "globals": {
+        "console.log": true,
+        "console.warn": true,
+        "navigator": true
+      },
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@keystonehq/hw-transport-webusb/lib/helper.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/_shortw_utils.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/weierstrass.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/hmac.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/curve.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/modular.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/hash-to-curve.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/modular.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/modular.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/utils.js": {
+      "globals": {
+        "TextEncoder": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/weierstrass.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/curve.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/modular.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/secp256k1.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/_shortw_utils.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/hash-to-curve.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/modular.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/utils.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/abstract/weierstrass.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/sha256.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/_md.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/_assert.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/crypto.js": {
+      "globals": {
+        "crypto": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/hmac.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/_assert.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/sha256.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/_md.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/sha3.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/_assert.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/_u64.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/utils.js": {
+      "globals": {
+        "TextEncoder": true
+      },
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/_assert.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/crypto.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/keccak.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/sha3.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/random.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/secp256k1.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/curves/secp256k1.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/sha256.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/sha256.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/ethereum-cryptography/utils.js": {
+      "globals": {
+        "TextDecoder": true,
+        "crypto": true
+      },
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/_assert.js": true,
+        "external:../../node_modules/@keystonehq/hw-app-eth/node_modules/@noble/hashes/utils.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-transport-error/lib/error.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/status-code.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/error.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/status-code.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-transport-usb/lib/constants.js": {
+      "globals": {
+        "process.env.KEYSTONE_USB_ENV": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-transport-usb/lib/decorators.js": {
+      "globals": {
+        "console.log": true,
+        "process.env.KEYSTONE_USB_ENV": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-transport-usb/lib/frame.js": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/helper.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-transport-usb/lib/index.js": {
+      "globals": {
+        "console.error": true,
+        "console.log": true
+      },
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/actions.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/chain.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/constants.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/decorators.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/frame.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/helper.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/interface.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-transport-webusb/lib/index.js": {
+      "packages": {
+        "external:../../node_modules/@keystonehq/hw-transport-webusb/lib/webusb.js": true
+      }
+    },
+    "external:../../node_modules/@keystonehq/hw-transport-webusb/lib/webusb.js": {
+      "globals": {
+        "clearTimeout": true,
+        "console.warn": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true,
+        "external:../../node_modules/@keystonehq/hw-transport-usb/lib/index.js": true
+      }
+    },
+    "external:../../node_modules/react-i18next/dist/es/context.js": {
+      "packages": {
+        "external:../../node_modules/react-i18next/dist/es/unescape.js": true,
+        "external:../../node_modules/react-i18next/node_modules/@babel/runtime/helpers/esm/classCallCheck.js": true,
+        "external:../../node_modules/react-i18next/node_modules/@babel/runtime/helpers/esm/createClass.js": true,
+        "external:../../node_modules/react-i18next/node_modules/@babel/runtime/helpers/esm/defineProperty.js": true,
+        "@keystonehq/animated-qr>react": true
+      }
+    },
+    "external:../common/node_modules/@solana/addresses/dist/index.browser.mjs": {
+      "globals": {
+        "Intl.Collator": true,
+        "TextEncoder": true,
+        "crypto.subtle.digest": true,
+        "crypto.subtle.exportKey": true,
+        "crypto.subtle.importKey": true
+      },
+      "packages": {
+        "external:../common/node_modules/@solana/assertions/dist/index.browser.mjs": true,
+        "external:../common/node_modules/@solana/codecs-core/dist/index.browser.mjs": true,
+        "external:../common/node_modules/@solana/codecs-strings/dist/index.browser.mjs": true,
+        "external:../common/node_modules/@solana/errors/dist/index.browser.mjs": true
+      }
+    },
+    "external:../common/node_modules/@solana/codecs-core/dist/index.browser.mjs": {
+      "packages": {
+        "external:../common/node_modules/@solana/errors/dist/index.browser.mjs": true
+      }
+    },
+    "external:../common/node_modules/@solana/codecs-strings/dist/index.browser.mjs": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true
+      },
+      "packages": {
+        "external:../common/node_modules/@solana/codecs-core/dist/index.browser.mjs": true,
+        "external:../common/node_modules/@solana/errors/dist/index.browser.mjs": true
+      }
+    },
+    "external:../common/node_modules/@solana/errors/dist/index.browser.mjs": {
+      "globals": {
+        "btoa": true,
+        "process.env.NODE_ENV": true
+      }
+    },
+    "external:../common/src/concurrency/Mutex.ts": {
+      "packages": {
+        "external:../common/src/concurrency/Semaphore.ts": true
+      }
+    },
+    "external:../common/src/concurrency/ReadWriteLock.ts": {
+      "packages": {
+        "events": true,
+        "external:../common/src/concurrency/Mutex.ts": true
+      }
+    },
+    "external:../common/src/constants.ts": {
+      "globals": {
+        "location.origin": true
+      },
+      "packages": {
+        "external:../common/src/utils/environment.ts": true,
+        "webextension-polyfill": true
+      }
+    },
+    "external:../common/src/feature-flags.ts": {
+      "packages": {
+        "external:../types/src/index.ts": true
+      }
+    },
+    "external:../common/src/initI18n.ts": {
+      "packages": {
+        "external:../../node_modules/react-i18next/dist/es/context.js": true,
+        "external:../../node_modules/react-i18next/dist/es/index.js": true,
+        "i18next": true,
+        "i18next-http-backend": true
+      }
+    },
+    "external:../common/src/monitoring/sentryCaptureException.ts": {
+      "meta": {
+        "graph-optimization": [
+          "Dependency '@sentry/browser' reexports from '@sentry/browser>@sentry/core' and the bundler collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@sentry/browser": true,
+        "@sentry/browser>@sentry/core": true
+      }
+    },
+    "external:../common/src/monitoring/sharedSentryConfig.ts": {
+      "globals": {
+        "process.env.RELEASE": true,
+        "process.env.SENTRY_DEBUG": true,
+        "process.env.SENTRY_DSN": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "webextension-polyfill": true
+      }
+    },
+    "external:../common/src/unifiedTransfer/getEnabledTransferServices.ts": {
+      "packages": {
+        "external:../common/node_modules/@avalabs/fusion-sdk/dist/constants.js": true,
+        "external:../common/node_modules/@avalabs/fusion-sdk/dist/mod.js": true,
+        "external:../types/src/index.ts": true,
+        "lodash": true
+      }
+    },
+    "external:../common/src/unifiedTransfer/getServiceInitializer.ts": {
+      "globals": {
+        "process.env.MARKR_API_TOKEN": true,
+        "process.env.MARKR_API_URL": true
+      },
+      "packages": {
+        "external:../common/node_modules/@avalabs/fusion-sdk/dist/constants.js": true,
+        "external:../common/node_modules/@avalabs/fusion-sdk/dist/mod.js": true,
+        "external:../common/src/unifiedTransfer/constants.ts": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "external:../common/src/utils/accounts/accountTypeGuards.ts": {
+      "packages": {
+        "external:../types/src/index.ts": true
+      }
+    },
+    "external:../common/src/utils/address.ts": {
+      "packages": {
+        "@avalabs/core-wallets-sdk": true,
+        "@avalabs/vm-module-types": true,
+        "bitcoinjs-lib": true,
+        "external:../common/src/utils/object.ts": true
+      }
+    },
+    "external:../common/src/utils/array.ts": {
+      "packages": {
+        "external:../common/src/utils/typeUtils.ts": true
+      }
+    },
+    "external:../common/src/utils/assertions.ts": {
+      "globals": {
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "buffer": true,
+        "eth-rpc-errors": true,
+        "external:../types/src/index.ts": true
+      }
+    },
+    "external:../common/src/utils/balance/balanceServiceHelpers.ts": {
+      "packages": {
+        "external:../types/src/index.ts": true,
+        "webextension-polyfill": true
+      }
+    },
+    "external:../common/src/utils/balance/groupTokensByType.ts": {
+      "packages": {
+        "external:../common/src/utils/nfts/isNFT.ts": true
+      }
+    },
+    "external:../common/src/utils/caipConversion.ts": {
+      "packages": {
+        "@avalabs/core-chains-sdk": true,
+        "@avalabs/core-wallets-sdk": true,
+        "@avalabs/vm-module-types": true
+      }
+    },
+    "external:../common/src/utils/calculateTotalAtomicFundsForAccounts.ts": {
+      "packages": {
+        "@avalabs/core-chains-sdk": true,
+        "@avalabs/core-utils-sdk": true,
+        "external:../common/src/utils/constants.ts": true
+      }
+    },
+    "external:../common/src/utils/calculateTotalBalance.ts": {
+      "packages": {
+        "external:../common/src/utils/getAddressForChain.ts": true,
+        "external:../common/src/utils/hasAccountBalances.ts": true,
+        "external:../common/src/utils/isTokenCountIn.ts": true,
+        "external:../types/src/index.ts": true
+      }
+    },
+    "external:../common/src/utils/canSkipApproval.ts": {
+      "packages": {
+        "external:../common/src/utils/getSyncDomain.ts": true,
+        "external:../common/src/utils/isActiveTab.ts": true,
+        "webextension-polyfill": true
+      }
+    },
+    "external:../common/src/utils/environment.ts": {
+      "globals": {
+        "process.env.NODE_ENV": true,
+        "process.env.RELEASE": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "external:../common/src/utils/errors/errorHelpers.ts": {
+      "packages": {
+        "ledger-bitcoin>@ledgerhq/hw-transport": true,
+        "eth-rpc-errors": true,
+        "external:../../node_modules/@keystonehq/hw-transport-error/lib/index.js": true,
+        "external:../types/src/index.ts": true
+      }
+    },
+    "external:../common/src/utils/extensionUtils.ts": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "external:../types/src/index.ts": true,
+        "rxjs": true,
+        "webextension-polyfill": true
+      }
+    },
+    "external:../common/src/utils/fetchAndVerify.ts": {
+      "globals": {
+        "fetch": true
+      }
+    },
+    "external:../common/src/utils/getAddressForChain.ts": {
+      "packages": {
+        "external:../common/src/utils/address.ts": true
+      }
+    },
+    "external:../common/src/utils/getDefaultChainIds.ts": {
+      "packages": {
+        "@avalabs/core-chains-sdk": true
+      }
+    },
+    "external:../common/src/utils/getSyncDomain.ts": {
+      "packages": {
+        "external:../common/src/constants.ts": true,
+        "webextension-polyfill": true
+      }
+    },
+    "external:../common/src/utils/hasAccountBalances.ts": {
+      "packages": {
+        "external:../common/src/utils/account.ts": true
+      }
+    },
+    "external:../common/src/utils/incrementalPromiseResolve.ts": {
+      "globals": {
+        "setTimeout": true
+      }
+    },
+    "external:../common/src/utils/isActiveTab.ts": {
+      "packages": {
+        "webextension-polyfill": true
+      }
+    },
+    "external:../common/src/utils/isAddressValid.ts": {
+      "meta": {
+        "graph-optimization": [
+          "Dependency 'external:../common/node_modules/@solana/kit/dist/index.browser.mjs' reexports from 'external:../common/node_modules/@solana/addresses/dist/index.browser.mjs' and the bundler collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@avalabs/avalanchejs": true,
+        "ethers": true,
+        "external:../common/node_modules/@solana/addresses/dist/index.browser.mjs": true,
+        "external:../common/node_modules/@solana/kit/dist/index.browser.mjs": true,
+        "external:../common/src/utils/address.ts": true,
+        "external:../common/src/utils/stripAddressPrefix.ts": true
+      }
+    },
+    "external:../common/src/utils/isContactValid.ts": {
+      "packages": {
+        "ethers": true,
+        "external:../common/src/utils/address.ts": true,
+        "external:../common/src/utils/isAddressValid.ts": true
+      }
+    },
+    "external:../common/src/utils/isSupportedBrowser.ts": {
+      "packages": {
+        "detect-browser": true
+      }
+    },
+    "external:../common/src/utils/isTokenCountIn.ts": {
+      "packages": {
+        "lodash": true
+      }
+    },
+    "external:../common/src/utils/jsonRpcEngine.ts": {
+      "packages": {
+        "eth-json-rpc-middleware": true,
+        "external:../common/src/utils/network/addGlacierAPIKeyIfNeeded.ts": true,
+        "json-rpc-engine": true
+      }
+    },
+    "external:../common/src/utils/ledger/ensureLedgerAppOpen.ts": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "@avalabs/core-utils-sdk": true,
+        "ledger-bitcoin>@ledgerhq/hw-transport": true,
+        "buffer": true
+      }
+    },
+    "external:../common/src/utils/logging.ts": {
+      "globals": {
+        "console.groupCollapsed": true,
+        "console.groupEnd": true,
+        "console.log": true
+      },
+      "packages": {
+        "external:../common/src/utils/environment.ts": true,
+        "rxjs": true
+      }
+    },
+    "external:../common/src/utils/measureDuration.ts": {
+      "globals": {
+        "crypto.randomUUID": true,
+        "performance.clearMarks": true,
+        "performance.clearMeasures": true,
+        "performance.mark": true,
+        "performance.measure": true
+      }
+    },
+    "external:../common/src/utils/network/addGlacierAPIKeyIfNeeded.ts": {
+      "globals": {
+        "URL": true,
+        "process.env.GLACIER_API_KEY": true,
+        "process.env.GLACIER_URL": true,
+        "process.env.PROXY_URL": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "external:../common/src/utils/network/buildCoreEth.ts": {
+      "packages": {
+        "@avalabs/core-chains-sdk": true,
+        "@avalabs/vm-module-types": true
+      }
+    },
+    "external:../common/src/utils/network/getProviderForNetwork.ts": {
+      "globals": {
+        "process.env.GLACIER_API_KEY": true,
+        "process.env.PROXY_URL": true
+      },
+      "packages": {
+        "@avalabs/core-chains-sdk": true,
+        "@avalabs/core-wallets-sdk": true,
+        "ethers": true,
+        "external:../common/src/utils/network/addGlacierAPIKeyIfNeeded.ts": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "external:../common/src/utils/network/isAvalanchePchainNetwork.ts": {
+      "packages": {
+        "@avalabs/core-chains-sdk": true
+      }
+    },
+    "external:../common/src/utils/network/isAvalancheXchainNetwork.ts": {
+      "packages": {
+        "@avalabs/core-chains-sdk": true
+      }
+    },
+    "external:../common/src/utils/network/isBitcoinNetwork.ts": {
+      "packages": {
+        "@avalabs/core-chains-sdk": true
+      }
+    },
+    "external:../common/src/utils/network/isEthereumNetwork.ts": {
+      "packages": {
+        "@avalabs/core-chains-sdk": true
+      }
+    },
+    "external:../common/src/utils/network/isSolanaNetwork.ts": {
+      "packages": {
+        "@avalabs/core-chains-sdk": true
+      }
+    },
+    "external:../common/src/utils/network/isValidHttpHeader.ts": {
+      "globals": {
+        "Headers": true
+      }
+    },
+    "external:../common/src/utils/nfts/isNFT.ts": {
+      "packages": {
+        "@avalabs/vm-module-types": true
+      }
+    },
+    "external:../common/src/utils/normalizeBalance.ts": {
+      "packages": {
+        "@avalabs/core-utils-sdk": true,
+        "@avalabs/core-utils-sdk>big.js": true,
+        "bn.js": true,
+        "external:../common/src/utils/bigintToBig.ts": true
+      }
+    },
+    "external:../common/src/utils/secrets.ts": {
+      "packages": {
+        "@avalabs/vm-module-types": true
+      }
+    },
+    "external:../common/src/utils/seedless/fido/seedless-utils.ts": {
+      "packages": {
+        "external:../types/src/index.ts": true
+      }
+    },
+    "external:../common/src/utils/sidePanel.ts": {
+      "packages": {
+        "webextension-polyfill": true
+      }
+    },
+    "external:../common/src/utils/stringToBigint.ts": {
+      "packages": {
+        "@avalabs/core-utils-sdk>big.js": true
+      }
+    },
+    "external:../messaging/src/AbstractConnection.ts": {
+      "globals": {
+        "crypto.randomUUID": true
+      },
+      "meta": {
+        "graph-optimization": [
+          "Dependency 'external:../common/src/index.ts' reexports from 'external:../common/src/utils/environment.ts' and the bundler collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "eth-rpc-errors": true,
+        "events": true,
+        "external:../common/src/index.ts": true,
+        "external:../common/src/utils/environment.ts": true,
+        "external:../messaging/src/models.ts": true,
+        "external:../types/src/index.ts": true
+      }
+    },
+    "external:../messaging/src/AutoPairingPostMessageConnection.ts": {
+      "globals": {
+        "AbortController": true,
+        "crypto.randomUUID": true,
+        "location.origin": true
+      },
+      "packages": {
+        "external:../messaging/src/AbstractConnection.ts": true
+      }
+    },
+    "external:../messaging/src/PortConnection.ts": {
+      "packages": {
+        "external:../messaging/src/AbstractConnection.ts": true,
+        "external:../messaging/src/serialization/index.ts": true
+      }
+    },
+    "external:../messaging/src/index.ts": {
+      "packages": {
+        "external:../messaging/src/AbstractConnection.ts": true,
+        "external:../messaging/src/AutoPairingPostMessageConnection.ts": true,
+        "external:../messaging/src/PortConnection.ts": true,
+        "external:../messaging/src/models.ts": true,
+        "external:../messaging/src/serialization/index.ts": true
+      }
+    },
+    "external:../messaging/src/serialization/deserialize.ts": {
+      "globals": {
+        "Buffer.from": true
+      },
+      "packages": {
+        "@avalabs/core-utils-sdk>big.js": true,
+        "bn.js": true,
+        "buffer": true
+      }
+    },
+    "external:../messaging/src/serialization/index.ts": {
+      "packages": {
+        "external:../messaging/src/serialization/deserialize.ts": true,
+        "external:../messaging/src/serialization/serialize.ts": true
+      }
+    },
+    "external:../messaging/src/serialization/serialize.ts": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "@avalabs/core-utils-sdk>big.js": true,
+        "bn.js": true,
+        "buffer": true
+      }
+    },
+    "external:../types/src/account.ts": {
+      "packages": {
+        "@avalabs/vm-module-types": true
+      }
+    },
+    "external:../types/src/balance.ts": {
+      "packages": {
+        "@avalabs/vm-module-types": true,
+        "lodash": true
+      }
+    },
+    "external:../types/src/currency.ts": {
+      "packages": {
+        "joi": true
+      }
+    },
+    "external:../types/src/fireblocks.ts": {
+      "packages": {
+        "fireblocks-sdk": true
+      }
+    },
+    "external:../types/src/index.ts": {
+      "packages": {
+        "external:../types/src/account.ts": true,
+        "external:../types/src/actions.ts": true,
+        "external:../types/src/address.ts": true,
+        "external:../types/src/analytics.ts": true,
+        "external:../types/src/app-check.ts": true,
+        "external:../types/src/approvals.ts": true,
+        "external:../types/src/balance.ts": true,
+        "external:../types/src/contacts.ts": true,
+        "external:../types/src/currency.ts": true,
+        "external:../types/src/dapp-connection.ts": true,
+        "external:../types/src/debank.ts": true,
+        "external:../types/src/defi.ts": true,
+        "external:../types/src/domain-metadata.ts": true,
+        "external:../types/src/error.ts": true,
+        "external:../types/src/feature-flags.ts": true,
+        "external:../types/src/firebase.ts": true,
+        "external:../types/src/fireblocks.ts": true,
+        "external:../types/src/gasless.ts": true,
+        "external:../types/src/history.ts": true,
+        "external:../types/src/keystone.ts": true,
+        "external:../types/src/keystore.ts": true,
+        "external:../types/src/ledger.ts": true,
+        "external:../types/src/lock.ts": true,
+        "external:../types/src/messages.ts": true,
+        "external:../types/src/navigation-history.ts": true,
+        "external:../types/src/network-fee.ts": true,
+        "external:../types/src/network.ts": true,
+        "external:../types/src/notification-center.ts": true,
+        "external:../types/src/notifications.ts": true,
+        "external:../types/src/onboarding.ts": true,
+        "external:../types/src/permissions.ts": true,
+        "external:../types/src/secrets.ts": true,
+        "external:../types/src/seedless.ts": true,
+        "external:../types/src/send.ts": true,
+        "external:../types/src/settings.ts": true,
+        "external:../types/src/storage.ts": true,
+        "external:../types/src/tokens.ts": true,
+        "external:../types/src/transaction.ts": true,
+        "external:../types/src/trendingToken.ts": true,
+        "external:../types/src/ui-connection.ts": true,
+        "external:../types/src/ui.ts": true,
+        "external:../types/src/unifiedTransfer.ts": true,
+        "external:../types/src/util-types.ts": true,
+        "external:../types/src/wallet-connect.ts": true,
+        "external:../types/src/wallet.ts": true,
+        "external:../types/src/web3.ts": true
+      }
+    },
+    "external:../types/src/messages.ts": {
+      "packages": {
+        "external:../types/src/dapp-connection.ts": true
+      }
+    },
+    "external:../types/src/network.ts": {
+      "packages": {
+        "@avalabs/core-chains-sdk": true
+      }
+    },
+    "external:../types/src/notification-center.ts": {
+      "packages": {
+        "zod": true
+      }
+    },
+    "external:../types/src/trendingToken.ts": {
+      "packages": {
+        "zod": true
+      }
+    },
+    "external:../types/src/wallet.ts": {
+      "packages": {
+        "@avalabs/vm-module-types": true,
+        "external:../types/src/secrets.ts": true
+      }
+    },
+    "firebase": {
+      "packages": {
+        "firebase>@firebase/app-check": true,
+        "firebase>@firebase/app": true,
+        "firebase>@firebase/messaging": true,
+        "firebase>@firebase/vertexai": true
+      }
+    },
+    "fireblocks-sdk": {
+      "globals": {
+        "URLSearchParams": true
+      },
+      "packages": {
+        "fireblocks-sdk>@notabene/pii-sdk": true,
+        "fireblocks-sdk>axios": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "fireblocks-sdk>jsonwebtoken": true,
+        "@rsbuild/plugin-node-polyfill>os-browserify": true,
+        "fireblocks-sdk>platform": true,
+        "fireblocks-sdk>qs": true,
+        "fireblocks-sdk>query-string": true,
+        "fireblocks-sdk>uuid": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each>is-callable": true
+      }
+    },
+    "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each": {
+      "packages": {
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each>is-callable": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>call-bind>function-bind": true,
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true,
+        "@lavamoat/allow-scripts>resolve>is-core-module>has": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind>function-bind": true,
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true,
+        "@lavamoat/allow-scripts>resolve>is-core-module>has": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>is-nan>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>is-nan>call-bind>function-bind": true,
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true,
+        "@lavamoat/allow-scripts>resolve>is-core-module>has": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind>function-bind": true,
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true,
+        "@lavamoat/allow-scripts>resolve>is-core-module>has": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@paraswap/sdk>axios>form-data>hasown>function-bind": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>get-intrinsic>has-proto": true,
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true,
+        "@paraswap/sdk>axios>form-data>hasown": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>object-is>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>object-is>call-bind>function-bind": true,
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true,
+        "@lavamoat/allow-scripts>resolve>is-core-module>has": true
+      }
+    },
+    "i18next-scanner>vinyl-fs>object.assign>call-bind>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "i18next-scanner>vinyl-fs>object.assign>call-bind>function-bind": true,
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true,
+        "@lavamoat/allow-scripts>resolve>is-core-module>has": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "Float16Array": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>call-bind-apply-helpers": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>get-intrinsic>es-define-property": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>get-intrinsic>es-object-atoms": true,
+        "@paraswap/sdk>axios>form-data>hasown>function-bind": true,
+        "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>get-intrinsic>gopd": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>get-intrinsic>has-symbols": true,
+        "@paraswap/sdk>axios>form-data>hasown": true,
+        "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>math-intrinsics": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length>gopd>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length>gopd>get-intrinsic>function-bind": true,
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true,
+        "@lavamoat/allow-scripts>resolve>is-core-module>has": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "Float16Array": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>call-bind-apply-helpers": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>get-intrinsic>es-define-property": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>get-intrinsic>es-object-atoms": true,
+        "@paraswap/sdk>axios>form-data>hasown>function-bind": true,
+        "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>get-intrinsic>gopd": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>get-intrinsic>has-symbols": true,
+        "@paraswap/sdk>axios>form-data>hasown": true,
+        "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>math-intrinsics": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-weakmap>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "Float16Array": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound>call-bind-apply-helpers": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-weakmap>get-intrinsic>es-define-property": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-weakmap>get-intrinsic>es-object-atoms": true,
+        "@paraswap/sdk>axios>form-data>hasown>function-bind": true,
+        "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-weakmap>get-intrinsic>gopd": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-weakmap>get-intrinsic>has-symbols": true,
+        "@paraswap/sdk>axios>form-data>hasown": true,
+        "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>math-intrinsics": true
+      }
+    },
+    "fireblocks-sdk>qs>side-channel>get-intrinsic": {
+      "globals": {
+        "AggregateError": true,
+        "FinalizationRegistry": true,
+        "WeakRef": true
+      },
+      "packages": {
+        "fireblocks-sdk>qs>side-channel>call-bind>function-bind": true,
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true,
+        "@lavamoat/allow-scripts>resolve>is-core-module>has": true
+      }
+    },
+    "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": {
+      "packages": {
+        "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto>dunder-proto": true,
+        "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto>es-object-atoms": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length>gopd": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length>gopd>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>is-nan>define-properties>has-property-descriptors": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>is-nan>call-bind>get-intrinsic": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>object-is>define-properties>has-property-descriptors": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>object-is>call-bind>get-intrinsic": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length>has-property-descriptors": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>es-define-property": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-arguments>has-tostringtag": {
+      "packages": {
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true
+      }
+    },
+    "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>has-tostringtag": {
+      "packages": {
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true
+      }
+    },
+    "@lavamoat/allow-scripts>resolve>is-core-module>has": {
+      "packages": {
+        "@lavamoat/allow-scripts>resolve>is-core-module>has>function-bind": true
+      }
+    },
+    "bip32>create-hash>md5.js>hash-base": {
+      "packages": {
+        "bip32>create-hash>inherits": true,
+        "bestzip>archiver>readable-stream": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@ledgerhq/hw-app-btc>ripemd160>hash-base": {
+      "packages": {
+        "bip32>create-hash>inherits": true,
+        "bestzip>archiver>readable-stream": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "bip39>pbkdf2>ripemd160>hash-base": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "buffer": true,
+        "bip32>create-hash>inherits": true,
+        "@rsbuild/plugin-node-polyfill>stream-browserify": true
+      }
+    },
+    "bip32>tiny-secp256k1>elliptic>hash.js": {
+      "packages": {
+        "bip32>create-hash>inherits": true,
+        "bip32>tiny-secp256k1>elliptic>minimalistic-assert": true
+      }
+    },
+    "@paraswap/sdk>axios>form-data>hasown": {
+      "packages": {
+        "@paraswap/sdk>axios>form-data>hasown>function-bind": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>hdkey": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert": true,
+        "bip32>bs58check": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "bip32>bs58check>safe-buffer": true,
+        "@avalabs/core-wallets-sdk>hdkey>secp256k1": true
+      }
+    },
+    "@keystonehq/bc-ur-registry-eth>hdkey": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert": true,
+        "bip32>bs58check": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "@ledgerhq/hw-app-btc>ripemd160": true,
+        "bip32>bs58check>safe-buffer": true,
+        "@avalabs/core-wallets-sdk>hdkey>secp256k1": true
+      }
+    },
+    "bip32>tiny-secp256k1>elliptic>hmac-drbg": {
+      "packages": {
+        "bip32>tiny-secp256k1>elliptic>hash.js": true,
+        "bip32>tiny-secp256k1>elliptic>minimalistic-assert": true,
+        "bip32>tiny-secp256k1>elliptic>minimalistic-crypto-utils": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>https-browserify": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>stream-http": true,
+        "@rsbuild/plugin-node-polyfill>url": true
+      }
+    },
+    "hypersdk-client": {
+      "globals": {
+        "AbortController": true,
+        "CustomEvent": true,
+        "Event": true,
+        "EventTarget": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "addEventListener": true,
+        "atob": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "console.log": true,
+        "dispatchEvent": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "hypersdk-client>@metamask/sdk": true,
+        "hypersdk-client>@noble/curves": true,
+        "hypersdk-client>@noble/hashes": true,
+        "hypersdk-client>@scure/base": true,
+        "hypersdk-client>lossless-json": true
+      }
+    },
+    "i18next": {
+      "globals": {
+        "Intl": true,
+        "console": true,
+        "navigator": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "i18next>@babel/runtime": true
+      }
+    },
+    "i18next-http-backend": {
+      "globals": {
+        "ActiveXObject": true,
+        "XMLHttpRequest": true,
+        "console": true,
+        "document": true,
+        "fetch": true,
+        "setInterval": true
+      },
+      "packages": {
+        "i18next-http-backend>cross-fetch": true
+      }
+    },
+    "firebase>@firebase/app>idb": {
+      "globals": {
+        "DOMException": true,
+        "IDBCursor": true,
+        "IDBDatabase": true,
+        "IDBIndex": true,
+        "IDBObjectStore": true,
+        "IDBRequest": true,
+        "IDBTransaction": true,
+        "indexedDB.deleteDatabase": true,
+        "indexedDB.open": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-arguments": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>has-tostringtag": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each>is-callable": {
+      "globals": {
+        "document": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-generator-function": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>has-tostringtag": true
+      }
+    },
+    "@avalabs/core-utils-sdk>is-ipfs>multiaddr>is-ip": {
+      "packages": {
+        "@avalabs/core-utils-sdk>is-ipfs>multiaddr>is-ip>ip-regex": true
+      }
+    },
+    "@avalabs/core-utils-sdk>is-ipfs": {
+      "packages": {
+        "@avalabs/core-utils-sdk>is-ipfs>iso-url": true,
+        "@avalabs/core-utils-sdk>is-ipfs>mafmt": true,
+        "@avalabs/core-utils-sdk>is-ipfs>multiaddr": true,
+        "@walletconnect/core>uint8arrays>multiformats": true,
+        "@walletconnect/core>uint8arrays": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>is-nan": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>is-nan>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>assert>is-nan>define-properties": true
+      }
+    },
+    "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array": {
+      "packages": {
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>is-typed-array": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>available-typed-arrays": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>es-abstract": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each": true,
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>has-tostringtag": true
+      }
+    },
+    "@avalabs/core-utils-sdk>is-ipfs>iso-url": {
+      "globals": {
+        "URL": true,
+        "URLSearchParams": true,
+        "location": true,
+        "navigator": true
+      }
+    },
+    "joi": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "joi>@hapi/hoek": true,
+        "joi>@hapi/topo": true,
+        "joi>@sideway/address": true,
+        "joi>@sideway/formula": true,
+        "joi>@sideway/pinpoint": true,
+        "buffer": true
+      }
+    },
+    "jose": {
+      "globals": {
+        "AbortController": true,
+        "CryptoKey": true,
+        "EdgeRuntime": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "WebSocketPair": true,
+        "atob": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "crypto": true,
+        "fetch": true,
+        "navigator": true,
+        "setTimeout": true,
+        "structuredClone": true
+      }
+    },
+    "web3>web3-utils>ethereum-bloom-filters>js-sha3": {
+      "globals": {
+        "define": true,
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@keystonehq/ur-decoder>@ngraveio/bc-ur>jsbi": {
+      "globals": {
+        "define": true
+      }
+    },
+    "json-rpc-engine": {
+      "packages": {
+        "json-rpc-engine>@metamask/safe-event-emitter": true,
+        "eth-rpc-errors": true
+      }
+    },
+    "eth-json-rpc-middleware>json-stable-stringify": {
+      "packages": {
+        "eth-json-rpc-middleware>json-stable-stringify>jsonify": true
+      }
+    },
+    "fireblocks-sdk>jsonwebtoken": {
+      "globals": {
+        "Buffer.from": true,
+        "Buffer.isBuffer": true,
+        "process.version": true
+      },
+      "packages": {
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "fireblocks-sdk>jsonwebtoken>jws": true,
+        "lodash": true,
+        "fireblocks-sdk>jsonwebtoken>ms": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "semver": true
+      }
+    },
+    "fireblocks-sdk>jsonwebtoken>jws>jwa": {
+      "packages": {
+        "fireblocks-sdk>jsonwebtoken>jws>jwa>buffer-equal-constant-time": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
+        "fireblocks-sdk>jsonwebtoken>jws>jwa>ecdsa-sig-formatter": true,
+        "bip32>bs58check>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "fireblocks-sdk>jsonwebtoken>jws": {
+      "globals": {
+        "process.nextTick": true
+      },
+      "packages": {
+        "buffer": true,
+        "fireblocks-sdk>jsonwebtoken>jws>jwa": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "bip32>bs58check>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>stream-browserify": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography>keccak": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "buffer": true,
+        "bestzip>archiver>readable-stream": true
+      }
+    },
+    "ledger-bitcoin": {
+      "globals": {
+        "Buffer.alloc": true,
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "ledger-bitcoin>bip32-path": true,
+        "ledger-bitcoin>bitcoinjs-lib": true,
+        "ledger-bitcoin>bitcoinjs-lib>bs58check": true,
+        "buffer": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>axios-token-interceptor>lock": {
+      "globals": {
+        "setImmediate": true,
+        "setTimeout": true
+      }
+    },
+    "lodash": {
+      "globals": {
+        "define": true
+      }
+    },
+    "hypersdk-client>lossless-json": {
+      "globals": {
+        "define": true
+      }
+    },
+    "lru-cache": {
+      "globals": {
+        "AbortController": true,
+        "AbortSignal": true,
+        "console.error": true,
+        "performance": true,
+        "process": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "semver>lru-cache": {
+      "packages": {
+        "semver>lru-cache>yallist": true
+      }
+    },
+    "@avalabs/core-utils-sdk>is-ipfs>mafmt": {
+      "packages": {
+        "@avalabs/core-utils-sdk>is-ipfs>multiaddr": true
+      }
+    },
+    "bip32>create-hash>md5.js": {
+      "packages": {
+        "bip32>create-hash>md5.js>hash-base": true,
+        "bip32>create-hash>inherits": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "bitcoinjs-lib>merkle-lib": {
+      "globals": {
+        "Buffer.concat": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@ethereumjs/util>micro-ftch": {
+      "globals": {
+        "Buffer.concat": true,
+        "Headers": true,
+        "TextDecoder": true,
+        "URL": true,
+        "btoa": true,
+        "fetch": true,
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>browserify-zlib": true,
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>https-browserify": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>stream-http": true,
+        "@rsbuild/plugin-node-polyfill>url": true,
+        "@rsbuild/plugin-node-polyfill>util": true
+      }
+    },
+    "micro-key-producer": {
+      "packages": {
+        "micro-key-producer>@noble/curves": true,
+        "micro-key-producer>@noble/hashes": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin": {
+      "packages": {
+        "bn.js": true,
+        "bip32>tiny-secp256k1>elliptic>brorand": true
+      }
+    },
+    "@avalabs/core-utils-sdk>is-ipfs>multiaddr": {
+      "packages": {
+        "@avalabs/core-utils-sdk>is-ipfs>multiaddr>err-code": true,
+        "@avalabs/core-utils-sdk>is-ipfs>multiaddr>is-ip": true,
+        "@walletconnect/core>uint8arrays>multiformats": true,
+        "@walletconnect/core>uint8arrays": true,
+        "@avalabs/core-utils-sdk>is-ipfs>multiaddr>varint": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>multibase": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "fireblocks-sdk>@notabene/pii-sdk>multibase>@multiformats/base-x": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>multicodec": {
+      "packages": {
+        "@walletconnect/core>uint8arrays": true,
+        "fireblocks-sdk>@notabene/pii-sdk>multicodec>varint": true
+      }
+    },
+    "@walletconnect/core>uint8arrays>multiformats": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "console.warn": true,
+        "crypto.subtle.digest": true
+      }
+    },
+    "fireblocks-sdk>qs>side-channel>object-inspect": {
+      "globals": {
+        "HTMLElement": true,
+        "WeakRef": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel>object-inspect": {
+      "globals": {
+        "HTMLElement": true,
+        "WeakRef": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>assert>object-is": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>assert>object-is>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>assert>object-is>define-properties": true
+      }
+    },
+    "i18next-scanner>vinyl-fs>object.assign": {
+      "packages": {
+        "i18next-scanner>vinyl-fs>object.assign>call-bind": true,
+        "i18next-scanner>vinyl-fs>object.assign>has-symbols": true,
+        "i18next-scanner>vinyl-fs>object.assign>object-keys": true
+      }
+    },
+    "@cubist-labs/cubesigner-sdk>openapi-fetch": {
+      "globals": {
+        "FormData": true,
+        "Headers": true,
+        "URLSearchParams": true,
+        "fetch": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>os-browserify": {
+      "globals": {
+        "location": true,
+        "navigator": true
+      }
+    },
+    "viem>ox": {
+      "globals": {
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "crypto.getRandomValues": true
+      },
+      "packages": {
+        "viem>ox>@noble/curves": true,
+        "viem>ox>@noble/hashes": true,
+        "viem>ox>abitype": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js": true,
+        "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "bip39>pbkdf2": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1>asn1.js": true,
+        "@ethereumjs/tx>ethereumjs-util>ethereum-cryptography>browserify-aes": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-cipher>evp_bytestokey": true,
+        "bip39>pbkdf2": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "path-browserify": {
+      "globals": {
+        "process.cwd": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "bip39>pbkdf2": {
+      "globals": {
+        "crypto": true,
+        "process": true,
+        "queueMicrotask": true,
+        "setImmediate": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "bip39>pbkdf2>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "bip39>pbkdf2>ripemd160": true,
+        "bip32>bs58check>safe-buffer": true,
+        "@ledgerhq/hw-app-btc>sha.js": true,
+        "bip39>pbkdf2>to-buffer": true
+      }
+    },
+    "@walletconnect/core>@walletconnect/logger>pino": {
+      "packages": {
+        "@walletconnect/core>@walletconnect/logger>pino>quick-format-unescaped": true
+      }
+    },
+    "fireblocks-sdk>platform": {
+      "globals": {
+        "define": true
+      }
+    },
+    "i18next-scanner>vinyl>cloneable-readable>process-nextick-args": {
+      "globals": {
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>process": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt": {
+      "packages": {
+        "bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa": true,
+        "bip32>create-hash": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>parse-asn1": true,
+        "bip39>randombytes": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>punycode": {
+      "globals": {
+        "define": true
+      }
+    },
+    "bitcoinjs-lib>pushdata-bitcoin": {
+      "packages": {
+        "bitcoinjs-lib>bitcoin-ops": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>axios-oauth-client>qs": {
+      "packages": {
+        "fireblocks-sdk>qs>side-channel": true
+      }
+    },
+    "fireblocks-sdk>qs": {
+      "packages": {
+        "fireblocks-sdk>qs>side-channel": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel": true
+      }
+    },
+    "fireblocks-sdk>query-string": {
+      "packages": {
+        "fireblocks-sdk>query-string>decode-uri-component": true,
+        "fireblocks-sdk>query-string>filter-obj": true,
+        "fireblocks-sdk>query-string>split-on-first": true,
+        "fireblocks-sdk>query-string>strict-uri-encode": true
+      }
+    },
+    "bip39>randombytes": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "process.nextTick": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>randomfill": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "process.browser": true,
+        "process.nextTick": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "bip39>randombytes": true,
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@keystonehq/animated-qr>react": {
+      "globals": {
+        "ErrorEvent": true,
+        "console.error": true,
+        "dispatchEvent": true,
+        "process": true,
+        "reportError": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "bestzip>archiver>readable-stream": {
+      "globals": {
+        "process.nextTick": true,
+        "process.stderr": true,
+        "process.stdout": true
+      },
+      "packages": {
+        "buffer": true,
+        "events": true,
+        "bip32>create-hash>inherits": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>string_decoder": true,
+        "bestzip>archiver>readable-stream>util-deprecate": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream": {
+      "globals": {
+        "process.browser": true,
+        "process.stderr": true,
+        "process.stdout": true,
+        "process.version.slice": true,
+        "setImmediate": true
+      },
+      "packages": {
+        "i18next-scanner>vinyl-fs>readable-stream>core-util-is": true,
+        "events": true,
+        "bip32>create-hash>inherits": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>isarray": true,
+        "i18next-scanner>vinyl>cloneable-readable>process-nextick-args": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>safe-buffer": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder": true,
+        "bestzip>archiver>readable-stream>util-deprecate": true
+      }
+    },
+    "reflect-metadata": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "process": true
+      },
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@ledgerhq/hw-app-btc>ripemd160": {
+      "packages": {
+        "buffer": true,
+        "@ledgerhq/hw-app-btc>ripemd160>hash-base": true,
+        "bip32>create-hash>inherits": true
+      }
+    },
+    "bip39>pbkdf2>ripemd160": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "buffer": true,
+        "bip39>pbkdf2>ripemd160>hash-base": true,
+        "bip32>create-hash>inherits": true
+      }
+    },
+    "@ethereumjs/tx>ethereumjs-util>rlp": {
+      "globals": {
+        "Buffer.concat": true,
+        "Buffer.from": true,
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "bn.js": true,
+        "buffer": true
+      }
+    },
+    "rxjs": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout.apply": true
+      },
+      "packages": {
+        "rxjs>tslib": true
+      }
+    },
+    "@ledgerhq/hw-app-eth>@ledgerhq/evm-tools>@ledgerhq/live-env>rxjs": {
+      "globals": {
+        "clearTimeout": true,
+        "setTimeout.apply": true
+      },
+      "packages": {
+        "rxjs>tslib": true
+      }
+    },
+    "bip32>bs58check>safe-buffer": {
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>safe-buffer": {
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder>safe-buffer": {
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@blockaid/client>node-fetch>encoding>iconv-lite>safer-buffer": {
+      "globals": {
+        "process.binding": true
+      },
+      "packages": {
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>hdkey>secp256k1": {
+      "packages": {
+        "bip32>tiny-secp256k1>elliptic": true
+      }
+    },
+    "semver": {
+      "globals": {
+        "console.error": true,
+        "process": true
+      },
+      "packages": {
+        "semver>lru-cache": true,
+        "@rsbuild/plugin-node-polyfill>process": true
+      }
+    },
+    "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length>define-data-property": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>get-intrinsic": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length>gopd": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind>set-function-length>has-property-descriptors": true
+      }
+    },
+    "@ledgerhq/hw-app-btc>sha.js": {
+      "packages": {
+        "bip32>create-hash>inherits": true,
+        "bip32>bs58check>safe-buffer": true,
+        "bip39>pbkdf2>to-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-list": {
+      "packages": {
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>object-inspect": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map>get-intrinsic": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>object-inspect": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-weakmap": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-weakmap>get-intrinsic": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>object-inspect": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map": true
+      }
+    },
+    "fireblocks-sdk>qs>side-channel": {
+      "packages": {
+        "fireblocks-sdk>qs>side-channel>call-bind": true,
+        "fireblocks-sdk>qs>side-channel>get-intrinsic": true,
+        "fireblocks-sdk>qs>side-channel>object-inspect": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url>qs>side-channel": {
+      "packages": {
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>object-inspect": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-list": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-map": true,
+        "@rsbuild/plugin-node-polyfill>url>qs>side-channel>side-channel-weakmap": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>stream-browserify": {
+      "packages": {
+        "events": true,
+        "bip32>create-hash>inherits": true,
+        "bestzip>archiver>readable-stream": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>stream-http": {
+      "globals": {
+        "AbortController": true,
+        "Blob": true,
+        "Buffer.alloc": true,
+        "Buffer.from": true,
+        "MSStreamReader": true,
+        "ReadableStream": true,
+        "WritableStream": true,
+        "XDomainRequest": true,
+        "XMLHttpRequest": true,
+        "clearTimeout": true,
+        "fetch": true,
+        "location.protocol.search": true,
+        "process.nextTick": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "buffer": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>builtin-status-codes": true,
+        "bip32>create-hash>inherits": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "bestzip>archiver>readable-stream": true,
+        "@rsbuild/plugin-node-polyfill>url": true,
+        "@rsbuild/plugin-node-polyfill>stream-http>xtend": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>string_decoder": {
+      "packages": {
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>readable-stream>string_decoder>safe-buffer": true
+      }
+    },
+    "@metamask/eth-sig-util>ethjs-util>strip-hex-prefix": {
+      "packages": {
+        "@metamask/eth-sig-util>ethjs-util>is-hex-prefixed": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>@metamask/eth-sig-util>@metamask/utils>superstruct": {
+      "globals": {
+        "console.warn": true
+      }
+    },
+    "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>tiny-invariant": {
+      "globals": {
+        "process.env.NODE_ENV": true
+      }
+    },
+    "bip32>tiny-secp256k1": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "bn.js": true,
+        "buffer": true,
+        "bip32>create-hmac": true,
+        "bip32>tiny-secp256k1>elliptic": true
+      }
+    },
+    "bip39>pbkdf2>to-buffer": {
+      "packages": {
+        "bip39>pbkdf2>to-buffer>isarray": true,
+        "bip32>bs58check>safe-buffer": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer": true
+      }
+    },
+    "@rspack/core>@swc/helpers>tslib": {
+      "globals": {
+        "AsyncIterator": true,
+        "Iterator": true,
+        "SuppressedError": true
+      }
+    },
+    "ethers>tslib": {
+      "globals": {
+        "AsyncIterator": true,
+        "Iterator": true,
+        "SuppressedError": true
+      }
+    },
+    "tsyringe": {
+      "packages": {
+        "tsyringe>tslib": true
+      }
+    },
+    "tweetnacl": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true,
+        "nacl": "write"
+      }
+    },
+    "@metamask/eth-sig-util>tweetnacl-util": {
+      "globals": {
+        "Buffer": true,
+        "atob": true,
+        "btoa": true
+      }
+    },
+    "bip39>pbkdf2>to-buffer>typed-array-buffer": {
+      "packages": {
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>es-errors": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array": true
+      }
+    },
+    "bip32>typeforce": {
+      "globals": {
+        "Buffer.isBuffer": true
+      },
+      "packages": {
+        "buffer": true
+      }
+    },
+    "@walletconnect/core>uint8arrays": {
+      "globals": {
+        "Buffer": true,
+        "TextDecoder": true,
+        "TextEncoder": true
+      },
+      "packages": {
+        "@walletconnect/core>uint8arrays>multiformats": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>url": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>url>punycode": true,
+        "@rsbuild/plugin-node-polyfill>url>qs": true
+      }
+    },
+    "bestzip>archiver>readable-stream>util-deprecate": {
+      "globals": {
+        "console.trace": true,
+        "console.warn": true,
+        "localStorage": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util": {
+      "globals": {
+        "console.error": true,
+        "console.log": true,
+        "console.trace": true,
+        "process": true
+      },
+      "packages": {
+        "bip32>create-hash>inherits": true,
+        "@rsbuild/plugin-node-polyfill>util>is-arguments": true,
+        "@rsbuild/plugin-node-polyfill>util>is-generator-function": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array": true,
+        "@rsbuild/plugin-node-polyfill>process": true,
+        "@rsbuild/plugin-node-polyfill>util>which-typed-array": true
+      }
+    },
+    "fireblocks-sdk>uuid": {
+      "globals": {
+        "crypto": true,
+        "msCrypto": true
+      }
+    },
+    "bitcoinjs-lib>varuint-bitcoin": {
+      "packages": {
+        "bip32>bs58check>safe-buffer": true
+      }
+    },
+    "viem": {
+      "globals": {
+        "AbortController": true,
+        "Image": true,
+        "Request": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "viem>@noble/curves": true,
+        "viem>@noble/hashes": true,
+        "viem>abitype": true,
+        "viem>ox": true
+      }
+    },
+    "@avalabs/bridge-unified>viem": {
+      "globals": {
+        "AbortController": true,
+        "Image": true,
+        "Request": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "atob": true,
+        "btoa": true,
+        "clearTimeout": true,
+        "fetch": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@avalabs/bridge-unified>viem>@noble/curves": true,
+        "@noble/hashes": true,
+        "@avalabs/bridge-unified>viem>abitype": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>vm-browserify": {
+      "globals": {
+        "document.body.appendChild": true,
+        "document.body.removeChild": true,
+        "document.createElement": true
+      }
+    },
+    "webextension-polyfill": {
+      "globals": {
+        "browser": true,
+        "chrome": true,
+        "console.error": true,
+        "console.warn": true,
+        "define": true
+      }
+    },
+    "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array": {
+      "packages": {
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>available-typed-arrays": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bind": true,
+        "@core/lavamoat-rspack>lavamoat-core>json-stable-stringify>call-bound": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>for-each": true,
+        "@paraswap/sdk>axios>form-data>es-set-tostringtag>get-intrinsic>get-proto": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>gopd": true,
+        "bip39>pbkdf2>to-buffer>typed-array-buffer>is-typed-array>which-typed-array>has-tostringtag": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>util>which-typed-array": {
+      "packages": {
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>available-typed-arrays": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>call-bind": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>es-abstract": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array>for-each": true,
+        "@rsbuild/plugin-node-polyfill>util>is-arguments>has-tostringtag": true,
+        "@rsbuild/plugin-node-polyfill>util>is-typed-array": true
+      }
+    },
+    "bip32>wif": {
+      "globals": {
+        "Buffer": true
+      },
+      "packages": {
+        "bip32>bs58check": true,
+        "buffer": true
+      }
+    },
+    "xss": {
+      "globals": {
+        "DedicatedWorkerGlobalScope": true,
+        "console.error": true,
+        "filterXSS": "write"
+      },
+      "packages": {
+        "xss>cssfilter": true
+      }
+    },
+    "@avalabs/core-wallets-sdk>xss": {
+      "globals": {
+        "DedicatedWorkerGlobalScope": true,
+        "console.error": true,
+        "filterXSS": "write"
+      },
+      "packages": {
+        "xss>cssfilter": true
+      }
+    },
+    "zod": {
+      "globals": {
+        "File": true,
+        "JSONSchema": true,
+        "URL": true,
+        "__zod_globalRegistry": true,
+        "atob": true,
+        "btoa": true,
+        "coerce": true,
+        "core": true,
+        "iso": true,
+        "locales": true,
+        "navigator": true,
+        "regexes": true,
+        "util": true
+      }
+    },
+    "@avalabs/avalanche-module>zod": {
+      "globals": {
+        "SuppressedError": true,
+        "URL": true
+      }
+    },
+    "@avalabs/bitcoin-module>zod": {
+      "globals": {
+        "SuppressedError": true,
+        "URL": true
+      }
+    },
+    "@avalabs/bridge-unified>zod": {
+      "globals": {
+        "SuppressedError": true,
+        "URL": true
+      }
+    },
+    "@avalabs/core-gasless-sdk>zod": {
+      "globals": {
+        "SuppressedError": true,
+        "URL": true
+      }
+    },
+    "@avalabs/evm-module>zod": {
+      "globals": {
+        "SuppressedError": true,
+        "URL": true
+      }
+    },
+    "@avalabs/hvm-module>zod": {
+      "globals": {
+        "SuppressedError": true,
+        "URL": true
+      }
+    },
+    "@avalabs/svm-module>zod": {
+      "globals": {
+        "SuppressedError": true,
+        "URL": true
+      }
+    },
+    "@avalabs/vm-module-types>zod": {
+      "globals": {
+        "SuppressedError": true,
+        "URL": true
+      }
+    }
+  }
+}

--- a/packages/service-worker/lavamoat/rspack/policy.json
+++ b/packages/service-worker/lavamoat/rspack/policy.json
@@ -4792,8 +4792,7 @@
       "packages": {
         "external:../common/node_modules/@avalabs/fusion-sdk/dist/constants.js": true,
         "external:../common/node_modules/@avalabs/fusion-sdk/dist/mod.js": true,
-        "external:../common/src/unifiedTransfer/constants.ts": true,
-        "@rsbuild/plugin-node-polyfill>process": true
+        "external:../common/src/unifiedTransfer/constants.ts": true
       }
     },
     "external:../common/src/utils/accounts/accountTypeGuards.ts": {
@@ -4868,9 +4867,6 @@
       "globals": {
         "process.env.NODE_ENV": true,
         "process.env.RELEASE": true
-      },
-      "packages": {
-        "@rsbuild/plugin-node-polyfill>process": true
       }
     },
     "external:../common/src/utils/errors/errorHelpers.ts": {
@@ -4945,7 +4941,6 @@
     "external:../common/src/utils/isContactValid.ts": {
       "packages": {
         "ethers": true,
-        "external:../common/src/utils/address.ts": true,
         "external:../common/src/utils/isAddressValid.ts": true
       }
     },

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -110,6 +110,7 @@
     "@commitlint/cli": "17.0.3",
     "@commitlint/config-angular": "17.0.3",
     "@commitlint/config-conventional": "17.0.3",
+    "@core/lavamoat-rspack": "workspace:*",
     "@eslint/compat": "1.2.4",
     "@eslint/eslintrc": "3.2.0",
     "@eslint/js": "9.16.0",

--- a/packages/service-worker/rsbuild.worker.common.ts
+++ b/packages/service-worker/rsbuild.worker.common.ts
@@ -1,90 +1,145 @@
+import LavaMoatRspackPlugin from '@core/lavamoat-rspack';
 import { defineConfig } from '@rsbuild/core';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import path from 'path';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-export default defineConfig(() => {
-  const distSubdirectory = 'dist';
+export interface CommonConfigOptions {
+  /**
+   * When true, LavaMoat regenerates `policy.json` during the build. Enabled
+   * for shippable builds (prod) so CI can flag policy drift; disabled for
+   * local dev so editing app code can't silently widen permissions.
+   */
+  generateLavaMoatPolicy: boolean;
+}
 
-  return {
-    environments: {
-      'web-worker': {
-        source: {
-          decorators: {
-            version: 'legacy',
-          },
-          entry: {
-            backgroundPage: path.join(__dirname, 'src/init.ts'),
-          },
-        },
-        output: {
-          target: 'web-worker',
-        },
-      },
-    },
-    output: {
-      cleanDistPath: true,
-      inlineStyles: true,
-      injectStyles: true,
-      filename: {
-        js: '[name].js', // this is the default, but just to make sure
-      },
-      distPath: {
-        root: path.join(__dirname, '../..', distSubdirectory, 'sw'),
-        js: 'js',
-        jsAsync: 'js',
-        image: 'images',
-        font: 'js/assets',
-        // assets: 'assets',
-      },
-    },
-    resolve: {
-      extensions: ['.ts', '.tsx', '.js'],
-      alias: {
-        path: require.resolve('path-browserify'),
-        '@hpke/core': '../../node_modules/@hpke/core/esm/mod.js',
-        // Joi by default goes to browser-specific version which does not include the list of TLDS (which we need for email validation)
-        joi: require.resolve('joi/lib/index.js'),
-      },
-      dedupe: ['bn.js', 'ledger-bitcoin'],
-      fallback: {
-        path: false,
-        fs: false,
-        Buffer: false,
-        process: false,
-      },
-    },
-    plugins: [
-      pluginNodePolyfill({
-        overrides: {
-          buffer: 'buffer',
-        },
-      }),
-      pluginReact({
-        swcReactOptions: {
-          refresh: false,
-        },
-      }),
-    ],
-    tools: {
-      rspack: (_, { appendPlugins, appendRules }) => {
-        if (process.env.RSDOCTOR === 'true') {
-          appendPlugins(new RsdoctorRspackPlugin({}));
-        }
+export default ({ generateLavaMoatPolicy }: CommonConfigOptions) =>
+  defineConfig(() => {
+    const distSubdirectory = 'dist';
 
-        appendRules({
-          test: /\.wasm$/,
-          // Tells WebPack that this module should be included as
-          // base64-encoded binary file and not as code
-          loader: 'base64-loader',
-          // Disables WebPack's opinion where WebAssembly should be,
-          // makes it think that it's not WebAssembly
-          //
-          // Error: WebAssembly module is included in initial chunk.
-          type: 'javascript/auto',
-        });
+    return {
+      environments: {
+        'web-worker': {
+          source: {
+            decorators: {
+              version: 'legacy',
+            },
+            entry: {
+              backgroundPage: path.join(__dirname, 'src/init.ts'),
+            },
+          },
+          output: {
+            target: 'web-worker',
+          },
+        },
       },
-    },
-  };
-});
+      output: {
+        cleanDistPath: true,
+        inlineStyles: true,
+        injectStyles: true,
+        filename: {
+          js: '[name].js', // this is the default, but just to make sure
+        },
+        distPath: {
+          root: path.join(__dirname, '../..', distSubdirectory, 'sw'),
+          js: 'js',
+          jsAsync: 'js',
+          image: 'images',
+          font: 'js/assets',
+          // assets: 'assets',
+        },
+      },
+      resolve: {
+        extensions: ['.ts', '.tsx', '.js'],
+        alias: {
+          path: require.resolve('path-browserify'),
+          '@hpke/core': '../../node_modules/@hpke/core/esm/mod.js',
+          // Joi by default goes to browser-specific version which does not include the list of TLDS (which we need for email validation)
+          joi: require.resolve('joi/lib/index.js'),
+        },
+        dedupe: ['bn.js', 'ledger-bitcoin'],
+        fallback: {
+          path: false,
+          fs: false,
+          Buffer: false,
+          process: false,
+        },
+      },
+      plugins: [
+        pluginNodePolyfill({
+          overrides: {
+            buffer: 'buffer',
+          },
+        }),
+        pluginReact({
+          swcReactOptions: {
+            refresh: false,
+          },
+        }),
+      ],
+      tools: {
+        rspack: (_, { appendPlugins, appendRules }) => {
+          if (process.env.RSDOCTOR === 'true') {
+            appendPlugins(new RsdoctorRspackPlugin({}));
+          }
+
+          appendRules({
+            test: /\.wasm$/,
+            // Tells WebPack that this module should be included as
+            // base64-encoded binary file and not as code
+            loader: 'base64-loader',
+            // Disables WebPack's opinion where WebAssembly should be,
+            // makes it think that it's not WebAssembly
+            //
+            // Error: WebAssembly module is included in initial chunk.
+            type: 'javascript/auto',
+          });
+
+          appendPlugins(
+            new LavaMoatRspackPlugin({
+              // Driven per build target: prod regenerates so PR CI can fail
+              // on policy drift, dev loads the checked-in policy so local
+              // edits can't silently widen permissions without a code review.
+              generatePolicy: generateLavaMoatPolicy,
+              policyLocation: path.join(__dirname, 'lavamoat/rspack'),
+              // Service worker has no HTML host page to inject a <script
+              // src="./lockdown"> tag into. Prepend SES lockdown directly to
+              // the entry bundle so it executes before any wrapped module.
+              inlineLockdown: /backgroundPage\.js$/,
+              // Packages whose code statically appears to mutate JS
+              // primordials (e.g. Object.keys, Function.prototype), which
+              // SES lockdown freezes. The build will fail if an unlisted
+              // package triggers this warning.
+              //
+              // See `apps/next/rsbuild.next.common.ts` for the criteria
+              // applied when deciding whether to add a package here.
+              //
+              // The canonical names differ from the ones in `apps/next`
+              // because @lavamoat/aa traverses the dep tree from this
+              // workspace, so e.g. `@sentry/browser` is a direct dep here
+              // (`@sentry/browser>...`) rather than reached via `@core/ui`.
+              knownIncompatiblePackages: [
+                // Wraps Function.prototype.toString in a try/catch; already
+                // handles frozen intrinsics gracefully (catches and skips
+                // the patch).
+                '@sentry/browser>@sentry/core',
+                // Assigns Symbol.iterator only when it's missing; always
+                // present in Chromium so the `||` short-circuits and never
+                // writes.
+                'fireblocks-sdk>@notabene/pii-sdk>did-jwt',
+                // Polyfills Object.keys for Safari 5.0 arguments bug; the
+                // guard (`if (!keysWorksWithArguments)`) is always false in
+                // Chromium 80+.
+                'i18next-scanner>vinyl-fs>object.assign>object-keys',
+                // Polyfills Array.isArray and ArrayBuffer.isView behind
+                // `JS_SHA3_NO_NODE_JS` flag checks; both exist natively in
+                // Chromium.
+                'web3>web3-utils>ethereum-bloom-filters>js-sha3',
+              ],
+            }),
+          );
+        },
+      },
+    };
+  });

--- a/packages/service-worker/rsbuild.worker.common.ts
+++ b/packages/service-worker/rsbuild.worker.common.ts
@@ -107,6 +107,35 @@ export default ({ generateLavaMoatPolicy }: CommonConfigOptions) =>
               // src="./lockdown"> tag into. Prepend SES lockdown directly to
               // the entry bundle so it executes before any wrapped module.
               inlineLockdown: /backgroundPage\.js$/,
+              // `reflect-metadata` polyfills `Reflect.decorate`, `.metadata`,
+              // `.getMetadata` etc. by calling `Object.defineProperty` on
+              // the real `Reflect`. tsyringe (our DI container) and every
+              // `@injectable` / `@inject` decorator at module top-level
+              // depends on those being installed before any service code
+              // runs. If we let `import 'reflect-metadata'` execute as a
+              // normal wrapped module it lands AFTER `hardenIntrinsics()`
+              // freezes `Reflect`, so the very first `defineProperty` call
+              // throws `TypeError: Cannot define property decorate, object
+              // is not extensible` and the SW bundle never finishes
+              // booting (manifests as extension not booting up at all).
+              //
+              // Registering it as a static shim instead inlines its source
+              // into the `LOCKDOWN_SHIMS` array, which the runtime runs
+              // between `repairIntrinsics()` and `hardenIntrinsics()` —
+              // `Reflect` is still extensible at that point, the polyfill
+              // installs cleanly, and the subsequent harden step freezes
+              // `Reflect` *with* the new properties present.
+              //
+              // `require.resolve` runs in this package's context so we get
+              // service-worker's hoisted copy (not lavamoat-rspack's own
+              // node_modules), matching exactly the copy `init.ts` would
+              // have imported.
+              //
+              // NOTE: Important to note here, this renders `reflect-metadata`
+              // as a possible supply-chain attack vector, but with it being
+              // pinned to version 0.1.13, with no real updates in ~4 years
+              // and no other dependencies, this is considered low risk.
+              staticShims_experimental: [require.resolve('reflect-metadata')],
               // Packages whose code statically appears to mutate JS
               // primordials (e.g. Object.keys, Function.prototype), which
               // SES lockdown freezes. The build will fail if an unlisted

--- a/packages/service-worker/rsbuild.worker.dev.ts
+++ b/packages/service-worker/rsbuild.worker.dev.ts
@@ -1,8 +1,11 @@
 import { defineConfig, mergeRsbuildConfig } from '@rsbuild/core';
-import commonConfig from './rsbuild.worker.common';
+import buildCommonConfig from './rsbuild.worker.common';
 import { getEnvVars } from '../../build-scripts/getEnvVars';
 
 const skipSourceMap = process.env.NO_SOURCE_MAPS === 'true';
+// Local dev never regenerates the LavaMoat policy — keep app edits from
+// silently widening permissions. Use `yarn build` (or CI) to refresh it.
+const commonConfig = buildCommonConfig({ generateLavaMoatPolicy: false });
 
 export default defineConfig((...args) =>
   mergeRsbuildConfig(commonConfig(...args), {

--- a/packages/service-worker/rsbuild.worker.prod.ts
+++ b/packages/service-worker/rsbuild.worker.prod.ts
@@ -1,8 +1,11 @@
 import { defineConfig, mergeRsbuildConfig } from '@rsbuild/core';
-import commonConfig from './rsbuild.worker.common';
+import buildCommonConfig from './rsbuild.worker.common';
 import { getEnvVars } from '../../build-scripts/getEnvVars';
 
 const skipSourceMap = process.env.NO_SOURCE_MAPS === 'true';
+// Production builds regenerate the policy so PR CI can detect drift between
+// the checked-in policy.json and what the actual bundle would need.
+const commonConfig = buildCommonConfig({ generateLavaMoatPolicy: true });
 
 export default defineConfig((...args) =>
   mergeRsbuildConfig(commonConfig(...args), {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2941,6 +2941,7 @@ __metadata:
   resolution: "@core/content-script@workspace:packages/content-script"
   dependencies:
     "@core/common": "workspace:*"
+    "@core/lavamoat-rspack": "workspace:*"
     "@core/messaging": "workspace:*"
     "@rsbuild/core": "npm:1.3.3"
     "@rsbuild/plugin-node-polyfill": "npm:1.3.0"
@@ -3040,6 +3041,7 @@ __metadata:
   dependencies:
     "@avalabs/core-gasless-sdk": "npm:3.1.0-alpha.87"
     "@core/common": "workspace:*"
+    "@core/lavamoat-rspack": "workspace:*"
     "@core/messaging": "workspace:*"
     "@core/types": "workspace:*"
     "@rsbuild/core": "npm:1.3.3"
@@ -3087,6 +3089,7 @@ __metadata:
     "@commitlint/cli": "npm:17.0.3"
     "@commitlint/config-angular": "npm:17.0.3"
     "@commitlint/config-conventional": "npm:17.0.3"
+    "@core/lavamoat-rspack": "workspace:*"
     "@cubist-labs/cubesigner-sdk": "npm:0.3.28"
     "@cubist-labs/cubesigner-sdk-ethers-v6": "npm:0.3.28"
     "@eslint/compat": "npm:1.2.4"


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-13618
Figma: _n/a_

⚠️ **This intentionally _does not_ apply the `@lavamoat/node` protections to our build scripts.**

## Out of scope: build-time sandboxing via `@lavamoat/node`
This PR layers in install-time integrity (`yarn install --check-cache`)
and narrows the secret scope of `pr-checks`, but it intentionally does
**not** wrap the build process itself in `@lavamoat/node`. Filing here
so the decision is reviewable; the corresponding ticket gets a comment with the same rationale.


### What `@lavamoat/node` would buy us
It sandboxes every build-time dependency (`@rspack/core`, `@swc/core`,
every babel plugin, etc.) in its own SES Compartment with policy-
restricted access to `globalThis`, `fs`, `net`, `child_process`, and
the rest of Node's surface. In principle this prevents a compromised
build dep from exfiltrating `.env.production` secrets, rewriting the
bundle mid-codegen, or reaching out to attacker infrastructure during
`yarn build`.
### Why we're not doing it
**1. The protection has a structural gap we can't close without changing the bundler itself.** Rspack runs
codegen in Rust via N-API. SES Compartments sandbox JavaScript
execution; they don't reach into native bindings. A compromise of
`@rspack/binding-*`'s Rust binary would let an attacker rewrite bundle
output before LavaMoat ever sees it, regardless of any build-time
policy we ship. The largest realistic attack vector at the build layer
is exactly the one `@lavamoat/node` can't address.

**2. Policy maintenance has a known failure mode at our team size.**
Build-time policies are dominated by mechanical entries — "rspack needs
`fs.realpath`", "babel needs `Module.createRequire`". 95%+ of every
diff is "yes, of course this build tool needs that, approve." Without
a reviewer who has a mental model of what each transitive dep should
legitimately be allowed to do — i.e. a supply-chain-specialised role
we don't have on our team of 5 — the review likely degrades to rubber-stamping
very quick. At that point the gate produces **negative**
security: a green check that signals nothing, plus reviewer attention
that could go somewhere else.

For scale reference: our runtime LavaMoat policies — which are smaller
and more focused than a build-time policy would be, with a threat model
("don't leak the seed phrase") the team can actually reason about —
already weigh 1.1k–6.6k lines per bundle. A build-time policy covering
the entire dev-dep tree would be substantially larger and substantially
less tractable to review.

**3. The marginal protection over what we already have is small.** The
existing stack covers most of the realistic build-time attack surface:
- `enableScripts: false` + `@lavamoat/allow-scripts` → no lifecycle
  scripts execute during install
- `yarn install --check-cache` *(this PR)* → tarball checksums
  re-validated against the registry on every install
- Signed-commits-only branch protection + reviewed `yarn.lock` → no
  silent lock mutation
- `semgrep-ava-labs[bot]` with reachability analysis → CVE detection
  on every PR
- `pr-checks` secret-scope narrowing *(this PR)* → no prod secrets
  reach lint / typecheck / test
- Runtime LavaMoat on every shipping bundle → if a malicious dep does
  make it past install-time gates, its in-browser capabilities are
  policy-restricted
The slice `@lavamoat/node` would close (a build-time dep exfiltrating
secrets or subtly modifying bundle output in ways the runtime policy
doesn't catch) is real but narrow.

<!-- Additional notes and context. Explain non-synchronized design, product, or architectural design decisions -->

## Testing
1. CI passing

## Media
_n/a_