### PR TITLE
test(e2e): onboarding language test + collectibles manage fixes

### DIFF
--- a/e2e/pages/extension/CollectiblesTabPage.ts
+++ b/e2e/pages/extension/CollectiblesTabPage.ts
@@ -273,11 +273,11 @@ export class CollectiblesTabPage extends BasePage {
     return this.gridItems.evaluateAll((els) => {
       for (const el of els) {
         const name = (el.getAttribute('data-collectible-name') ?? '').trim();
-        if (name) {
-          return {
-            tokenId: el.getAttribute('data-collectible-tokenid') ?? '',
-            name,
-          };
+        const tokenId = (
+          el.getAttribute('data-collectible-tokenid') ?? ''
+        ).trim();
+        if (name && tokenId) {
+          return { tokenId, name };
         }
       }
       return null;
@@ -292,11 +292,11 @@ export class CollectiblesTabPage extends BasePage {
     return this.manageItems.evaluateAll((els) => {
       for (const el of els) {
         const name = (el.getAttribute('data-collectible-name') ?? '').trim();
-        if (name) {
-          return {
-            tokenId: el.getAttribute('data-collectible-tokenid') ?? '',
-            name,
-          };
+        const tokenId = (
+          el.getAttribute('data-collectible-tokenid') ?? ''
+        ).trim();
+        if (name && tokenId) {
+          return { tokenId, name };
         }
       }
       return null;

--- a/e2e/pages/extension/CollectiblesTabPage.ts
+++ b/e2e/pages/extension/CollectiblesTabPage.ts
@@ -63,12 +63,27 @@ export class CollectiblesTabPage extends BasePage {
   }
 
   /** Switches to the Collectibles tab and waits for the grid (or empty state). */
-  async open(timeout = 60_000): Promise<void> {
+  async open(timeout = 90_000): Promise<void> {
     await this.navTab.first().waitFor({ state: 'visible', timeout });
-    await this.navTab.first().click();
-    // Balances may still be loading (PortfolioTabs shows a skeleton LoadingState
-    // until then, so the collectibles tab isn't mounted yet) — allow full time.
-    await this.tab.waitFor({ state: 'visible', timeout });
+    // Balances may still be loading: PortfolioTabs renders a skeleton
+    // LoadingState until then, so the collectibles panel isn't mounted yet and
+    // the tab bar can remount mid-load — dropping an early click. Re-click the
+    // nav tab until the panel actually mounts.
+    await expect
+      .poll(
+        async () => {
+          if (await this.tab.isVisible()) {
+            return true;
+          }
+          await this.navTab
+            .first()
+            .click()
+            .catch(() => {});
+          return this.tab.isVisible();
+        },
+        { timeout, intervals: [500, 1000, 2000] },
+      )
+      .toBe(true);
     await this.waitForGridLoaded(timeout);
   }
 
@@ -242,6 +257,50 @@ export class CollectiblesTabPage extends BasePage {
         .first()
         .getAttribute('data-collectible-tokenid')) ?? ''
     );
+  }
+
+  /**
+   * First grid cell that has a non-empty display name, with its tokenId.
+   *
+   * The Manage list's search filters by name/collectionName/symbol (NOT
+   * tokenId), so searching must use a name to reliably surface a specific row.
+   * Returns null if no visible cell has a name.
+   */
+  async firstNamedGridItem(): Promise<{
+    tokenId: string;
+    name: string;
+  } | null> {
+    return this.gridItems.evaluateAll((els) => {
+      for (const el of els) {
+        const name = (el.getAttribute('data-collectible-name') ?? '').trim();
+        if (name) {
+          return {
+            tokenId: el.getAttribute('data-collectible-tokenid') ?? '',
+            name,
+          };
+        }
+      }
+      return null;
+    });
+  }
+
+  /** First manage-list row that has a non-empty display name, with its tokenId. */
+  async firstNamedManageItem(): Promise<{
+    tokenId: string;
+    name: string;
+  } | null> {
+    return this.manageItems.evaluateAll((els) => {
+      for (const el of els) {
+        const name = (el.getAttribute('data-collectible-name') ?? '').trim();
+        if (name) {
+          return {
+            tokenId: el.getAttribute('data-collectible-tokenid') ?? '',
+            name,
+          };
+        }
+      }
+      return null;
+    });
   }
 
   /** Toggles a manage-list row's show/hide switch by tokenId. */

--- a/e2e/pages/extension/OnboardingPage.ts
+++ b/e2e/pages/extension/OnboardingPage.ts
@@ -195,6 +195,9 @@ export class OnboardingPage extends BasePage {
    */
   languageMenuItem(code: string): Locator {
     const name = OnboardingPage.LANGUAGE_ORIGINAL_NAMES[code];
+    if (!name) {
+      throw new Error(`Unknown language code: ${code}`);
+    }
     return this.page.locator('li').filter({ hasText: `(${name})` });
   }
 
@@ -211,14 +214,19 @@ export class OnboardingPage extends BasePage {
    * if it never does (e.g. no POSTHOG_KEY / offline) so callers can skip.
    */
   async enableLanguagesFlag(timeoutMs = 45000): Promise<boolean> {
-    await this.page.evaluate(() => {
-      return new Promise<void>((resolve) => {
-        chrome.storage.local.set(
-          { '__feature-flag-overrides__': { data: { languages: true } } },
-          () => resolve(),
-        );
+    try {
+      await this.page.evaluate(() => {
+        return new Promise<void>((resolve) => {
+          chrome.storage.local.set(
+            { '__feature-flag-overrides__': { data: { languages: true } } },
+            () => resolve(),
+          );
+        });
       });
-    });
+    } catch {
+      // chrome/storage APIs unavailable — let the caller skip cleanly.
+      return false;
+    }
 
     try {
       await this.languageSelectorTrigger.waitFor({

--- a/e2e/pages/extension/OnboardingPage.ts
+++ b/e2e/pages/extension/OnboardingPage.ts
@@ -55,6 +55,8 @@ export class OnboardingPage extends BasePage {
   readonly seedphraseVerificationButtons: Locator;
   readonly seedphraseWords: Locator;
   readonly verifySeedphraseTitle: Locator;
+  // Language selector (gated behind the LANGUAGES feature flag)
+  readonly languageSelectorTrigger: Locator;
   readonly extensionId: string | null;
 
   constructor(page: Page) {
@@ -160,6 +162,107 @@ export class OnboardingPage extends BasePage {
       name: 'Verify your recovery phrase',
       exact: true,
     });
+    // Language selector
+    this.languageSelectorTrigger = page.locator(
+      '[data-testid="onboarding-language-selector"]',
+    );
+  }
+
+  /**
+   * Static, locale-independent originalName for each language code, as defined
+   * in useLanguage() (packages/ui/src/hooks/useLanguages.ts). The k2-alpine
+   * PopoverItem does not forward data-testid to the DOM, so menu rows are
+   * matched by this name (rendered in parentheses, e.g. "Spanish (Español)").
+   */
+  private static readonly LANGUAGE_ORIGINAL_NAMES: Record<string, string> = {
+    en: 'English',
+    'zh-CN': '简体中文',
+    'zh-TW': '繁體中文',
+    'de-DE': 'Deutsch',
+    'fr-FR': 'Français',
+    'hi-IN': 'हिन्दी',
+    'ja-JP': '日本語',
+    'ko-KR': '한국인',
+    'ru-RU': 'Русский',
+    'es-ES': 'Español',
+    'tr-TR': 'Türkçe',
+  };
+
+  /**
+   * Menu row for a language code. Rows render as <li> elements; the selector
+   * trigger is not inside an <li>, so this never matches the trigger. The
+   * parenthesised originalName is stable across UI languages.
+   */
+  languageMenuItem(code: string): Locator {
+    const name = OnboardingPage.LANGUAGE_ORIGINAL_NAMES[code];
+    return this.page.locator('li').filter({ hasText: `(${name})` });
+  }
+
+  /**
+   * Forces the LANGUAGES feature flag on via the unencrypted storage override
+   * the service worker merges on top of fetched flags
+   * (StorageService.loadUnencrypted reads `result[key].data`, so the value is
+   * wrapped accordingly). This requires POSTHOG_KEY in the build (set in CI and
+   * in local .env files) so the flag-fetch cycle runs and applies the override.
+   *
+   * The flag context is reactive, so once the SW applies the override on its
+   * next fetch cycle (~5s dev / ~30s prod) the onboarding page renders the
+   * selector without a reload. Returns true once the selector appears, or false
+   * if it never does (e.g. no POSTHOG_KEY / offline) so callers can skip.
+   */
+  async enableLanguagesFlag(timeoutMs = 45000): Promise<boolean> {
+    await this.page.evaluate(() => {
+      return new Promise<void>((resolve) => {
+        chrome.storage.local.set(
+          { '__feature-flag-overrides__': { data: { languages: true } } },
+          () => resolve(),
+        );
+      });
+    });
+
+    try {
+      await this.languageSelectorTrigger.waitFor({
+        state: 'visible',
+        timeout: timeoutMs,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async openLanguageDropdown(): Promise<void> {
+    await this.languageSelectorTrigger.click();
+    // English is always present; wait for it to confirm the popover is open.
+    await this.languageMenuItem('en').waitFor({
+      state: 'visible',
+      timeout: 10000,
+    });
+  }
+
+  async closeLanguageDropdown(): Promise<void> {
+    await this.page.keyboard.press('Escape');
+    await this.languageMenuItem('en')
+      .waitFor({ state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+  }
+
+  /** Selects a language from the (open) dropdown; the popover closes after. */
+  async selectLanguage(code: string): Promise<void> {
+    await this.languageMenuItem(code).getByRole('button').click();
+    await this.languageMenuItem('en')
+      .waitFor({ state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+  }
+
+  /**
+   * Whether a language option is marked selected. The dropdown must be open.
+   * PopoverItem renders the active option with a trailing check icon (an svg);
+   * non-selected rows have text only, so the icon's presence indicates the
+   * active language.
+   */
+  async isLanguageOptionSelected(code: string): Promise<boolean> {
+    return (await this.languageMenuItem(code).locator('svg').count()) > 0;
   }
 
   async isOnOnboardingPage(): Promise<boolean> {

--- a/e2e/tests/onboarding.spec.ts
+++ b/e2e/tests/onboarding.spec.ts
@@ -2,6 +2,21 @@ import { test, expect } from '../fixtures/extension.fixture';
 import { OnboardingPage } from '../pages/extension/OnboardingPage';
 import { INVALID_RECOVERY_PHRASE_12, TEST_WALLET_NAMES } from '../constants';
 
+// All languages exposed by useLanguage() (packages/ui/src/hooks/useLanguages.ts).
+const EXPECTED_LANGUAGE_CODES = [
+  'en',
+  'zh-CN',
+  'zh-TW',
+  'de-DE',
+  'fr-FR',
+  'hi-IN',
+  'ja-JP',
+  'ko-KR',
+  'ru-RU',
+  'es-ES',
+  'tr-TR',
+];
+
 const WALLET_PASSWORD = process.env.WALLET_PASSWORD || 'password#123';
 const RECOVERY_PHRASE_12_WORDS =
   process.env.RECOVERY_PHRASE_12_WORDS?.split(' ') || [];
@@ -35,6 +50,63 @@ test.describe('Onboarding Tests', () => {
       await expect(onboardingPage.continueWithAppleButton).toBeVisible();
       await expect(onboardingPage.createWalletButton).toBeVisible();
       await expect(onboardingPage.importWalletButton).toBeVisible();
+    },
+  );
+
+  test(
+    'As a CORE ext user, on the onboarding page, I can check the language dropdown box and verify all languages are selectable',
+    {
+      tag: ['@regression'],
+      annotation: [
+        {
+          type: 'snapshot',
+          description: 'none',
+        },
+        {
+          type: 'testrail_case_field',
+          description: 'custom_automation_id:ONB-008',
+        },
+      ],
+    },
+    async ({ extensionPage }) => {
+      test.setTimeout(120000);
+      const onboardingPage = new OnboardingPage(extensionPage);
+
+      await extensionPage.waitForTimeout(3000);
+      expect(await onboardingPage.isOnOnboardingPage()).toBe(true);
+
+      // The selector is gated behind the LANGUAGES feature flag; enable it via
+      // the SW storage override. Skip if it never renders (no POSTHOG_KEY).
+      const enabled = await onboardingPage.enableLanguagesFlag();
+      test.skip(
+        !enabled,
+        'LANGUAGES feature flag unavailable (POSTHOG_KEY missing / offline)',
+      );
+
+      // The dropdown exposes every supported language.
+      await onboardingPage.openLanguageDropdown();
+      for (const code of EXPECTED_LANGUAGE_CODES) {
+        const row = onboardingPage.languageMenuItem(code);
+        await expect(row, `language ${code} should be listed`).toBeVisible();
+        await expect(row.getByRole('button')).toBeEnabled();
+      }
+
+      // English is the default selection.
+      expect(await onboardingPage.isLanguageOptionSelected('en')).toBe(true);
+
+      // Every listed language is actually selectable: choosing it marks it
+      // selected (verified locale-independently via the menu item's state).
+      for (const code of EXPECTED_LANGUAGE_CODES) {
+        await onboardingPage.selectLanguage(code);
+        await onboardingPage.openLanguageDropdown();
+        expect(
+          await onboardingPage.isLanguageOptionSelected(code),
+          `selecting ${code} should mark it as the active language`,
+        ).toBe(true);
+      }
+
+      // Restore the default so the dropdown ends in a known state.
+      await onboardingPage.selectLanguage('en');
     },
   );
 

--- a/e2e/tests/portfolio.spec.ts
+++ b/e2e/tests/portfolio.spec.ts
@@ -900,16 +900,19 @@ test.describe('Portfolio - Collectibles', () => {
       const collectibles = new CollectiblesTabPage(unlockedExtensionPage);
       await collectibles.open();
 
-      // Track a specific NFT that's visible at the top of the grid. Tracking one
-      // item (rather than a total count) is robust to virtualization: a hidden
-      // item is removed from the dataset entirely, and a stable sort returns it
-      // to the top when re-shown.
-      const tokenId = await collectibles.firstGridTokenId();
-      expect(tokenId.length).toBeGreaterThan(0);
+      // Track a specific named NFT visible in the grid. Tracking one item
+      // (rather than a total count) is robust to virtualization: a hidden item
+      // is removed from the dataset entirely and returns when re-shown.
+      // We search the Manage list by NAME (not tokenId) because the Manage
+      // list filters by name/collectionName/symbol — searching a tokenId
+      // renders zero rows and the toggle can't be found.
+      const item = await collectibles.firstNamedGridItem();
+      expect(item, 'expected a grid NFT with a searchable name').not.toBeNull();
+      const { tokenId, name } = item!;
 
-      // Disable: hide it via Manage (search so the toggle is rendered).
+      // Disable: hide it via Manage (search by name so the toggle is rendered).
       await collectibles.openManage();
-      await collectibles.searchManage(tokenId);
+      await collectibles.searchManage(name);
       await collectibles.toggleManageItem(tokenId);
       await collectibles.closeManage();
       await expect
@@ -918,7 +921,7 @@ test.describe('Portfolio - Collectibles', () => {
 
       // Enable: re-show it → its cell returns to the grid.
       await collectibles.openManage();
-      await collectibles.searchManage(tokenId);
+      await collectibles.searchManage(name);
       await collectibles.toggleManageItem(tokenId);
       await collectibles.closeManage();
       await expect
@@ -948,9 +951,17 @@ test.describe('Portfolio - Collectibles', () => {
       const total = await collectibles.manageItemCount();
       expect(total).toBeGreaterThan(0);
 
-      // Search by the first row's tokenId → results narrow to matches.
-      const tokenId = await collectibles.firstManageTokenId();
-      await collectibles.searchManage(tokenId);
+      // Search by the first named row's NAME → results narrow to matches.
+      // The Manage list filters by name/collectionName/symbol, so a tokenId
+      // search would render zero rows; using the name keeps the row visible.
+      const item = await collectibles.firstNamedManageItem();
+      expect(
+        item,
+        'expected a manage-list NFT with a searchable name',
+      ).not.toBeNull();
+      const { tokenId, name } = item!;
+
+      await collectibles.searchManage(name);
       await expect
         .poll(() => collectibles.manageItemCount(), { timeout: 10_000 })
         .toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Add **ONB-008**: verifies the onboarding language dropdown lists all 11 supported languages and that each is selectable. Forces the `LANGUAGES` feature flag on via the feature-flag storage override (skips cleanly if `POSTHOG_KEY` is unavailable), and matches rows by their locale-stable `originalName` since k2-alpine's `PopoverItem` doesn't forward `data-testid`.
- Stabilize the Collectibles Manage List tests (**COL-009 / COL-010**): search the Manage list by name instead of `tokenId` so the popup's outer and inner filters agree, and harden `CollectiblesTabPage.open()` against the balance-load tab-remount race.
