### PR TITLE
ci: allow qa team to update e2e files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # The @ava-labs/core-qa team owns the end-to-end tests and can
 # update files in the e2e directory without approval from the
 # default codeowners.
-/e2e/ @ava-labs/core-qa
+/e2e/ @ava-labs/core-qa @ava-labs/core-web-ext

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,8 @@
 # @ava-labs/core-web-ext team will be requested for
 # review when someone opens a pull request.
 * @ava-labs/core-web-ext
+
+# The @ava-labs/core-qa team owns the end-to-end tests and can
+# update files in the e2e directory without approval from the
+# default codeowners.
+/e2e/ @ava-labs/core-qa


### PR DESCRIPTION
## Notes
Allow @ava-labs/core-qa to update E2E files without involving the dev team.