### PR TITLE
fix(security): implement SIWE domain mismatch detection

### DIFF
--- a/packages/service-worker/src/vmModules/ApprovalController.test.ts
+++ b/packages/service-worker/src/vmModules/ApprovalController.test.ts
@@ -493,6 +493,84 @@ describe('src/background/vmModules/ApprovalController', () => {
         expect(await promise).toEqual({ signedData: signedTx });
       });
     });
+
+    describe('SIWE domain mismatch detection', () => {
+      const account = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+
+      const buildSiweApprovalParams = (
+        siweDomain: string,
+      ): ApprovalParamsWithContext => {
+        const message = `${siweDomain} wants you to sign in with your Ethereum account:
+${account}
+
+Sign in to Example App
+
+URI: https://${siweDomain}/login
+Version: 1
+Chain ID: 1
+Nonce: 32891756
+Issued At: 2021-09-30T16:25:24Z`;
+        const hexMessage = `0x${Buffer.from(message, 'utf8').toString('hex')}`;
+
+        return {
+          request: {
+            chainId: chainIdToCaip(cChain.chainId),
+            method: RpcMethod.PERSONAL_SIGN,
+            requestId: 'requestId',
+            sessionId: 'sessionId',
+            dappInfo,
+            context: {
+              tabId: 1234,
+            },
+            params: [hexMessage, account],
+          },
+          displayData: {
+            title: 'Sign Message',
+            details: [],
+          },
+          signingData: {
+            type: RpcMethod.PERSONAL_SIGN,
+            account,
+            data: hexMessage,
+          },
+        };
+      };
+
+      it('opens the approval window with a DANGER alert when the SIWE domain does not match the dApp origin', async () => {
+        controller.requestApproval(buildSiweApprovalParams('evil.com'));
+
+        await new Promise(process.nextTick);
+
+        expect(openApprovalWindow).toHaveBeenCalledWith(
+          expect.objectContaining({
+            displayData: expect.objectContaining({
+              alert: expect.objectContaining({
+                type: AlertType.DANGER,
+                details: expect.objectContaining({
+                  title: 'Sign-In Request Mismatch',
+                }),
+              }),
+            }),
+          }),
+          'approve/generic',
+        );
+      });
+
+      it('opens the approval window without an alert when the SIWE domain matches the dApp origin', async () => {
+        controller.requestApproval(buildSiweApprovalParams('extension.url'));
+
+        await new Promise(process.nextTick);
+
+        expect(openApprovalWindow).toHaveBeenCalledWith(
+          expect.objectContaining({
+            displayData: expect.not.objectContaining({
+              alert: expect.anything(),
+            }),
+          }),
+          'approve/generic',
+        );
+      });
+    });
   });
 
   describe('requestBatchApproval()', () => {

--- a/packages/service-worker/src/vmModules/ApprovalController.ts
+++ b/packages/service-worker/src/vmModules/ApprovalController.ts
@@ -41,6 +41,7 @@ import {
 import { batchSwapValidator, swapValidator } from './validators';
 import { TransactionStatusEvents } from '../services/transactions/events/transactionStatusEvents';
 import { isUserRejectionError } from '@core/common';
+import { maybeInjectSiweAlert } from './utils/siwe';
 
 // Create and populate the validator registry
 const validatorRegistry = new ValidatorRegistry();
@@ -262,7 +263,17 @@ export class ApprovalController implements BatchApprovalController {
     }
 
     const actionId = crypto.randomUUID();
-    const action = this.#buildAction(params, actionId);
+
+    // Warn the user if a SIWE message's domain does not match the dApp origin
+    const paramsWithSiweCheck = {
+      ...params,
+      displayData: maybeInjectSiweAlert({
+        request: params.request,
+        signingData: params.signingData,
+        displayData: params.displayData,
+      }),
+    };
+    const action = this.#buildAction(paramsWithSiweCheck, actionId);
 
     // Get validator by type from context
     let validator = context?.swapAutoApprove?.validatorType
@@ -271,19 +282,23 @@ export class ApprovalController implements BatchApprovalController {
 
     if (validator) {
       // Verify the validator can actually handle this request
-      if (!validator.canHandle(params)) {
+      if (!validator.canHandle(paramsWithSiweCheck)) {
         validator = undefined;
       }
     }
 
     if (validator) {
-      const validation = validator.validateAction(action, params);
+      const validation = validator.validateAction(action, paramsWithSiweCheck);
 
       // If alert already exists (e.g., Blockaid warning), require manual approval
       const hasExistingAlert = Boolean(action.displayData.alert);
 
       if (validation.isValid && !hasExistingAlert) {
-        return await this.#executeAutoApproval(params, action, network);
+        return await this.#executeAutoApproval(
+          paramsWithSiweCheck,
+          action,
+          network,
+        );
       } else if (validation.requiresManualApproval || hasExistingAlert) {
         // Only set alert if not already populated
         action.displayData.alert ??= {
@@ -308,7 +323,7 @@ export class ApprovalController implements BatchApprovalController {
 
     return new Promise((resolve) => {
       this.#requests.set(actionId, {
-        params,
+        params: paramsWithSiweCheck,
         network,
         resolve,
       });

--- a/packages/service-worker/src/vmModules/utils/siwe/getSiweAlert.test.ts
+++ b/packages/service-worker/src/vmModules/utils/siwe/getSiweAlert.test.ts
@@ -1,0 +1,128 @@
+import { AlertType, RpcMethod } from '@avalabs/vm-module-types';
+import type {
+  DisplayData,
+  RpcRequest,
+  SigningData,
+} from '@avalabs/vm-module-types';
+
+import { maybeInjectSiweAlert } from './getSiweAlert';
+
+const toHex = (message: string) =>
+  `0x${Buffer.from(message, 'utf8').toString('hex')}`;
+
+const buildSiweMessage = (domain: string, uri: string) =>
+  `${domain} wants you to sign in with your Ethereum account:
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+Sign in to Example App
+
+URI: ${uri}
+Version: 1
+Chain ID: 1
+Nonce: 32891756
+Issued At: 2021-09-30T16:25:24Z`;
+
+const buildRequest = (url: string): RpcRequest =>
+  ({
+    dappInfo: {
+      icon: 'icon',
+      name: 'name',
+      url,
+    },
+  }) as RpcRequest;
+
+const buildSigningData = (message: string): SigningData => ({
+  type: RpcMethod.PERSONAL_SIGN,
+  account: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+  data: toHex(message),
+});
+
+const displayData: DisplayData = {
+  title: 'Sign Message',
+  details: [],
+};
+
+describe('maybeInjectSiweAlert', () => {
+  it('injects a DANGER alert when SIWE domain does not match the dApp origin', () => {
+    const result = maybeInjectSiweAlert({
+      request: buildRequest('https://example.com'),
+      signingData: buildSigningData(
+        buildSiweMessage('evil.com', 'https://evil.com/login'),
+      ),
+      displayData,
+    });
+
+    expect(result.alert).toBeDefined();
+    expect(result.alert?.type).toBe(AlertType.DANGER);
+    expect(result.alert?.details.title).toBe('Sign-In Request Mismatch');
+  });
+
+  it('returns displayData untouched when SIWE domain matches the dApp origin', () => {
+    const result = maybeInjectSiweAlert({
+      request: buildRequest('https://example.com'),
+      signingData: buildSigningData(
+        buildSiweMessage('example.com', 'https://example.com/login'),
+      ),
+      displayData,
+    });
+
+    expect(result).toBe(displayData);
+  });
+
+  it('ignores methods other than personal_sign', () => {
+    const result = maybeInjectSiweAlert({
+      request: buildRequest('https://example.com'),
+      signingData: {
+        type: RpcMethod.ETH_SIGN,
+        account: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+        data: toHex(buildSiweMessage('evil.com', 'https://evil.com/login')),
+      },
+      displayData,
+    });
+
+    expect(result).toBe(displayData);
+  });
+
+  it('does not override an existing alert (e.g. from Blockaid)', () => {
+    const existingAlert = {
+      type: AlertType.WARNING,
+      details: {
+        title: 'Existing alert',
+        description: 'Existing description',
+      },
+    };
+    const result = maybeInjectSiweAlert({
+      request: buildRequest('https://example.com'),
+      signingData: buildSigningData(
+        buildSiweMessage('evil.com', 'https://evil.com/login'),
+      ),
+      displayData: { ...displayData, alert: existingAlert },
+    });
+
+    expect(result.alert).toBe(existingAlert);
+  });
+
+  it('ignores messages that are not SIWE', () => {
+    const result = maybeInjectSiweAlert({
+      request: buildRequest('https://example.com'),
+      signingData: buildSigningData('Hello world'),
+      displayData,
+    });
+
+    expect(result).toBe(displayData);
+  });
+
+  it('handles plain-text (non-hex) personal_sign payloads', () => {
+    const result = maybeInjectSiweAlert({
+      request: buildRequest('https://example.com'),
+      signingData: {
+        type: RpcMethod.PERSONAL_SIGN,
+        account: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+        data: 'Hello world',
+      },
+      displayData,
+    });
+
+    expect(result).toBe(displayData);
+  });
+});

--- a/packages/service-worker/src/vmModules/utils/siwe/getSiweAlert.ts
+++ b/packages/service-worker/src/vmModules/utils/siwe/getSiweAlert.ts
@@ -1,0 +1,54 @@
+import { RpcMethod } from '@avalabs/vm-module-types';
+import type {
+  DisplayData,
+  RpcRequest,
+  SigningData,
+} from '@avalabs/vm-module-types';
+
+import { parseSiweMessage } from './parseSiweMessage';
+import { validateSiweOrigin } from './validateSiweOrigin';
+
+/**
+ * For personal_sign requests, checks whether the message is a SIWE (EIP-4361)
+ * message and validates that its domain/URI matches the requesting dApp.
+ *
+ * Returns an updated displayData with an alert injected if there is a mismatch,
+ * or the original displayData if no issue is found.
+ */
+export function maybeInjectSiweAlert({
+  request,
+  signingData,
+  displayData,
+}: {
+  request: RpcRequest;
+  signingData: SigningData;
+  displayData: DisplayData;
+}): DisplayData {
+  if (signingData.type !== RpcMethod.PERSONAL_SIGN) return displayData;
+
+  // Already has an alert from simulation/Blockaid — don't override it
+  if (displayData.alert) return displayData;
+
+  const message = hexToUtf8(signingData.data);
+  if (!message) return displayData;
+
+  const siwe = parseSiweMessage(message);
+  if (!siwe) return displayData;
+
+  const alert = validateSiweOrigin(siwe, request.dappInfo.url);
+  if (!alert) return displayData;
+
+  return { ...displayData, alert };
+}
+
+function hexToUtf8(hex: string): string | undefined {
+  try {
+    const cleaned = hex.startsWith('0x') ? hex.slice(2) : hex;
+    const bytes = new Uint8Array(
+      cleaned.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) ?? [],
+    );
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/service-worker/src/vmModules/utils/siwe/index.ts
+++ b/packages/service-worker/src/vmModules/utils/siwe/index.ts
@@ -1,0 +1,3 @@
+export * from './getSiweAlert';
+export * from './parseSiweMessage';
+export * from './validateSiweOrigin';

--- a/packages/service-worker/src/vmModules/utils/siwe/parseSiweMessage.test.ts
+++ b/packages/service-worker/src/vmModules/utils/siwe/parseSiweMessage.test.ts
@@ -1,0 +1,105 @@
+import { parseSiweMessage } from './parseSiweMessage';
+
+const VALID_SIWE_MESSAGE = `example.com wants you to sign in with your Ethereum account:
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+Sign in to Example App
+
+URI: https://example.com/login
+Version: 1
+Chain ID: 1
+Nonce: 32891756
+Issued At: 2021-09-30T16:25:24Z`;
+
+const MINIMAL_SIWE_MESSAGE = `example.com wants you to sign in with your Ethereum account:
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+URI: https://example.com/login
+Version: 1
+Chain ID: 1
+Nonce: abc123
+Issued At: 2021-09-30T16:25:24Z`;
+
+const FULL_SIWE_MESSAGE = `example.com wants you to sign in with your Ethereum account:
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+I accept the Terms of Service: https://example.com/tos
+
+URI: https://example.com/login
+Version: 1
+Chain ID: 1
+Nonce: 32891756
+Issued At: 2021-09-30T16:25:24Z
+Expiration Time: 2021-10-01T16:25:24Z
+Not Before: 2021-09-30T16:25:24Z
+Request ID: some-request-id
+Resources:
+- https://example.com/resource1
+- https://example.com/resource2`;
+
+describe('parseSiweMessage', () => {
+  it('parses a valid SIWE message with statement', () => {
+    const result = parseSiweMessage(VALID_SIWE_MESSAGE);
+    expect(result).toEqual({
+      domain: 'example.com',
+      address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      statement: 'Sign in to Example App',
+      uri: 'https://example.com/login',
+      version: '1',
+      chainId: '1',
+      nonce: '32891756',
+      issuedAt: '2021-09-30T16:25:24Z',
+      expirationTime: undefined,
+      notBefore: undefined,
+      requestId: undefined,
+      resources: undefined,
+    });
+  });
+
+  it('parses a minimal SIWE message without statement', () => {
+    const result = parseSiweMessage(MINIMAL_SIWE_MESSAGE);
+    expect(result).toBeDefined();
+    expect(result?.domain).toBe('example.com');
+    expect(result?.statement).toBeUndefined();
+  });
+
+  it('parses all optional fields', () => {
+    const result = parseSiweMessage(FULL_SIWE_MESSAGE);
+    expect(result).toBeDefined();
+    expect(result?.expirationTime).toBe('2021-10-01T16:25:24Z');
+    expect(result?.notBefore).toBe('2021-09-30T16:25:24Z');
+    expect(result?.requestId).toBe('some-request-id');
+    expect(result?.resources).toEqual([
+      'https://example.com/resource1',
+      'https://example.com/resource2',
+    ]);
+  });
+
+  it('returns undefined for non-SIWE messages', () => {
+    expect(parseSiweMessage('Hello world')).toBeUndefined();
+    expect(parseSiweMessage('')).toBeUndefined();
+    expect(parseSiweMessage('Please sign this message')).toBeUndefined();
+  });
+
+  it('returns undefined when required fields are missing', () => {
+    const incomplete = `example.com wants you to sign in with your Ethereum account:
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+URI: https://example.com/login
+Version: 1`;
+    expect(parseSiweMessage(incomplete)).toBeUndefined();
+  });
+
+  it('handles domain with port', () => {
+    const message = `localhost:3000 wants you to sign in with your Ethereum account:
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+URI: http://localhost:3000
+Version: 1
+Chain ID: 1
+Nonce: abc
+Issued At: 2021-09-30T16:25:24Z`;
+    const result = parseSiweMessage(message);
+    expect(result?.domain).toBe('localhost:3000');
+  });
+});

--- a/packages/service-worker/src/vmModules/utils/siwe/parseSiweMessage.ts
+++ b/packages/service-worker/src/vmModules/utils/siwe/parseSiweMessage.ts
@@ -1,0 +1,100 @@
+/**
+ * Minimal EIP-4361 (Sign-In with Ethereum) message parser.
+ *
+ * Reference: https://eips.ethereum.org/EIPS/eip-4361
+ *
+ * Message format:
+ * ${domain} wants you to sign in with your Ethereum account:\n
+ * ${address}\n
+ * \n
+ * ${statement (optional)}\n
+ * \n
+ * URI: ${uri}\n
+ * Version: ${version}\n
+ * Chain ID: ${chain-id}\n
+ * Nonce: ${nonce}\n
+ * Issued At: ${issued-at}\n
+ * [Expiration Time: ...]\n
+ * [Not Before: ...]\n
+ * [Request ID: ...]\n
+ * [Resources:\n- ...\n- ...]
+ */
+
+export type SiweMessage = {
+  domain: string;
+  address: string;
+  uri: string;
+  version: string;
+  chainId: string;
+  nonce: string;
+  issuedAt: string;
+  statement?: string;
+  expirationTime?: string;
+  notBefore?: string;
+  requestId?: string;
+  resources?: string[];
+};
+
+const SIWE_HEADER_REGEX =
+  /^(?<domain>[^ ]+) wants you to sign in with your Ethereum account:\n(?<address>0x[a-fA-F0-9]{40})\n/;
+
+export function parseSiweMessage(message: string): SiweMessage | undefined {
+  const headerMatch = SIWE_HEADER_REGEX.exec(message);
+  if (!headerMatch?.groups) return undefined;
+
+  const { domain, address } = headerMatch.groups as {
+    domain: string;
+    address: string;
+  };
+
+  const uri = extractField(message, 'URI');
+  const version = extractField(message, 'Version');
+  const chainId = extractField(message, 'Chain ID');
+  const nonce = extractField(message, 'Nonce');
+  const issuedAt = extractField(message, 'Issued At');
+
+  if (!uri || !version || !chainId || !nonce || !issuedAt) return undefined;
+
+  const statement = extractStatement(message, headerMatch[0]);
+
+  return {
+    domain,
+    address,
+    uri,
+    version,
+    chainId,
+    nonce,
+    issuedAt,
+    statement: statement || undefined,
+    expirationTime: extractField(message, 'Expiration Time') || undefined,
+    notBefore: extractField(message, 'Not Before') || undefined,
+    requestId: extractField(message, 'Request ID') || undefined,
+    resources: extractResources(message),
+  };
+}
+
+function extractField(message: string, fieldName: string): string | undefined {
+  const regex = new RegExp(`^${fieldName}: (.+)$`, 'm');
+  return regex.exec(message)?.[1]?.trim();
+}
+
+function extractStatement(
+  message: string,
+  headerText: string,
+): string | undefined {
+  const afterHeader = message.slice(headerText.length);
+  const match = /^\n([\s\S]*?)\n\nURI: /m.exec(afterHeader);
+  return match?.[1]?.trim() || undefined;
+}
+
+function extractResources(message: string): string[] | undefined {
+  const match = /\nResources:\n([\s\S]*)$/.exec(message);
+  if (!match?.[1]) return undefined;
+
+  const resources = match[1]
+    .split('\n')
+    .map((line) => line.replace(/^- /, '').trim())
+    .filter(Boolean);
+
+  return resources.length > 0 ? resources : undefined;
+}

--- a/packages/service-worker/src/vmModules/utils/siwe/validateSiweOrigin.test.ts
+++ b/packages/service-worker/src/vmModules/utils/siwe/validateSiweOrigin.test.ts
@@ -1,0 +1,213 @@
+import { AlertType } from '@avalabs/vm-module-types';
+
+import type { SiweMessage } from './parseSiweMessage';
+import { validateSiweOrigin } from './validateSiweOrigin';
+
+const baseSiwe: SiweMessage = {
+  domain: 'example.com',
+  address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+  uri: 'https://example.com/login',
+  version: '1',
+  chainId: '1',
+  nonce: '123',
+  issuedAt: '2021-09-30T16:25:24Z',
+};
+
+describe('validateSiweOrigin', () => {
+  it('returns undefined when domain and URI match dApp origin', () => {
+    const result = validateSiweOrigin(baseSiwe, 'https://example.com');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when dApp URL has a path', () => {
+    const result = validateSiweOrigin(
+      baseSiwe,
+      'https://example.com/some/path',
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('returns DANGER alert on domain mismatch', () => {
+    const siwe = { ...baseSiwe, domain: 'evil.com' };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(AlertType.DANGER);
+    expect(result?.details.body?.[0]).toContain(
+      'Domain "evil.com" doesn\'t match dApp origin "example.com".',
+    );
+  });
+
+  it('returns DANGER alert on scheme mismatch', () => {
+    const siwe = { ...baseSiwe, uri: 'http://example.com/login' };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(AlertType.DANGER);
+    expect(result?.details.body?.[0]).toContain(
+      'URI "http://example.com/login" doesn\'t match dApp origin "example.com".',
+    );
+  });
+
+  it('returns DANGER alert on port mismatch', () => {
+    const siwe = {
+      ...baseSiwe,
+      domain: 'localhost:3000',
+      uri: 'http://localhost:3000',
+    };
+    const result = validateSiweOrigin(siwe, 'http://localhost:4000');
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(AlertType.DANGER);
+    expect(result?.details.body?.[0]).toContain(
+      'URI "http://localhost:3000" doesn\'t match dApp origin "http://localhost:4000".',
+    );
+  });
+
+  it('detects similar port numbers (e.g., 443 vs 4433)', () => {
+    const siwe = {
+      ...baseSiwe,
+      uri: 'https://example.com:4433/login',
+    };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(AlertType.DANGER);
+    expect(result?.details.body?.[0]).toContain(
+      'URI "https://example.com:4433/login" doesn\'t match dApp origin "example.com".',
+    );
+  });
+
+  it('treats default HTTPS port 443 as equivalent to no port', () => {
+    const siwe = {
+      ...baseSiwe,
+      uri: 'https://example.com:443/login',
+    };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result).toBeUndefined();
+  });
+
+  it('treats default HTTP port 80 as equivalent to no port', () => {
+    const siwe = {
+      ...baseSiwe,
+      uri: 'http://example.com:80/login',
+    };
+    const result = validateSiweOrigin(siwe, 'http://example.com');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns DANGER when URI host differs from dApp origin', () => {
+    const siwe = {
+      ...baseSiwe,
+      uri: 'https://evil.com/login',
+    };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(AlertType.DANGER);
+    expect(result?.details.body?.[0]).toContain(
+      'URI "https://evil.com/login" doesn\'t match dApp origin "example.com".',
+    );
+  });
+
+  it('is case-insensitive for domains', () => {
+    const siwe = { ...baseSiwe, domain: 'Example.COM' };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when dApp URL cannot be parsed', () => {
+    const result = validateSiweOrigin(baseSiwe, '');
+    expect(result).toBeUndefined();
+  });
+
+  it('handles dApp URL without scheme', () => {
+    const result = validateSiweOrigin(baseSiwe, 'example.com');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when domain includes matching scheme', () => {
+    const siwe = { ...baseSiwe, domain: 'https://example.com' };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns DANGER when domain includes mismatched scheme', () => {
+    const siwe = { ...baseSiwe, domain: 'http://example.com' };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(AlertType.DANGER);
+  });
+
+  it('returns undefined when domain has no scheme (scheme is optional per EIP-4361)', () => {
+    const siwe = { ...baseSiwe, domain: 'example.com' };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when domain includes matching port', () => {
+    const siwe = {
+      ...baseSiwe,
+      domain: 'localhost:3000',
+      uri: 'http://localhost:3000',
+    };
+    const result = validateSiweOrigin(siwe, 'http://localhost:3000');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns DANGER when domain includes mismatched port', () => {
+    const siwe = {
+      ...baseSiwe,
+      domain: 'localhost:3000',
+      uri: 'http://localhost:4000',
+    };
+    const result = validateSiweOrigin(siwe, 'http://localhost:4000');
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(AlertType.DANGER);
+  });
+
+  it('returns undefined when domain has scheme and port that match', () => {
+    const siwe = {
+      ...baseSiwe,
+      domain: 'http://localhost:3000',
+      uri: 'http://localhost:3000',
+    };
+    const result = validateSiweOrigin(siwe, 'http://localhost:3000');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns DANGER when domain has scheme and port with scheme mismatch', () => {
+    const siwe = {
+      ...baseSiwe,
+      domain: 'http://localhost:3000',
+      uri: 'https://localhost:3000',
+    };
+    const result = validateSiweOrigin(siwe, 'https://localhost:3000');
+    expect(result).toBeDefined();
+    expect(result?.type).toBe(AlertType.DANGER);
+  });
+
+  it('reports multiple mismatches at once', () => {
+    const siwe = {
+      ...baseSiwe,
+      domain: 'evil.com',
+      uri: 'http://evil.com:8080/login',
+    };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result).toBeDefined();
+    expect(result?.details.body?.[0]).toContain(
+      'Domain "evil.com" doesn\'t match dApp origin "example.com".',
+    );
+    expect(result?.details.body?.[0]).toContain(
+      'URI "http://evil.com:8080/login" doesn\'t match dApp origin "example.com".',
+    );
+  });
+
+  it('keeps all reasons in the first body line and the caution note in the second', () => {
+    const siwe = {
+      ...baseSiwe,
+      domain: 'evil.com',
+      uri: 'http://evil.com:8080/login',
+    };
+    const result = validateSiweOrigin(siwe, 'https://example.com');
+    expect(result?.details.body).toHaveLength(2);
+    expect(result?.details.body?.[1]).toBe(
+      'This could be a phishing attempt. Proceed with caution.',
+    );
+  });
+});

--- a/packages/service-worker/src/vmModules/utils/siwe/validateSiweOrigin.ts
+++ b/packages/service-worker/src/vmModules/utils/siwe/validateSiweOrigin.ts
@@ -1,0 +1,144 @@
+import { AlertType } from '@avalabs/vm-module-types';
+
+import type { SiweMessage } from './parseSiweMessage';
+
+// Same shape as the vm-module-types Alert, widened with the `body` field
+// that MaliciousTxOverlay renders for itemized warnings.
+export type SiweAlert = {
+  type: AlertType;
+  details: {
+    title: string;
+    description: string;
+    body?: string[];
+  };
+};
+
+/**
+ * Compares the SIWE message's domain and URI against the requesting dApp's
+ * origin URL. Returns a DANGER alert if there is a mismatch in domain,
+ * scheme, or port — which may indicate a phishing attempt.
+ */
+export function validateSiweOrigin(
+  siwe: SiweMessage,
+  dappUrl: string,
+): SiweAlert | undefined {
+  const dappOrigin = safeParseUrl(dappUrl);
+  const siweUri = safeParseUrl(siwe.uri);
+
+  if (!dappOrigin) return undefined;
+
+  const parsedDomain = safeParseUrl(siwe.domain);
+  const domainHasScheme = siwe.domain.includes('://');
+
+  const domainMismatch = parsedDomain
+    ? domainFieldMismatch(parsedDomain, domainHasScheme, dappOrigin)
+    : normalizeDomain(siwe.domain) !==
+      normalizeDomain(dappOrigin.hostname ?? '');
+
+  const uriMismatch =
+    siweUri !== undefined &&
+    (normalizeScheme(siweUri.protocol) !==
+      normalizeScheme(dappOrigin.protocol) ||
+      effectivePort(siweUri) !== effectivePort(dappOrigin) ||
+      normalizeDomain(siweUri.hostname ?? '') !==
+        normalizeDomain(dappOrigin.hostname ?? ''));
+
+  if (!domainMismatch && !uriMismatch) return undefined;
+
+  const dappHostname = dappOrigin.hostname ?? dappUrl;
+  const dappDisplay = formatOrigin(dappOrigin, dappUrl);
+  const reasons: string[] = [];
+  if (domainMismatch)
+    reasons.push(
+      `Domain "${siwe.domain}" doesn't match dApp origin "${dappHostname}".`,
+    );
+  if (uriMismatch)
+    reasons.push(
+      `URI "${siwe.uri}" doesn't match dApp origin "${dappDisplay}".`,
+    );
+
+  // MaliciousTxOverlay renders body[0] as the description and body[1] as an
+  // underlined call-to-action, so keep all reasons in a single first line.
+  return {
+    type: AlertType.DANGER,
+    details: {
+      title: 'Sign-In Request Mismatch',
+      description: 'This could be a phishing attempt. Proceed with caution.',
+      body: [
+        reasons.join(' '),
+        'This could be a phishing attempt. Proceed with caution.',
+      ],
+    },
+  };
+}
+
+function safeParseUrl(url: string): URL | undefined {
+  try {
+    // Handle bare domains (no scheme) by prepending https://
+    if (!url.includes('://')) {
+      return new URL(`https://${url}`);
+    }
+    return new URL(url);
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeDomain(domain: string): string {
+  return domain.toLowerCase().replace(/\.$/, '');
+}
+
+function normalizeScheme(protocol: string): string {
+  return protocol.replace(/:$/, '').toLowerCase();
+}
+
+const DEFAULT_PORTS: Record<string, string> = {
+  'http:': '80',
+  'https:': '443',
+};
+
+function effectivePort(url: URL): string {
+  return url.port || DEFAULT_PORTS[url.protocol] || '';
+}
+
+function domainFieldMismatch(
+  parsedDomain: URL,
+  hasScheme: boolean,
+  dappOrigin: URL,
+): boolean {
+  if (
+    normalizeDomain(parsedDomain.hostname) !==
+    normalizeDomain(dappOrigin.hostname ?? '')
+  ) {
+    return true;
+  }
+
+  if (
+    hasScheme &&
+    normalizeScheme(parsedDomain.protocol) !==
+      normalizeScheme(dappOrigin.protocol)
+  ) {
+    return true;
+  }
+
+  return (
+    parsedDomain.port !== '' &&
+    effectivePort(parsedDomain) !== effectivePort(dappOrigin)
+  );
+}
+
+function formatOrigin(url: URL, fallback: string): string {
+  const hostname = url.hostname || fallback;
+  const scheme = normalizeScheme(url.protocol);
+  const isStandardScheme = scheme === 'https';
+  const hasNonStandardPort = url.port !== '';
+
+  let result = hostname;
+  if (!isStandardScheme) {
+    result = `${scheme}://${result}`;
+  }
+  if (hasNonStandardPort) {
+    result = `${result}:${url.port}`;
+  }
+  return result;
+}


### PR DESCRIPTION
Ported SIWE domain mismatch logic from core-mobile and created an alert

# Summary

Jira ticket: CP-14527
Figma: No figma for this.

I reused the alert from blockaid alerting. Everything else is ported pretty much 1:1 from the implementation in core-mobile.


<!-- Describe the changes -->
<!-- Link the Jira ticket and Figma designs. Prefer listing expectations vs. linking large docs like PRD -->

## Notes

Parses an SIWE signature request and then checks the dapp origin vs the {domain} and {URI} fields https://eips.ethereum.org/EIPS/eip-4361

<!-- Additional notes and context. Explain non-synchronized design, product, or architectural design decisions -->

## Testing

<!-- Add high-level testing information for the reviewer to properly QA (wallet setup, local storage overrides, etc.) -->

Test to make sure that SIWE mismatches cause an alert and that wellformed SIWE requests do not cause an alert to fire.

## Testing Instructions

<!-- Add expected testing steps - be specific about whether or not you have a wallet connected, new routes, etc. -->

## Media
<img width="399" height="728" alt="Screenshot 2026-06-22 at 3 56 40 PM" src="https://github.com/user-attachments/assets/08ec7085-f9c1-45eb-8930-76ab5575d7f1" />
<img width="398" height="743" alt="Screenshot 2026-06-22 at 3 56 52 PM" src="https://github.com/user-attachments/assets/a1442a61-77ba-4fad-9a71-2ec5e20b0fa2" />



<!-- Add screenshots and videos of the feature/changes. Great opportunity to self-QA before sharing PR -->
<!-- Bonus points for including a Loom demoing features and explaining code changes -->
