### PR TITLE
feat: add spender address to erc20 token approval screen

### DIFF
--- a/apps/next/src/localization/locales/en/translation.json
+++ b/apps/next/src/localization/locales/en/translation.json
@@ -809,6 +809,7 @@
   "Special offers and promotions": "Special offers and promotions",
   "Spend limit": "Spend limit",
   "Spend limit approved": "Spend limit approved",
+  "Spender": "Spender",
   "Staked": "Staked",
   "Start recurring swap": "Start recurring swap",
   "Status": "Status",

--- a/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmActionDetails.tsx
+++ b/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmActionDetails.tsx
@@ -52,7 +52,9 @@ export const EvmActionDetails = ({
         outs={action.displayData.balanceChange?.outs ?? []}
         isSimulationSuccessful={action.displayData.isSimulationSuccessful}
       />
-      {hasTokenApprovals(action) && <EvmTokenApprovals action={action} />}
+      {hasTokenApprovals(action) && (
+        <EvmTokenApprovals action={action} network={network} />
+      )}
       {action.displayData.details.map((section) => (
         <DetailsSection key={section.title}>
           {section.items.map((item, index) => (

--- a/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmTokenApprovals/EvmTokenApprovals.tsx
+++ b/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmTokenApprovals/EvmTokenApprovals.tsx
@@ -2,19 +2,35 @@ import { Stack } from '@avalabs/k2-alpine';
 import { FC, useRef } from 'react';
 import { DisplayData } from '@avalabs/vm-module-types';
 
-import { Action, EnsureDefined } from '@core/types';
+import { Action, EnsureDefined, EvmNetwork } from '@core/types';
 import { useTokenPrice } from '@core/ui';
 
 import { DetailsSection } from '../../generic/DetailsSection';
 import { getApprovalValue, isUnlimitedApproval } from './lib';
-import { CustomApprovalLimit, TokenSpendLimitCard } from './components';
+import {
+  CustomApprovalLimit,
+  SpenderDetail,
+  TokenSpendLimitCard,
+} from './components';
 
 type EvmTokenApprovalsProps = {
   action: Action<EnsureDefined<DisplayData, 'tokenApprovals'>>;
+  network: EvmNetwork;
 };
 
-export const EvmTokenApprovals: FC<EvmTokenApprovalsProps> = ({ action }) => {
+export const EvmTokenApprovals: FC<EvmTokenApprovalsProps> = ({
+  action,
+  network,
+}) => {
   const { tokenApprovals } = action.displayData;
+
+  const spenderAddresses = [
+    ...new Set(
+      tokenApprovals.approvals
+        .map((approval) => approval.spenderAddress)
+        .filter(Boolean),
+    ),
+  ];
 
   const requestedApprovalRef = useRef(tokenApprovals.approvals[0]);
   const hasOnlyOneEditableApproval =
@@ -55,6 +71,17 @@ export const EvmTokenApprovals: FC<EvmTokenApprovalsProps> = ({ action }) => {
           />
         ))}
       </DetailsSection>
+      {spenderAddresses.length > 0 && (
+        <DetailsSection>
+          {spenderAddresses.map((spenderAddress) => (
+            <SpenderDetail
+              key={spenderAddress}
+              spenderAddress={spenderAddress}
+              network={network}
+            />
+          ))}
+        </DetailsSection>
+      )}
       {hasOnlyOneEditableApproval && firstApproval && requestedApproval && (
         <CustomApprovalLimit
           action={action}

--- a/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmTokenApprovals/components/SpenderDetail.tsx
+++ b/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmTokenApprovals/components/SpenderDetail.tsx
@@ -1,0 +1,54 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  IconButton,
+  OutboundIcon,
+  Stack,
+  Tooltip,
+  truncateAddress,
+  Typography,
+} from '@avalabs/k2-alpine';
+
+import { getExplorerAddressByNetwork } from '@core/common';
+import { NetworkWithCaipId } from '@core/types';
+
+import { TxDetailsRow } from '../../../generic/DetailsItem/items/DetailRow';
+
+type SpenderDetailProps = {
+  spenderAddress: string;
+  network: NetworkWithCaipId;
+};
+
+export const SpenderDetail: FC<SpenderDetailProps> = ({
+  spenderAddress,
+  network,
+}) => {
+  const { t } = useTranslation();
+  const explorerLink = getExplorerAddressByNetwork(
+    network,
+    spenderAddress,
+    'address',
+  );
+
+  return (
+    <TxDetailsRow label={t('Spender')}>
+      <Stack direction="row" alignItems="center" gap={0.5}>
+        <Typography variant="mono" color="text.secondary">
+          {truncateAddress(spenderAddress, 10)}
+        </Typography>
+        <Tooltip title={t('View in Explorer')} arrow>
+          <IconButton
+            sx={{ padding: 0.25 }}
+            size="small"
+            onClick={async () => {
+              window.open(explorerLink, '_blank', 'noreferrer');
+            }}
+            data-testid="spender-explorer-link"
+          >
+            <OutboundIcon size={16} viewBox="0 0 24 24" />
+          </IconButton>
+        </Tooltip>
+      </Stack>
+    </TxDetailsRow>
+  );
+};

--- a/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmTokenApprovals/components/index.ts
+++ b/apps/next/src/pages/Approve/components/ActionDetails/evm/EvmTokenApprovals/components/index.ts
@@ -2,3 +2,4 @@ export * from './CustomApprovalLimit';
 export * from './InfinitySymbol';
 export * from './AmountInput';
 export * from './TokenSpendLimitCard';
+export * from './SpenderDetail';


### PR DESCRIPTION
# Summary

Jira ticket: CP-14528
Figma:

<!-- Describe the changes -->
<!-- Link the Jira ticket and Figma designs. Prefer listing expectations vs. linking large docs like PRD -->
Adds the spender field from ERC20 spend approvals as a field with a link to the explorer.

## Notes

<!-- Additional notes and context. Explain non-synchronized design, product, or architectural design decisions -->

## Testing

<!-- Add high-level testing information for the reviewer to properly QA (wallet setup, local storage overrides, etc.) -->

## Testing Instructions


Initiate an erc20 spend approval tx and make sure the spender address is correctly displayed.
<!-- Add expected testing steps - be specific about whether or not you have a wallet connected, new routes, etc. -->

## Media

<img width="322" height="666" alt="Screenshot 2026-06-23 at 2 37 07 PM" src="https://github.com/user-attachments/assets/3a31065f-35e7-441a-8dc0-121c00fbef6b" />

<!-- Add screenshots and videos of the feature/changes. Great opportunity to self-QA before sharing PR -->
<!-- Bonus points for including a Loom demoing features and explaining code changes -->
