### PR TITLE
fix: dca swaps issues, 1st QA round

### DIFF
--- a/apps/next/lavamoat/rspack/policy.json
+++ b/apps/next/lavamoat/rspack/policy.json
@@ -382,6 +382,7 @@
         "@avalabs/core-chains-sdk": true,
         "@avalabs/core-utils-sdk": true,
         "@avalabs/core-wallets-sdk": true,
+        "@avalabs/fusion-sdk": true,
         "@core/ui>@avalabs/glacier-sdk": true,
         "@core/ui>@avalabs/hw-app-avalanche": true,
         "@avalabs/k2-alpine": true,

--- a/apps/next/src/components/Transactions/TransactionsProviderWithConfetti.test.tsx
+++ b/apps/next/src/components/Transactions/TransactionsProviderWithConfetti.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@shared/tests/test-utils';
 import { ChainId, NetworkVMType } from '@avalabs/core-chains-sdk';
-import { NetworkWithCaipId } from '@core/types';
+import { NetworkWithCaipId, RecurringSwapAction } from '@core/types';
 import { TransactionStatusProviderWithConfetti } from './TransactionsProviderWithConfetti';
 import { useIsOptimisticConfirmationEnabled } from '@core/ui';
 
 type CapturedContext = {
-  recurringSwaps?: { action: 'schedule' | 'pause' | 'unpause' | 'cancel' };
+  recurringSwaps?: { action: RecurringSwapAction };
 };
 
 const mockTriggerConfetti = jest.fn();

--- a/apps/next/src/components/Transactions/TransactionsProviderWithConfetti.test.tsx
+++ b/apps/next/src/components/Transactions/TransactionsProviderWithConfetti.test.tsx
@@ -4,13 +4,23 @@ import { NetworkWithCaipId } from '@core/types';
 import { TransactionStatusProviderWithConfetti } from './TransactionsProviderWithConfetti';
 import { useIsOptimisticConfirmationEnabled } from '@core/ui';
 
+type CapturedContext = {
+  recurringSwaps?: { action: 'schedule' | 'pause' | 'unpause' | 'cancel' };
+};
+
 const mockTriggerConfetti = jest.fn();
 const mockHistoryReplace = jest.fn();
 let capturedOnPending:
-  | ((params: { network?: NetworkWithCaipId }) => void)
+  | ((params: {
+      network?: NetworkWithCaipId;
+      context?: CapturedContext;
+    }) => void)
   | undefined;
 let capturedOnSuccess:
-  | ((params: { network?: NetworkWithCaipId }) => void)
+  | ((params: {
+      network?: NetworkWithCaipId;
+      context?: CapturedContext;
+    }) => void)
   | undefined;
 
 jest.mock('@/components/Confetti', () => ({
@@ -33,8 +43,14 @@ jest.mock('@core/ui', () => ({
     onSuccess,
   }: {
     children: React.ReactNode;
-    onPending?: (params: { network?: NetworkWithCaipId }) => Promise<void>;
-    onSuccess?: (params: { network?: NetworkWithCaipId }) => Promise<void>;
+    onPending?: (params: {
+      network?: NetworkWithCaipId;
+      context?: CapturedContext;
+    }) => Promise<void>;
+    onSuccess?: (params: {
+      network?: NetworkWithCaipId;
+      context?: CapturedContext;
+    }) => Promise<void>;
   }) => {
     capturedOnPending = onPending;
     capturedOnSuccess = onSuccess;
@@ -266,6 +282,71 @@ describe('TransactionStatusProviderWithConfetti', () => {
 
     it('triggers confetti when network is undefined (non-Avalanche default)', async () => {
       await capturedOnSuccess?.({ network: undefined });
+
+      expect(mockTriggerConfetti).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('administrative recurring-swap actions', () => {
+    it.each(['pause', 'unpause', 'cancel'] as const)(
+      'does not trigger confetti on pending for a %s action',
+      async (action) => {
+        jest
+          .mocked(useIsOptimisticConfirmationEnabled)
+          .mockReturnValue(() => Promise.resolve(true));
+
+        render(
+          <TransactionStatusProviderWithConfetti>
+            <div>Test</div>
+          </TransactionStatusProviderWithConfetti>,
+        );
+
+        await capturedOnPending?.({
+          network: createMockNetwork(ChainId.AVALANCHE_MAINNET_ID),
+          context: { recurringSwaps: { action } },
+        });
+
+        expect(mockTriggerConfetti).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(['pause', 'unpause', 'cancel'] as const)(
+      'does not trigger confetti on success for a %s action',
+      async (action) => {
+        jest
+          .mocked(useIsOptimisticConfirmationEnabled)
+          .mockReturnValue(() => Promise.resolve(false));
+
+        render(
+          <TransactionStatusProviderWithConfetti>
+            <div>Test</div>
+          </TransactionStatusProviderWithConfetti>,
+        );
+
+        await capturedOnSuccess?.({
+          network: createMockNetwork(ChainId.ETHEREUM_HOMESTEAD),
+          context: { recurringSwaps: { action } },
+        });
+
+        expect(mockTriggerConfetti).not.toHaveBeenCalled();
+      },
+    );
+
+    it('still triggers confetti for a schedule action (first fill)', async () => {
+      jest
+        .mocked(useIsOptimisticConfirmationEnabled)
+        .mockReturnValue(() => Promise.resolve(false));
+
+      render(
+        <TransactionStatusProviderWithConfetti>
+          <div>Test</div>
+        </TransactionStatusProviderWithConfetti>,
+      );
+
+      await capturedOnSuccess?.({
+        network: createMockNetwork(ChainId.ETHEREUM_HOMESTEAD),
+        context: { recurringSwaps: { action: 'schedule' } },
+      });
 
       expect(mockTriggerConfetti).toHaveBeenCalledTimes(1);
     });

--- a/apps/next/src/components/Transactions/TransactionsProviderWithConfetti.tsx
+++ b/apps/next/src/components/Transactions/TransactionsProviderWithConfetti.tsx
@@ -11,6 +11,27 @@ import { openNewTab, getExplorerAddressByNetwork } from '@core/common';
 import { NetworkWithCaipId } from '@core/types';
 import { useIsOptimisticConfirmationEnabled } from '@core/ui';
 
+// Confetti is reserved for high-impact successes (swaps, first fill of a new
+// recurring order). Administrative recurring actions — pausing, resuming or
+// cancelling an existing order — are not milestones, so they get a plain
+// success toast only. `schedule` still celebrates: it broadcasts the first fill.
+const isAdministrativeRecurringAction = (
+  context: TransactionStatusCallbackParams['context'],
+): boolean => {
+  const recurringSwaps = context?.recurringSwaps;
+
+  if (
+    !recurringSwaps ||
+    typeof recurringSwaps !== 'object' ||
+    !('action' in recurringSwaps)
+  ) {
+    return false;
+  }
+
+  const { action } = recurringSwaps;
+  return action === 'pause' || action === 'unpause' || action === 'cancel';
+};
+
 export const TransactionStatusProviderWithConfetti = ({
   children,
 }: PropsWithChildren) => {
@@ -19,12 +40,12 @@ export const TransactionStatusProviderWithConfetti = ({
   const shouldUseOptimisticConfirmations = useIsOptimisticConfirmationEnabled();
 
   const handlePending = useCallback(
-    async ({ network }: TransactionStatusCallbackParams) => {
+    async ({ network, context }: TransactionStatusCallbackParams) => {
       history.replace('/');
       const showSuccessOnPending =
         await shouldUseOptimisticConfirmations(network);
 
-      if (showSuccessOnPending) {
+      if (showSuccessOnPending && !isAdministrativeRecurringAction(context)) {
         triggerConfetti();
       }
     },
@@ -32,11 +53,11 @@ export const TransactionStatusProviderWithConfetti = ({
   );
 
   const handleSuccess = useCallback(
-    async ({ network }: TransactionStatusCallbackParams) => {
+    async ({ network, context }: TransactionStatusCallbackParams) => {
       const showSuccessOnPending =
         await shouldUseOptimisticConfirmations(network);
 
-      if (!showSuccessOnPending) {
+      if (!showSuccessOnPending && !isAdministrativeRecurringAction(context)) {
         triggerConfetti();
       }
     },

--- a/apps/next/src/pages/Fusion/hooks/useRecurringSwapOrders.ts
+++ b/apps/next/src/pages/Fusion/hooks/useRecurringSwapOrders.ts
@@ -67,6 +67,11 @@ const RECURRING_CHAIN_ID = ChainId.AVALANCHE_MAINNET_ID;
 
 const RECURRING_SWAP_ORDERS_QUERY_KEY = 'recurringSwapOrders';
 
+// Poll while the orders are on screen so state driven by the backend (executed
+// count, next execution, status flips from pause/resume) refreshes without the
+// user having to close and reopen the page.
+const RECURRING_SWAP_ORDERS_REFETCH_INTERVAL_MS = 15_000;
+
 type UseRecurringSwapOrdersResult = {
   orders: RecurringSwapOrder[];
   scheduledCount: number;
@@ -148,6 +153,8 @@ export const useRecurringSwapOrders = (): UseRecurringSwapOrdersResult => {
   } = useQuery({
     queryKey: [RECURRING_SWAP_ORDERS_QUERY_KEY, address, manager?.id],
     enabled: isRecurringSwapsEnabled,
+    refetchInterval: RECURRING_SWAP_ORDERS_REFETCH_INTERVAL_MS,
+    refetchOnWindowFocus: true,
     queryFn:
       manager && address
         ? () =>

--- a/packages/ui/src/hooks/useErrorMessage.test.ts
+++ b/packages/ui/src/hooks/useErrorMessage.test.ts
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react';
+import { HttpError } from '@avalabs/fusion-sdk';
+
+import { useErrorMessage } from './useErrorMessage';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({
+    t: (key: string) => key,
+  })),
+}));
+
+const makeHttpError = (data: unknown) =>
+  new HttpError(
+    'HTTP 400 Bad Request',
+    { status: 400, statusText: 'Bad Request' } as unknown as Response,
+    data,
+  );
+
+describe('hooks/useErrorMessage', () => {
+  const renderGetTranslatedError = () =>
+    renderHook(() => useErrorMessage()).result.current;
+
+  describe('HttpError', () => {
+    it('surfaces the backend message from a `message` field', () => {
+      const getTranslatedError = renderGetTranslatedError();
+
+      expect(
+        getTranslatedError(
+          makeHttpError({
+            message: 'Minimum execution time between orders is 300 seconds',
+          }),
+        ),
+      ).toEqual({
+        title: 'Minimum execution time between orders is 300 seconds',
+      });
+    });
+
+    it('surfaces the backend message when the body is a plain string', () => {
+      const getTranslatedError = renderGetTranslatedError();
+
+      expect(getTranslatedError(makeHttpError('Something went wrong'))).toEqual(
+        {
+          title: 'Something went wrong',
+        },
+      );
+    });
+
+    it('surfaces the backend message from an `error` field', () => {
+      const getTranslatedError = renderGetTranslatedError();
+
+      expect(
+        getTranslatedError(makeHttpError({ error: 'Invalid frequency' })),
+      ).toEqual({ title: 'Invalid frequency' });
+    });
+
+    it('surfaces the backend message from a nested `error.message` field', () => {
+      const getTranslatedError = renderGetTranslatedError();
+
+      expect(
+        getTranslatedError(
+          makeHttpError({ error: { message: 'Nested reason' } }),
+        ),
+      ).toEqual({ title: 'Nested reason' });
+    });
+
+    it('trims surrounding whitespace from the backend message', () => {
+      const getTranslatedError = renderGetTranslatedError();
+
+      expect(
+        getTranslatedError(makeHttpError({ message: '  Trimmed reason \n' })),
+      ).toEqual({ title: 'Trimmed reason' });
+    });
+
+    it('falls back to the unknown error when the body has no usable message', () => {
+      const getTranslatedError = renderGetTranslatedError();
+
+      expect(getTranslatedError(makeHttpError(undefined))).toEqual({
+        title: 'Unknown error',
+      });
+      expect(getTranslatedError(makeHttpError({ status: 400 }))).toEqual({
+        title: 'Unknown error',
+      });
+      expect(getTranslatedError(makeHttpError({ message: '   ' }))).toEqual({
+        title: 'Unknown error',
+      });
+    });
+  });
+});

--- a/packages/ui/src/hooks/useErrorMessage.ts
+++ b/packages/ui/src/hooks/useErrorMessage.ts
@@ -1,6 +1,7 @@
 import { errorCodes } from 'eth-rpc-errors';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { isHttpError } from '@avalabs/fusion-sdk';
 
 import { isWrappedError } from '@core/common';
 import {
@@ -17,6 +18,38 @@ import {
 type ErrorTranslation = {
   title: string;
   hint?: string;
+};
+
+// Markr (and other Fusion SDK backends) surface validation failures as an
+// `HttpError` whose parsed JSON/text body holds the human-readable reason
+// (e.g. "Minimum execution time between orders is 300 seconds"). The error's
+// own `message` is only the status line ("HTTP 400 Bad Request"), so we dig
+// the actionable copy out of the response body when present.
+const getBackendErrorMessage = (data: unknown): string | undefined => {
+  if (typeof data === 'string') {
+    return data.trim() || undefined;
+  }
+
+  if (data && typeof data === 'object') {
+    const record = data as Record<string, unknown>;
+
+    if (typeof record.message === 'string' && record.message.trim()) {
+      return record.message;
+    }
+
+    if (typeof record.error === 'string' && record.error.trim()) {
+      return record.error;
+    }
+
+    if (record.error && typeof record.error === 'object') {
+      const nested = (record.error as Record<string, unknown>).message;
+      if (typeof nested === 'string' && nested.trim()) {
+        return nested;
+      }
+    }
+  }
+
+  return undefined;
 };
 
 export const useErrorMessage = () => {
@@ -379,6 +412,11 @@ export const useErrorMessage = () => {
 
       if (isWrappedError(error)) {
         message = messages[error.data.reason] ?? messages[CommonError.Unknown];
+      } else if (isHttpError(error)) {
+        const backendMessage = getBackendErrorMessage(error.data);
+        if (backendMessage) {
+          return { title: backendMessage };
+        }
       } else if (
         typeof error === 'object' &&
         error !== null &&

--- a/packages/ui/src/hooks/useErrorMessage.ts
+++ b/packages/ui/src/hooks/useErrorMessage.ts
@@ -34,17 +34,17 @@ const getBackendErrorMessage = (data: unknown): string | undefined => {
     const record = data as Record<string, unknown>;
 
     if (typeof record.message === 'string' && record.message.trim()) {
-      return record.message;
+      return record.message.trim();
     }
 
     if (typeof record.error === 'string' && record.error.trim()) {
-      return record.error;
+      return record.error.trim();
     }
 
     if (record.error && typeof record.error === 'object') {
       const nested = (record.error as Record<string, unknown>).message;
       if (typeof nested === 'string' && nested.trim()) {
-        return nested;
+        return nested.trim();
       }
     }
   }


### PR DESCRIPTION
# Summary

Jira tickets:
* https://ava-labs.atlassian.net/browse/CP-14634
* https://ava-labs.atlassian.net/browse/CP-14635
* https://ava-labs.atlassian.net/browse/CP-14636

<!-- Describe the changes -->
<!-- Link the Jira ticket and Figma designs. Prefer listing expectations vs. linking large docs like PRD -->

## Fixed issues

### Cryptic error messages
When the Fusion SDK returns an `HttpError`, we use it's error message (if available) instead of showing an `Unknown error` toast

### Unnecessary confettis
We now prevent confetti from being shown on pause/resume/cancel actions.

### Stale UI for recently updated schedules
`useRecurringSwapOrders()` hook now polls every 15 seconds to refresh the list.

## Testing
As detailed in the tickets