### PR TITLE
fix: dca swaps frequency validation

### DIFF
--- a/apps/next/src/localization/locales/en/translation.json
+++ b/apps/next/src/localization/locales/en/translation.json
@@ -510,6 +510,8 @@
   "Max priority fee cannot be negative": "Max priority fee cannot be negative",
   "Maximum available amount after fees is ~{{maxAmount}}.": "Maximum available amount after fees is ~{{maxAmount}}.",
   "Minimum amount is {{minimum}}.": "Minimum amount is {{minimum}}.",
+  "Minimum interval is {{minutes}} minute": "Minimum interval is {{minutes}} minute",
+  "Minimum interval is {{minutes}} minutes": "Minimum interval is {{minutes}} minutes",
   "Minimum possible amount is {{amount}} {{symbol}}": "Minimum possible amount is {{amount}} {{symbol}}",
   "Minute": "Minute",
   "Minutes": "Minutes",

--- a/apps/next/src/pages/Fusion/components/RecurringSwap/RecurringSwapForm.tsx
+++ b/apps/next/src/pages/Fusion/components/RecurringSwap/RecurringSwapForm.tsx
@@ -90,6 +90,16 @@ export const RecurringSwapForm = () => {
           <DropdownMenu
             label={unitLabel}
             dataTestId="recurring-swap-frequency-unit"
+            slotProps={{
+              button: {
+                variant: 'contained',
+                size: 'xsmall',
+                color: 'secondary',
+                sx: {
+                  px: 1,
+                },
+              },
+            }}
           >
             {FREQUENCY_UNITS.map((unit) => (
               <PopoverItem

--- a/apps/next/src/pages/Fusion/contexts/FusionStateContext.tsx
+++ b/apps/next/src/pages/Fusion/contexts/FusionStateContext.tsx
@@ -38,6 +38,11 @@ import { useSwapFormError, useSwapQuery } from '../hooks';
 import { usePriceImpact } from '../hooks/usePriceImpact';
 import { shouldRetryWithNextQuote } from '../lib/swapErrors';
 import {
+  MIN_FREQUENCY_INTERVAL_SECONDS,
+  getMinFrequencyMinutes,
+  isFrequencyBelowMinimum,
+} from '../lib/formatFrequency';
+import {
   useUserAddresses,
   useTransferManager,
   useAssetAndChain,
@@ -364,6 +369,9 @@ export const FusionStateContextProvider: FC<{ children: ReactNode }> = ({
 
   const isRecurringSubmission = isRecurring && recurringEligibility.isEligible;
 
+  const minFrequencySeconds =
+    recurringEligibility.minFrequencySeconds ?? MIN_FREQUENCY_INTERVAL_SECONDS;
+
   const recurringScheduleFeeNativeAmount = useMemo(() => {
     if (!isRecurringSubmission || !recurringScheduleFee) {
       return 0n;
@@ -385,6 +393,12 @@ export const FusionStateContextProvider: FC<{ children: ReactNode }> = ({
       ? {
           numberOfOrders,
           scheduleFeeNativeAmount: recurringScheduleFeeNativeAmount,
+          isFrequencyBelowMinimum: isFrequencyBelowMinimum(
+            frequencyQuantity,
+            frequencyUnit,
+            minFrequencySeconds,
+          ),
+          minFrequencyMinutes: getMinFrequencyMinutes(minFrequencySeconds),
         }
       : undefined,
   });

--- a/apps/next/src/pages/Fusion/contexts/hooks/useRecurringEligibility.ts
+++ b/apps/next/src/pages/Fusion/contexts/hooks/useRecurringEligibility.ts
@@ -11,6 +11,7 @@ import { getRecurringTokenAddress } from '../../lib/getRecurringTokenAddress';
 export type RecurringEligibility = {
   /** Pair-level support (chain + token + EVM address). Controls the toggle. */
   isEligible: boolean;
+  minFrequencySeconds?: number;
 };
 
 const NOT_ELIGIBLE: RecurringEligibility = {
@@ -55,6 +56,7 @@ export const useRecurringEligibility = ({
 
     // Pure, no-I/O check against the SDK's cached `/info/chains` metadata.
     let result: ReturnType<typeof manager.recurring.checkEligibility>;
+    let minFrequencySeconds: number | undefined;
     try {
       result = manager.recurring.checkEligibility({
         fromTokenAddress,
@@ -63,6 +65,9 @@ export const useRecurringEligibility = ({
         targetChainId,
         ownerAddress: ownerAddress as Address,
       });
+      minFrequencySeconds = manager.recurring
+        .getRecurringChainInfo()
+        .get(sourceChainId)?.minFrequencySeconds;
     } catch (err) {
       // `manager.recurring` throws ServiceUnavailableError when Markr isn't
       // initialized (e.g. feature flag off / non-PROD env) — an expected
@@ -75,7 +80,7 @@ export const useRecurringEligibility = ({
       return NOT_ELIGIBLE;
     }
 
-    return { isEligible: result.eligible };
+    return { isEligible: result.eligible, minFrequencySeconds };
   }, [
     manager,
     sourceAsset,

--- a/apps/next/src/pages/Fusion/hooks/useSwapFormError/lib/validateSwapAmount.tsx
+++ b/apps/next/src/pages/Fusion/hooks/useSwapFormError/lib/validateSwapAmount.tsx
@@ -23,6 +23,8 @@ const collapsedTokenAmountProps: Omit<
 export type RecurringSwapValidation = {
   numberOfOrders: number;
   scheduleFeeNativeAmount: bigint;
+  isFrequencyBelowMinimum: boolean;
+  minFrequencyMinutes: number;
 };
 
 export const validateSwapAmount = (

--- a/apps/next/src/pages/Fusion/hooks/useSwapFormError/useSwapFormError.test.tsx
+++ b/apps/next/src/pages/Fusion/hooks/useSwapFormError/useSwapFormError.test.tsx
@@ -69,7 +69,12 @@ describe('useSwapFormError', () => {
         ...baseArgs,
         debouncedUserAmount: '1',
         sourceToken: smallBalanceToken,
-        recurring: { numberOfOrders: 4, scheduleFeeNativeAmount: 0n },
+        recurring: {
+          numberOfOrders: 4,
+          scheduleFeeNativeAmount: 0n,
+          isFrequencyBelowMinimum: false,
+          minFrequencyMinutes: 5,
+        },
       }),
     );
 
@@ -82,7 +87,12 @@ describe('useSwapFormError', () => {
       useSwapFormError({
         ...baseArgs,
         debouncedUserAmount: '1',
-        recurring: { numberOfOrders: 4, scheduleFeeNativeAmount: 0n },
+        recurring: {
+          numberOfOrders: 4,
+          scheduleFeeNativeAmount: 0n,
+          isFrequencyBelowMinimum: false,
+          minFrequencyMinutes: 5,
+        },
       }),
     );
 
@@ -102,10 +112,64 @@ describe('useSwapFormError', () => {
         debouncedUserAmount: '1',
         sourceToken: tightBalanceToken,
         // 4 AVAX spend fits the 4 AVAX balance, but the schedule fee pushes it over.
-        recurring: { numberOfOrders: 4, scheduleFeeNativeAmount: ONE_AVAX },
+        recurring: {
+          numberOfOrders: 4,
+          scheduleFeeNativeAmount: ONE_AVAX,
+          isFrequencyBelowMinimum: false,
+          minFrequencyMinutes: 5,
+        },
       }),
     );
 
     expect(result.current).toBe('Insufficient funds');
+  });
+
+  it('flags a frequency below the minimum interval', () => {
+    const { result } = renderHook(() =>
+      useSwapFormError({
+        ...baseArgs,
+        recurring: {
+          numberOfOrders: 4,
+          scheduleFeeNativeAmount: 0n,
+          isFrequencyBelowMinimum: true,
+          minFrequencyMinutes: 5,
+        },
+      }),
+    );
+
+    expect(result.current).toBe('Minimum interval is {{minutes}} minutes');
+  });
+
+  it('uses the singular copy when the minimum is a single minute', () => {
+    const { result } = renderHook(() =>
+      useSwapFormError({
+        ...baseArgs,
+        recurring: {
+          numberOfOrders: 4,
+          scheduleFeeNativeAmount: 0n,
+          isFrequencyBelowMinimum: true,
+          minFrequencyMinutes: 1,
+        },
+      }),
+    );
+
+    expect(result.current).toBe('Minimum interval is {{minutes}} minute');
+  });
+
+  it('flags the frequency error even before a valid amount is entered', () => {
+    const { result } = renderHook(() =>
+      useSwapFormError({
+        ...baseArgs,
+        debouncedUserAmount: '',
+        recurring: {
+          numberOfOrders: 4,
+          scheduleFeeNativeAmount: 0n,
+          isFrequencyBelowMinimum: true,
+          minFrequencyMinutes: 5,
+        },
+      }),
+    );
+
+    expect(result.current).toBe('Minimum interval is {{minutes}} minutes');
   });
 });

--- a/apps/next/src/pages/Fusion/hooks/useSwapFormError/useSwapFormError.tsx
+++ b/apps/next/src/pages/Fusion/hooks/useSwapFormError/useSwapFormError.tsx
@@ -31,6 +31,17 @@ export const useSwapFormError = ({
 }: UseSwapFormErrorArgs) => {
   const { t } = useTranslation();
 
+  if (recurring?.isFrequencyBelowMinimum) {
+    const { minFrequencyMinutes } = recurring;
+    return minFrequencyMinutes === 1
+      ? t('Minimum interval is {{minutes}} minute', {
+          minutes: minFrequencyMinutes,
+        })
+      : t('Minimum interval is {{minutes}} minutes', {
+          minutes: minFrequencyMinutes,
+        });
+  }
+
   // 1. Parse the user amount
   const sourceAmountBigInt = safeParseUserAmount(
     debouncedUserAmount,

--- a/apps/next/src/pages/Fusion/lib/formatFrequency.ts
+++ b/apps/next/src/pages/Fusion/lib/formatFrequency.ts
@@ -27,6 +27,18 @@ export const getFrequencyInSeconds = (
   return quantity * SECONDS_IN_UNIT[unit];
 };
 
+export const MIN_FREQUENCY_INTERVAL_SECONDS = 5 * 60;
+
+export const isFrequencyBelowMinimum = (
+  quantity: number,
+  unit: FrequencyUnit,
+  minSeconds: number = MIN_FREQUENCY_INTERVAL_SECONDS,
+) => getFrequencyInSeconds(quantity, unit) < minSeconds;
+
+export const getMinFrequencyMinutes = (
+  minSeconds: number = MIN_FREQUENCY_INTERVAL_SECONDS,
+) => Math.ceil(minSeconds / 60);
+
 export const getFrequencyUnitLabel = (
   unit: FrequencyUnit,
   quantity: number,


### PR DESCRIPTION
# Summary

Jira ticket: n/a
Figma: n/a

<!-- Describe the changes -->
<!-- Link the Jira ticket and Figma designs. Prefer listing expectations vs. linking large docs like PRD -->

## Notes
1. Adds client-side validation for minimum frequency between recurring swaps

## Testing
* Try to schedule a recurring swap with frequency lower than 5 minutes

## Media

https://github.com/user-attachments/assets/192de2d9-2af4-4ce9-bed2-efbcd4b6db79

