### PR TITLE
feat: add Select UTXOs button to Fusion swap

### DIFF
--- a/apps/next/src/components/TokenAmountInput/TokenAmountInput.tsx
+++ b/apps/next/src/components/TokenAmountInput/TokenAmountInput.tsx
@@ -9,6 +9,7 @@ import {
 import {
   FC,
   FocusEventHandler,
+  ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -51,6 +52,7 @@ type TokenAmountInputProps = {
   onBlur?: FocusEventHandler;
   disabled?: boolean;
   chainFilterMode?: ChainFilterMode;
+  presetButtonsStartSlot?: ReactNode;
 } & AmountInputProps;
 
 type AmountInputProps =
@@ -94,6 +96,7 @@ export const TokenAmountInput: FC<TokenAmountInputProps> = ({
   onBlur,
   disabled,
   chainFilterMode,
+  presetButtonsStartSlot,
 }) => {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -246,7 +249,7 @@ export const TokenAmountInput: FC<TokenAmountInputProps> = ({
         <Stack
           direction="row"
           width="100%"
-          justifyContent="end"
+          justifyContent={presetButtonsStartSlot ? 'space-between' : 'end'}
           alignItems="center"
           gap={1}
           onFocus={onFocus}
@@ -256,25 +259,28 @@ export const TokenAmountInput: FC<TokenAmountInputProps> = ({
             transition: theme.transitions.create('opacity'),
           }}
         >
-          <AmountPresetButton
-            onClick={() => handlePresetClick(25)}
-            disabled={arePresetButtonsDisabled}
-          >
-            {t('25%')}
-          </AmountPresetButton>
-          <AmountPresetButton
-            onClick={() => handlePresetClick(50)}
-            disabled={arePresetButtonsDisabled}
-          >
-            {t('50%')}
-          </AmountPresetButton>
-          <AmountPresetButton
-            data-testid="amount-preset-max"
-            onClick={() => handlePresetClick(100)}
-            disabled={arePresetButtonsDisabled}
-          >
-            {t('Max')}
-          </AmountPresetButton>
+          {presetButtonsStartSlot}
+          <Stack direction="row" alignItems="center" gap={1}>
+            <AmountPresetButton
+              onClick={() => handlePresetClick(25)}
+              disabled={arePresetButtonsDisabled}
+            >
+              {t('25%')}
+            </AmountPresetButton>
+            <AmountPresetButton
+              onClick={() => handlePresetClick(50)}
+              disabled={arePresetButtonsDisabled}
+            >
+              {t('50%')}
+            </AmountPresetButton>
+            <AmountPresetButton
+              data-testid="amount-preset-max"
+              onClick={() => handlePresetClick(100)}
+              disabled={arePresetButtonsDisabled}
+            >
+              {t('Max')}
+            </AmountPresetButton>
+          </Stack>
         </Stack>
       </Collapse>
     </Stack>

--- a/apps/next/src/localization/locales/en/translation.json
+++ b/apps/next/src/localization/locales/en/translation.json
@@ -771,6 +771,7 @@
   "Seedless {{number}}": "Seedless {{number}}",
   "Select": "Select",
   "Select Currency": "Select Currency",
+  "Select UTXOs": "Select UTXOs",
   "Select device": "Select device",
   "Select different wallet": "Select different wallet",
   "Select network": "Select network",

--- a/apps/next/src/pages/Fusion/components/SwapPair.tsx
+++ b/apps/next/src/pages/Fusion/components/SwapPair.tsx
@@ -20,9 +20,10 @@ import { calculateNativeFee } from '../lib/calculateNativeFee';
 import { usePinnedMaxAmount } from '../hooks/usePinnedMaxAmount';
 
 const NATIVE_AVAX_ASSET_ID = 'NATIVE-avax';
+const DEFAULT_CORE_WEB_BASE_URL = 'https://core.app';
 
 const getCoreWebSwapUrl = (fromChain: string, toChain?: string) => {
-  const url = new URL('/swap', CORE_WEB_BASE_URL);
+  const url = new URL('/swap', CORE_WEB_BASE_URL || DEFAULT_CORE_WEB_BASE_URL);
   const params = new URLSearchParams({
     from: NATIVE_AVAX_ASSET_ID,
     fromChain,
@@ -140,7 +141,7 @@ export const SwapPair = () => {
                 color="secondary"
                 data-testid="fusion-select-utxos"
                 onClick={() => {
-                  window.open(selectUtxosUrl, '_blank', 'noreferrer');
+                  window.open(selectUtxosUrl, '_blank', 'noopener,noreferrer');
                 }}
                 size="xsmall"
                 variant="contained"

--- a/apps/next/src/pages/Fusion/components/SwapPair.tsx
+++ b/apps/next/src/pages/Fusion/components/SwapPair.tsx
@@ -1,17 +1,42 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Divider, Stack } from '@avalabs/k2-alpine';
+import { Button, Divider, Stack } from '@avalabs/k2-alpine';
 import { bigIntToString } from '@avalabs/core-utils-sdk';
 
-import { FeatureGates, getUniqueTokenId } from '@core/types';
+import {
+  FeatureGates,
+  getUniqueTokenId,
+  isPChainToken,
+  isXChainToken,
+} from '@core/types';
 import { useFeatureFlagContext } from '@core/ui';
 
 import { Card } from '@/components/Card';
 import { TokenAmountInput } from '@/components/TokenAmountInput';
+import { CORE_WEB_BASE_URL } from '@/config';
 
 import { useFusionState } from '../contexts';
 import { calculateNativeFee } from '../lib/calculateNativeFee';
 import { usePinnedMaxAmount } from '../hooks/usePinnedMaxAmount';
+
+const NATIVE_AVAX_ASSET_ID = 'NATIVE-avax';
+
+const getCoreWebSwapUrl = (fromChain: string, toChain?: string) => {
+  const url = new URL('/swap', CORE_WEB_BASE_URL);
+  const params = new URLSearchParams({
+    from: NATIVE_AVAX_ASSET_ID,
+    fromChain,
+  });
+
+  if (toChain) {
+    params.set('to', NATIVE_AVAX_ASSET_ID);
+    params.set('toChain', toChain);
+  }
+
+  url.search = params.toString();
+
+  return url.toString();
+};
 
 export const SwapPair = () => {
   const { t } = useTranslation();
@@ -42,6 +67,14 @@ export const SwapPair = () => {
   const chainFilterMode = isAvalancheCctEnabled
     ? 'avalanche-cct'
     : 'group-avalanche';
+  const showSelectUtxosButton =
+    isAvalancheCctEnabled &&
+    sourceToken !== undefined &&
+    (isPChainToken(sourceToken) || isXChainToken(sourceToken));
+  const selectUtxosUrl =
+    showSelectUtxosButton && sourceToken
+      ? getCoreWebSwapUrl(sourceToken.chainCaipId, targetToken?.chainCaipId)
+      : undefined;
 
   const { maxAmount, pin, unpin } = usePinnedMaxAmount(
     sourceToken,
@@ -101,6 +134,21 @@ export const SwapPair = () => {
           tokenHint={sourceToken ? t('You pay') : undefined}
           withPresetButtons={minimumRequiredTokens.state === 'complete'}
           chainFilterMode={chainFilterMode}
+          presetButtonsStartSlot={
+            selectUtxosUrl ? (
+              <Button
+                color="secondary"
+                data-testid="fusion-select-utxos"
+                onClick={() => {
+                  window.open(selectUtxosUrl, '_blank', 'noreferrer');
+                }}
+                size="xsmall"
+                variant="contained"
+              >
+                {t('Select UTXOs')}
+              </Button>
+            ) : undefined
+          }
         />
         <Divider sx={{ mx: 2 }} />
         <TokenAmountInput


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-14705
Figma: N/A

Adds a Fusion swap `Select UTXOs` button on the quick amount row. The button appears when `fusion-avalanche-cct` is enabled and the source token is native AVAX on P-Chain or X-Chain. It opens Core web swap with the selected source chain and optional target chain encoded in the query params.

## Notes

The shared `TokenAmountInput` quick amount row now supports an optional left-side slot so Fusion can place `Select UTXOs` on the left while keeping `25%`, `50%`, and `Max` grouped on the right.

The Core web swap URL is built with `URL` and `URLSearchParams`; if no target chain is available, the URL omits `to` and `toChain`.

Requires work in Core Web (https://github.com/ava-labs/core-web/pull/1931) to be merged.

## Testing Instructions

1. Enable the `fusion-avalanche-cct` feature flag.
2. Open Fusion swap and select native AVAX on P-Chain or X-Chain as the source token.
3. Confirm `Select UTXOs` appears left-aligned on the same row as `25%`, `50%`, and `Max`.
4. Click `Select UTXOs` and confirm Core web opens to `/swap` with `from=NATIVE-avax`, `fromChain=<source caip2 id>`, and the target AVAX params when a target chain is selected.
5. Disable the flag or select a non-P/X native AVAX source token and confirm the button is hidden.

## Media

<img width="400" height="620" alt="Screenshot 2026-07-07 at 11 50 00 AM" src="https://github.com/user-attachments/assets/3054d2ba-8f88-4156-ae18-ddcf9137333f" />

