### PR TITLE
feat: add hyperliquid feature-flag

### DIFF
--- a/packages/common/src/feature-flags.ts
+++ b/packages/common/src/feature-flags.ts
@@ -62,6 +62,7 @@ export const DISABLED_FLAG_VALUES: FeatureFlags = {
   [FeatureGates.FUSION_LOMBARD_AVA_TO_BTC]: false,
   [FeatureGates.FUSION_RECURRING_SWAPS]: false,
   [FeatureGates.FUSION_AVALANCHE_CCT]: false,
+  [FeatureGates.HYPERLIQUID_FEATURE]: false,
   [FeatureVars.SAE_OVERRIDE]: 'auto', // auto, enabled, disabled
 };
 
@@ -126,6 +127,7 @@ export const DEFAULT_FLAGS: FeatureFlags = {
   [FeatureGates.FUSION_LOMBARD_AVA_TO_BTC]: true,
   [FeatureGates.FUSION_RECURRING_SWAPS]: true,
   [FeatureGates.FUSION_AVALANCHE_CCT]: true,
+  [FeatureGates.HYPERLIQUID_FEATURE]: false,
   [FeatureVars.SAE_OVERRIDE]: 'auto', // auto, enabled, disabled
 };
 

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -71,6 +71,7 @@ export * from './network/isAvalancheXchainNetwork';
 export * from './network/isBitcoinNetwork';
 export * from './network/isEthereumNetwork';
 export * from './network/isSolanaNetwork';
+export * from './network/isHyperliquidNetwork';
 export * from './network/isValidHttpHeader';
 export * from './newsletter';
 export * from './nfts/getSmallImageForNFT';

--- a/packages/common/src/utils/network/isHyperliquidNetwork.test.ts
+++ b/packages/common/src/utils/network/isHyperliquidNetwork.test.ts
@@ -1,6 +1,5 @@
 import { NetworkVMType } from '@avalabs/core-chains-sdk';
 import {
-  HYPERCORE_CHAIN_ID,
   HYPEREVM_CHAIN_ID,
   isHyperliquidChainId,
   isHyperliquidNetwork,
@@ -32,26 +31,36 @@ describe('isHyperliquidNetwork', () => {
       isHyperliquidNetwork({
         ...baseNetwork,
         chainId: HYPEREVM_CHAIN_ID,
+        chainName: 'Some EVM Network',
+      }),
+    ).toBe(true);
+  });
+
+  it('identifies HyperEVM by chain name', () => {
+    expect(
+      isHyperliquidNetwork({
+        ...baseNetwork,
+        chainId: 1,
         chainName: 'HyperEVM',
       }),
     ).toBe(true);
   });
 
-  it('identifies HyperCore by chain name', () => {
+  it('identifies HyperCore by chain name only', () => {
     expect(
       isHyperliquidNetwork({
         ...baseNetwork,
-        chainId: HYPERCORE_CHAIN_ID,
+        chainId: 42,
         chainName: 'HyperCore',
       }),
     ).toBe(true);
   });
 
-  it('does not treat arbitrary chain id 1337 as Hyperliquid', () => {
+  it('does not treat arbitrary networks as Hyperliquid', () => {
     expect(
       isHyperliquidNetwork({
         ...baseNetwork,
-        chainId: HYPERCORE_CHAIN_ID,
+        chainId: 1337,
         chainName: 'Local Devnet',
       }),
     ).toBe(false);
@@ -61,6 +70,6 @@ describe('isHyperliquidNetwork', () => {
 describe('isHyperliquidChainId', () => {
   it('returns true only for HyperEVM chain id', () => {
     expect(isHyperliquidChainId(HYPEREVM_CHAIN_ID)).toBe(true);
-    expect(isHyperliquidChainId(HYPERCORE_CHAIN_ID)).toBe(false);
+    expect(isHyperliquidChainId(1337)).toBe(false);
   });
 });

--- a/packages/common/src/utils/network/isHyperliquidNetwork.test.ts
+++ b/packages/common/src/utils/network/isHyperliquidNetwork.test.ts
@@ -1,0 +1,66 @@
+import { NetworkVMType } from '@avalabs/core-chains-sdk';
+import {
+  HYPERCORE_CHAIN_ID,
+  HYPEREVM_CHAIN_ID,
+  isHyperliquidChainId,
+  isHyperliquidNetwork,
+} from './isHyperliquidNetwork';
+
+const baseNetwork = {
+  chainId: 1,
+  chainName: 'Ethereum',
+  vmName: NetworkVMType.EVM,
+  rpcUrl: 'https://rpc.example',
+  explorerUrl: 'https://explorer.example',
+  networkToken: {
+    name: 'Ether',
+    symbol: 'ETH',
+    description: '',
+    decimals: 18,
+    logoUri: '',
+  },
+  logoUri: '',
+};
+
+describe('isHyperliquidNetwork', () => {
+  it('returns false for undefined network', () => {
+    expect(isHyperliquidNetwork(undefined)).toBe(false);
+  });
+
+  it('identifies HyperEVM by chain id', () => {
+    expect(
+      isHyperliquidNetwork({
+        ...baseNetwork,
+        chainId: HYPEREVM_CHAIN_ID,
+        chainName: 'HyperEVM',
+      }),
+    ).toBe(true);
+  });
+
+  it('identifies HyperCore by chain name', () => {
+    expect(
+      isHyperliquidNetwork({
+        ...baseNetwork,
+        chainId: HYPERCORE_CHAIN_ID,
+        chainName: 'HyperCore',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat arbitrary chain id 1337 as Hyperliquid', () => {
+    expect(
+      isHyperliquidNetwork({
+        ...baseNetwork,
+        chainId: HYPERCORE_CHAIN_ID,
+        chainName: 'Local Devnet',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isHyperliquidChainId', () => {
+  it('returns true only for HyperEVM chain id', () => {
+    expect(isHyperliquidChainId(HYPEREVM_CHAIN_ID)).toBe(true);
+    expect(isHyperliquidChainId(HYPERCORE_CHAIN_ID)).toBe(false);
+  });
+});

--- a/packages/common/src/utils/network/isHyperliquidNetwork.ts
+++ b/packages/common/src/utils/network/isHyperliquidNetwork.ts
@@ -1,7 +1,9 @@
 import { Network } from '@avalabs/core-chains-sdk';
 
 export const HYPEREVM_CHAIN_ID = 999;
-export const HYPERCORE_CHAIN_ID = 1337;
+
+const HYPERCORE_CHAIN_NAME = 'HyperCore';
+const HYPEREVM_CHAIN_NAME = 'HyperEVM';
 
 export function isHyperliquidChainId(chainId: number) {
   return chainId === HYPEREVM_CHAIN_ID;
@@ -12,9 +14,12 @@ export function isHyperliquidNetwork(network?: Network) {
     return false;
   }
 
-  if (network.chainId === HYPEREVM_CHAIN_ID) {
+  if (network.chainName === HYPERCORE_CHAIN_NAME) {
     return true;
   }
 
-  return network.chainName === 'HyperCore' || network.chainName === 'HyperEVM';
+  return (
+    network.chainId === HYPEREVM_CHAIN_ID ||
+    network.chainName === HYPEREVM_CHAIN_NAME
+  );
 }

--- a/packages/common/src/utils/network/isHyperliquidNetwork.ts
+++ b/packages/common/src/utils/network/isHyperliquidNetwork.ts
@@ -14,12 +14,14 @@ export function isHyperliquidNetwork(network?: Network) {
     return false;
   }
 
+  // HyperCore is not an EVM chain and has no canonical chain id (Fusion/Relay use a
+  // synthetic eip155:1337 at the SDK boundary, which collides with local devnets).
   if (network.chainName === HYPERCORE_CHAIN_NAME) {
     return true;
   }
 
   return (
-    network.chainId === HYPEREVM_CHAIN_ID ||
+    isHyperliquidChainId(network.chainId) ||
     network.chainName === HYPEREVM_CHAIN_NAME
   );
 }

--- a/packages/common/src/utils/network/isHyperliquidNetwork.ts
+++ b/packages/common/src/utils/network/isHyperliquidNetwork.ts
@@ -1,0 +1,20 @@
+import { Network } from '@avalabs/core-chains-sdk';
+
+export const HYPEREVM_CHAIN_ID = 999;
+export const HYPERCORE_CHAIN_ID = 1337;
+
+export function isHyperliquidChainId(chainId: number) {
+  return chainId === HYPEREVM_CHAIN_ID;
+}
+
+export function isHyperliquidNetwork(network?: Network) {
+  if (!network) {
+    return false;
+  }
+
+  if (network.chainId === HYPEREVM_CHAIN_ID) {
+    return true;
+  }
+
+  return network.chainName === 'HyperCore' || network.chainName === 'HyperEVM';
+}

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -1053,6 +1053,151 @@ describe('background/services/network/NetworkService', () => {
     });
   });
 
+  describe('#filterBasedOnFeatureFlags (via activeNetworks signal)', () => {
+    it('hides Hyperliquid networks when hyperliquid-feature is disabled', async () => {
+      const hyperliquidFeatureFlagsServiceMock =
+        jest.mocked<FeatureFlagService>({
+          featureFlags: {
+            [FeatureGates.HYPERLIQUID_FEATURE]: false,
+          },
+          addListener: jest.fn(),
+        } as any);
+
+      const networkService = new NetworkService(
+        storageServiceMock,
+        hyperliquidFeatureFlagsServiceMock,
+        glacierServiceMock,
+      );
+      jest.spyOn(networkService, 'isMainnet').mockReturnValue(true);
+
+      const hyperEvmNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 999,
+        chainName: 'HyperEVM',
+      });
+      const hyperCoreNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 1337,
+        chainName: 'HyperCore',
+      });
+
+      // eslint-disable-next-line
+      // @ts-expect-error
+      networkService._allNetworks.dispatch({
+        [ethMainnet.chainId]: ethMainnet,
+        [hyperEvmNetwork.chainId]: hyperEvmNetwork,
+        [hyperCoreNetwork.chainId]: hyperCoreNetwork,
+      });
+
+      const activeNetworks = await networkService.activeNetworks.promisify();
+
+      expect(await activeNetworks[ethMainnet.chainId]).toBeDefined();
+      expect(await activeNetworks[hyperEvmNetwork.chainId]).toBeUndefined();
+      expect(await activeNetworks[hyperCoreNetwork.chainId]).toBeUndefined();
+    });
+
+    it('does not hide non-Hyperliquid networks that share HyperCore chain id', async () => {
+      const hyperliquidFeatureFlagsServiceMock =
+        jest.mocked<FeatureFlagService>({
+          featureFlags: {
+            [FeatureGates.HYPERLIQUID_FEATURE]: false,
+          },
+          addListener: jest.fn(),
+        } as any);
+
+      const networkService = new NetworkService(
+        storageServiceMock,
+        hyperliquidFeatureFlagsServiceMock,
+        glacierServiceMock,
+      );
+      jest.spyOn(networkService, 'isMainnet').mockReturnValue(true);
+
+      const localNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 1337,
+        chainName: 'Local Devnet',
+      });
+
+      // eslint-disable-next-line
+      // @ts-expect-error
+      networkService._allNetworks.dispatch({
+        [localNetwork.chainId]: localNetwork,
+      });
+
+      const activeNetworks = await networkService.activeNetworks.promisify();
+
+      expect(await activeNetworks[localNetwork.chainId]).toBeDefined();
+    });
+
+    it('does not hide custom Hyperliquid networks when hyperliquid-feature is disabled', async () => {
+      const hyperliquidFeatureFlagsServiceMock =
+        jest.mocked<FeatureFlagService>({
+          featureFlags: {
+            [FeatureGates.HYPERLIQUID_FEATURE]: false,
+          },
+          addListener: jest.fn(),
+        } as any);
+
+      const networkService = new NetworkService(
+        storageServiceMock,
+        hyperliquidFeatureFlagsServiceMock,
+        glacierServiceMock,
+      );
+      jest.spyOn(networkService, 'isMainnet').mockReturnValue(true);
+
+      const customHyperEvmNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 999,
+        chainName: 'HyperEVM',
+      });
+
+      // eslint-disable-next-line
+      // @ts-expect-error
+      networkService._customNetworks = {
+        [customHyperEvmNetwork.chainId]: customHyperEvmNetwork,
+      };
+
+      // eslint-disable-next-line
+      // @ts-expect-error
+      networkService._allNetworks.dispatch({
+        [customHyperEvmNetwork.chainId]: customHyperEvmNetwork,
+      });
+
+      const activeNetworks = await networkService.activeNetworks.promisify();
+
+      expect(await activeNetworks[customHyperEvmNetwork.chainId]).toBeDefined();
+    });
+
+    it('shows Hyperliquid networks when hyperliquid-feature is enabled', async () => {
+      const hyperliquidFeatureFlagsServiceMock =
+        jest.mocked<FeatureFlagService>({
+          featureFlags: {
+            [FeatureGates.HYPERLIQUID_FEATURE]: true,
+          },
+          addListener: jest.fn(),
+        } as any);
+
+      const networkService = new NetworkService(
+        storageServiceMock,
+        hyperliquidFeatureFlagsServiceMock,
+        glacierServiceMock,
+      );
+      jest.spyOn(networkService, 'isMainnet').mockReturnValue(true);
+
+      const hyperEvmNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 999,
+        chainName: 'HyperEVM',
+      });
+
+      // eslint-disable-next-line
+      // @ts-expect-error
+      networkService._allNetworks.dispatch({
+        [ethMainnet.chainId]: ethMainnet,
+        [hyperEvmNetwork.chainId]: hyperEvmNetwork,
+      });
+
+      const activeNetworks = await networkService.activeNetworks.promisify();
+
+      expect(await activeNetworks[hyperEvmNetwork.chainId]).toBeDefined();
+    });
+  });
+
   describe('Avalanche Devnet Mode', () => {
     const ethSepolia = mockNetwork(NetworkVMType.EVM, true, {
       chainId: 11155111,

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -1075,7 +1075,7 @@ describe('background/services/network/NetworkService', () => {
         chainName: 'HyperEVM',
       });
       const hyperCoreNetwork = mockNetwork(NetworkVMType.EVM, false, {
-        chainId: 1337,
+        chainId: 42,
         chainName: 'HyperCore',
       });
 
@@ -1094,7 +1094,7 @@ describe('background/services/network/NetworkService', () => {
       expect(await activeNetworks[hyperCoreNetwork.chainId]).toBeUndefined();
     });
 
-    it('does not hide non-Hyperliquid networks that share HyperCore chain id', async () => {
+    it('does not filter networks by chain id alone', async () => {
       const hyperliquidFeatureFlagsServiceMock =
         jest.mocked<FeatureFlagService>({
           featureFlags: {

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -50,7 +50,7 @@ import {
   getProviderForNetwork,
   isSyncDomain,
 } from '@core/common';
-import { isSolanaNetwork } from '@core/common';
+import { isSolanaNetwork, isHyperliquidNetwork } from '@core/common';
 import { GlacierService } from '../glacier/GlacierService';
 import {
   BASE_NETWORK_CONFIG_BY_TYPE,
@@ -167,7 +167,10 @@ export class NetworkService implements OnLock, OnStorageReady {
   }
 
   #getTrackedFeatureFlags(flags: FeatureFlags): Partial<FeatureFlags> {
-    const trackedFlags = [FeatureGates.SOLANA_SUPPORT];
+    const trackedFlags = [
+      FeatureGates.SOLANA_SUPPORT,
+      FeatureGates.HYPERLIQUID_FEATURE,
+    ];
 
     return Object.fromEntries(
       Object.entries(flags).filter(([flag]) =>
@@ -833,8 +836,15 @@ export class NetworkService implements OnLock, OnStorageReady {
     return Object.values(chainList ?? {})
       .filter(
         (network) =>
-          !isSolanaNetwork(network) ||
-          this.featureFlagService.featureFlags[FeatureGates.SOLANA_SUPPORT],
+          (!isSolanaNetwork(network) ||
+            this.featureFlagService.featureFlags[
+              FeatureGates.SOLANA_SUPPORT
+            ]) &&
+          (!isHyperliquidNetwork(network) ||
+            this.featureFlagService.featureFlags[
+              FeatureGates.HYPERLIQUID_FEATURE
+            ] ||
+            Boolean(this._customNetworks[network.chainId])),
       )
       .reduce(
         (acc, network) => ({

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -52,6 +52,7 @@ export enum FeatureGates {
   FUSION_LOMBARD_AVA_TO_BTC = 'fusion-lombard-ava-to-btc',
   FUSION_RECURRING_SWAPS = 'fusion-recurring-swaps',
   FUSION_AVALANCHE_CCT = 'fusion-avalanche-cct',
+  HYPERLIQUID_FEATURE = 'hyperliquid-feature',
 }
 
 export enum FeatureVars {

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -20,6 +20,7 @@ export * from './useInterval';
 export * from './useIsFunctionAvailable';
 export * from './useIsMainnet';
 export * from './useIsSolanaEnabled';
+export * from './useIsHyperliquidEnabled';
 export * from './useIsUsingFireblocksAccount';
 export * from './useIsUsingKeystoneWallet';
 export * from './useIsUsingKeystone3Wallet';

--- a/packages/ui/src/hooks/useIsHyperliquidEnabled.ts
+++ b/packages/ui/src/hooks/useIsHyperliquidEnabled.ts
@@ -1,0 +1,8 @@
+import { FeatureGates } from '@core/types';
+import { useFeatureFlagContext } from '../contexts';
+
+export const useIsHyperliquidEnabled = () => {
+  const { isFlagEnabled } = useFeatureFlagContext();
+
+  return isFlagEnabled(FeatureGates.HYPERLIQUID_FEATURE);
+};


### PR DESCRIPTION
# Summary

Jira ticket: N/A
Figma: N/A

## Notes

- Adds a feature flag `hyperliquid-feature` for the hyperevm and hypercore network
- A custom added hyperliquid network will not get filtered out 

## Media
<img width="378" height="620" alt="Screenshot 2026-07-07 at 2 02 46 PM" src="https://github.com/user-attachments/assets/c13d4516-7f56-479a-9e1e-438109493ebd" />
<img width="358" height="641" alt="Screenshot 2026-07-07 at 2 03 11 PM" src="https://github.com/user-attachments/assets/15789aba-c12a-4e67-b4e0-5f8bc907db0f" />
<img width="375" height="641" alt="Screenshot 2026-07-07 at 2 03 02 PM" src="https://github.com/user-attachments/assets/4a4b4bcf-5322-4f89-8ec0-044542614348" />
<img width="343" height="601" alt="Screenshot 2026-07-07 at 2 02 59 PM" src="https://github.com/user-attachments/assets/d90d2997-5ebf-4829-9eee-4a653cd492d8" />


