### PR TITLE
feat: register hyperliquid networks

### DIFF
--- a/packages/common/src/utils/network/isHyperliquidNetwork.test.ts
+++ b/packages/common/src/utils/network/isHyperliquidNetwork.test.ts
@@ -1,6 +1,8 @@
 import { NetworkVMType } from '@avalabs/core-chains-sdk';
 import {
+  HYPERCORE_CHAIN_ID,
   HYPEREVM_CHAIN_ID,
+  isHypercoreNetwork,
   isHyperliquidChainId,
   isHyperliquidNetwork,
 } from './isHyperliquidNetwork';
@@ -62,6 +64,42 @@ describe('isHyperliquidNetwork', () => {
         ...baseNetwork,
         chainId: 1337,
         chainName: 'Local Devnet',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isHypercoreNetwork', () => {
+  it('returns false for undefined network', () => {
+    expect(isHypercoreNetwork(undefined)).toBe(false);
+  });
+
+  it('identifies HyperCore by chain name', () => {
+    expect(
+      isHypercoreNetwork({
+        ...baseNetwork,
+        chainId: 1,
+        chainName: 'HyperCore',
+      }),
+    ).toBe(true);
+  });
+
+  it('identifies HyperCore by synthetic chain id', () => {
+    expect(
+      isHypercoreNetwork({
+        ...baseNetwork,
+        chainId: HYPERCORE_CHAIN_ID,
+        chainName: 'Something else',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat HyperEVM as HyperCore', () => {
+    expect(
+      isHypercoreNetwork({
+        ...baseNetwork,
+        chainId: HYPEREVM_CHAIN_ID,
+        chainName: 'HyperEVM',
       }),
     ).toBe(false);
   });

--- a/packages/common/src/utils/network/isHyperliquidNetwork.ts
+++ b/packages/common/src/utils/network/isHyperliquidNetwork.ts
@@ -10,13 +10,26 @@ export function isHyperliquidChainId(chainId: number) {
   return chainId === HYPEREVM_CHAIN_ID;
 }
 
+// HyperCore is a synthetic, display-only network: it is modeled as EVM for
+// reuse but has no RPC and no send/receive/swap/dApp actions, so EVM code paths
+// must guard against it. Matched by name because it has no canonical chain id.
+export function isHypercoreNetwork(network?: Network) {
+  if (!network) {
+    return false;
+  }
+
+  return (
+    network.chainName === HYPERCORE_CHAIN_NAME ||
+    network.chainId === HYPERCORE_CHAIN_ID
+  );
+}
+
 export function isHyperliquidNetwork(network?: Network) {
   if (!network) {
     return false;
   }
 
-  // HyperCore is matched by name because it has no canonical chain id.
-  if (network.chainName === HYPERCORE_CHAIN_NAME) {
+  if (isHypercoreNetwork(network)) {
     return true;
   }
 

--- a/packages/common/src/utils/network/isHyperliquidNetwork.ts
+++ b/packages/common/src/utils/network/isHyperliquidNetwork.ts
@@ -1,9 +1,10 @@
 import { Network } from '@avalabs/core-chains-sdk';
 
 export const HYPEREVM_CHAIN_ID = 999;
+export const HYPERCORE_CHAIN_ID = 9999; // synthetic, HyperCore has no real chain id
 
-const HYPERCORE_CHAIN_NAME = 'HyperCore';
-const HYPEREVM_CHAIN_NAME = 'HyperEVM';
+export const HYPEREVM_CHAIN_NAME = 'HyperEVM';
+export const HYPERCORE_CHAIN_NAME = 'HyperCore';
 
 export function isHyperliquidChainId(chainId: number) {
   return chainId === HYPEREVM_CHAIN_ID;
@@ -14,8 +15,7 @@ export function isHyperliquidNetwork(network?: Network) {
     return false;
   }
 
-  // HyperCore is not an EVM chain and has no canonical chain id (Fusion/Relay use a
-  // synthetic eip155:1337 at the SDK boundary, which collides with local devnets).
+  // HyperCore is matched by name because it has no canonical chain id.
   if (network.chainName === HYPERCORE_CHAIN_NAME) {
     return true;
   }

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -690,6 +690,31 @@ describe('background/services/network/NetworkService', () => {
     });
   });
 
+  describe('Hyperliquid networks injection', () => {
+    it('injects HyperEVM and HyperCore into the fetched chain list', async () => {
+      jest.mocked(getChainsAndTokens).mockResolvedValue({});
+
+      const freshService = new NetworkService(
+        storageServiceMock,
+        featureFlagsServiceMock,
+        glacierServiceMock,
+      );
+
+      const fetched = await freshService['_initChainList']();
+
+      expect(fetched[999]).toEqual(
+        expect.objectContaining({ chainName: 'HyperEVM', chainId: 999 }),
+      );
+      expect(fetched[9999]).toEqual(
+        expect.objectContaining({
+          chainName: 'HyperCore',
+          chainId: 9999,
+          rpcUrl: '',
+        }),
+      );
+    });
+  });
+
   describe('enabled networks management', () => {
     beforeEach(() => {
       service = new NetworkService(

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -190,6 +190,108 @@ describe('background/services/network/NetworkService', () => {
       expect(await service.getNetwork('eip155:1')).toEqual(ethMainnet);
       expect(await service.getNetwork('eip155:43114')).toEqual(avaxMainnet);
     });
+
+    it('returns undefined for Hyperliquid networks when the feature flag is off', async () => {
+      const hyperliquidFeatureFlagsServiceMock =
+        jest.mocked<FeatureFlagService>({
+          featureFlags: {
+            [FeatureGates.HYPERLIQUID_FEATURE]: false,
+          },
+          addListener: jest.fn(),
+        } as any);
+
+      const networkService = new NetworkService(
+        storageServiceMock,
+        hyperliquidFeatureFlagsServiceMock,
+        glacierServiceMock,
+      );
+
+      const hyperEvmNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 999,
+        chainName: 'HyperEVM',
+      });
+
+      jest.spyOn(networkService.allNetworks, 'promisify').mockResolvedValue(
+        Promise.resolve({
+          [ethMainnet.chainId]: ethMainnet,
+          [hyperEvmNetwork.chainId]: hyperEvmNetwork,
+        }),
+      );
+
+      expect(await networkService.getNetwork(ethMainnet.chainId)).toEqual(
+        ethMainnet,
+      );
+      expect(
+        await networkService.getNetwork(hyperEvmNetwork.chainId),
+      ).toBeUndefined();
+      expect(await networkService.getNetwork('eip155:999')).toBeUndefined();
+    });
+
+    it('resolves Hyperliquid networks when the feature flag is on', async () => {
+      const hyperliquidFeatureFlagsServiceMock =
+        jest.mocked<FeatureFlagService>({
+          featureFlags: {
+            [FeatureGates.HYPERLIQUID_FEATURE]: true,
+          },
+          addListener: jest.fn(),
+        } as any);
+
+      const networkService = new NetworkService(
+        storageServiceMock,
+        hyperliquidFeatureFlagsServiceMock,
+        glacierServiceMock,
+      );
+
+      const hyperEvmNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 999,
+        chainName: 'HyperEVM',
+      });
+
+      jest.spyOn(networkService.allNetworks, 'promisify').mockResolvedValue(
+        Promise.resolve({
+          [hyperEvmNetwork.chainId]: hyperEvmNetwork,
+        }),
+      );
+
+      expect(await networkService.getNetwork(999)).toEqual(hyperEvmNetwork);
+    });
+
+    it('still resolves custom Hyperliquid networks when the feature flag is off', async () => {
+      const hyperliquidFeatureFlagsServiceMock =
+        jest.mocked<FeatureFlagService>({
+          featureFlags: {
+            [FeatureGates.HYPERLIQUID_FEATURE]: false,
+          },
+          addListener: jest.fn(),
+        } as any);
+
+      const networkService = new NetworkService(
+        storageServiceMock,
+        hyperliquidFeatureFlagsServiceMock,
+        glacierServiceMock,
+      );
+
+      const customHyperEvmNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 999,
+        chainName: 'HyperEVM',
+      });
+
+      // eslint-disable-next-line
+      // @ts-expect-error
+      networkService._customNetworks = {
+        [customHyperEvmNetwork.chainId]: customHyperEvmNetwork,
+      };
+
+      jest.spyOn(networkService.allNetworks, 'promisify').mockResolvedValue(
+        Promise.resolve({
+          [customHyperEvmNetwork.chainId]: customHyperEvmNetwork,
+        }),
+      );
+
+      expect(await networkService.getNetwork(999)).toEqual(
+        customHyperEvmNetwork,
+      );
+    });
   });
 
   describe('.getInitialNetworkForDapp()', () => {

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -527,8 +527,16 @@ export class NetworkService implements OnLock, OnStorageReady {
           : caipToChainId(scopeOrChainId)
         : scopeOrChainId;
 
-    const activeNetworks = await this.allNetworks.promisify();
-    return activeNetworks?.[chainId];
+    const networks = await this.allNetworks.promisify();
+    const network = networks?.[chainId];
+
+    // Feature-gated chains stay in `allNetworks` (e.g. for UI config), but
+    // callers of getNetwork should only resolve networks that are enabled.
+    if (!network || !this.isNetworkEnabledByFeatureFlags(network)) {
+      return undefined;
+    }
+
+    return network;
   }
 
   /**
@@ -835,20 +843,29 @@ export class NetworkService implements OnLock, OnStorageReady {
       );
   };
 
+  isNetworkEnabledByFeatureFlags = (network: Network) => {
+    if (isSolanaNetwork(network)) {
+      return Boolean(
+        this.featureFlagService.featureFlags[FeatureGates.SOLANA_SUPPORT],
+      );
+    }
+
+    if (isHyperliquidNetwork(network)) {
+      return (
+        Boolean(
+          this.featureFlagService.featureFlags[
+            FeatureGates.HYPERLIQUID_FEATURE
+          ],
+        ) || Boolean(this._customNetworks[network.chainId])
+      );
+    }
+
+    return true;
+  };
+
   #filterBasedOnFeatureFlags = (chainList?: ChainList) => {
     return Object.values(chainList ?? {})
-      .filter(
-        (network) =>
-          (!isSolanaNetwork(network) ||
-            this.featureFlagService.featureFlags[
-              FeatureGates.SOLANA_SUPPORT
-            ]) &&
-          (!isHyperliquidNetwork(network) ||
-            this.featureFlagService.featureFlags[
-              FeatureGates.HYPERLIQUID_FEATURE
-            ] ||
-            Boolean(this._customNetworks[network.chainId])),
-      )
+      .filter((network) => this.isNetworkEnabledByFeatureFlags(network))
       .reduce(
         (acc, network) => ({
           ...acc,

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -58,6 +58,7 @@ import {
   getXPExplorerUrl,
   LOGO_BY_ALIAS,
 } from './avalanche-config';
+import { HYPERCORE_NETWORK, HYPEREVM_NETWORK } from './hyperliquid-config';
 
 @singleton()
 export class NetworkService implements OnLock, OnStorageReady {
@@ -487,6 +488,8 @@ export class NetworkService implements OnLock, OnStorageReady {
           [ChainId.AVALANCHE_TEST_X]: this._getXchainNetwork('testnet'),
           [ChainId.AVALANCHE_DEVNET_P]: this._getPchainNetwork('devnet'),
           [ChainId.AVALANCHE_DEVNET_X]: this._getXchainNetwork('devnet'),
+          [HYPEREVM_NETWORK.chainId]: HYPEREVM_NETWORK,
+          [HYPERCORE_NETWORK.chainId]: HYPERCORE_NETWORK,
         };
       } else {
         attempt += 1;

--- a/packages/service-worker/src/services/network/handlers/wallet_getEthereumChain.test.ts
+++ b/packages/service-worker/src/services/network/handlers/wallet_getEthereumChain.test.ts
@@ -66,6 +66,22 @@ describe('background/services/network/handlers/wallet_getEthereumChain.ts', () =
     expect(result.isTestnet).toEqual(true);
   });
 
+  it('handleAuthenticated rejects HyperCore (display-only)', async () => {
+    const networkServiceHypercore = {
+      getNetwork: () => ({ ...BITCOIN_NETWORK, chainName: 'HyperCore' }),
+    } as any;
+    const handler = new WalletGetEthereumChainHandler(networkServiceHypercore);
+    const result = await handler.handleAuthenticated(
+      buildRpcCall(getChainRequest),
+    );
+    expect(result).toEqual({
+      ...getChainRequest,
+      error: ethErrors.rpc.resourceUnavailable({
+        message: 'no active network',
+      }),
+    });
+  });
+
   it('handleUnauthenticated', async () => {
     const handler = new WalletGetEthereumChainHandler(
       networkServiceMockMainnet,

--- a/packages/service-worker/src/services/network/handlers/wallet_getEthereumChain.ts
+++ b/packages/service-worker/src/services/network/handlers/wallet_getEthereumChain.ts
@@ -4,6 +4,7 @@ import {
   DAppProviderRequest,
   DAppRequestHandler,
 } from '@core/types';
+import { isHypercoreNetwork } from '@core/common';
 import { ethErrors } from 'eth-rpc-errors';
 import { injectable } from 'tsyringe';
 import { NetworkService } from '../NetworkService';
@@ -33,7 +34,9 @@ export class WalletGetEthereumChainHandler extends DAppRequestHandler {
 
   handleAuthenticated = async ({ request, scope }) => {
     const activeNetwork = await this.networkService.getNetwork(scope);
-    if (!activeNetwork) {
+    // HyperCore is display-only and has no valid EVM chain descriptor (no RPC),
+    // so it must never be surfaced to dApps as a usable chain.
+    if (!activeNetwork || isHypercoreNetwork(activeNetwork)) {
       return {
         ...request,
         error: ethErrors.rpc.resourceUnavailable({

--- a/packages/service-worker/src/services/network/handlers/wallet_switchEthereumChain.test.ts
+++ b/packages/service-worker/src/services/network/handlers/wallet_switchEthereumChain.test.ts
@@ -3,7 +3,7 @@ import { buildRpcCall } from '@shared/tests/test-utils';
 import { DAppProviderRequest, DEFERRED_RESPONSE } from '@core/types';
 import { Network, NetworkVMType } from '@avalabs/core-chains-sdk';
 import { ethErrors } from 'eth-rpc-errors';
-import { canSkipApproval } from '@core/common';
+import { canSkipApproval, isHypercoreNetwork } from '@core/common';
 import { openApprovalWindow } from '~/runtime/openApprovalWindow';
 
 jest.mock('~/runtime/openApprovalWindow');
@@ -117,6 +117,24 @@ describe('src/background/services/network/handlers/wallet_switchEthereumChain.ts
       expect(result).toEqual({
         ...switchChainRequest,
         result: null,
+      });
+
+      expect(openApprovalWindow).toHaveBeenCalledTimes(0);
+    });
+
+    it('rejects switching to HyperCore (display-only)', async () => {
+      jest.mocked(isHypercoreNetwork).mockReturnValue(true);
+
+      const result = await handler.handleAuthenticated(
+        buildRpcCall(switchChainRequest),
+      );
+
+      expect(result).toEqual({
+        ...switchChainRequest,
+        error: ethErrors.provider.custom({
+          code: 4901,
+          message: `Chain ID "0xa869" is not available for dApp connections.`,
+        }),
       });
 
       expect(openApprovalWindow).toHaveBeenCalledTimes(0);

--- a/packages/service-worker/src/services/network/handlers/wallet_switchEthereumChain.ts
+++ b/packages/service-worker/src/services/network/handlers/wallet_switchEthereumChain.ts
@@ -8,7 +8,7 @@ import {
   JsonRpcRequestParams,
   NetworkWithCaipId,
 } from '@core/types';
-import { canSkipApproval } from '@core/common';
+import { canSkipApproval, isHypercoreNetwork } from '@core/common';
 import { ethErrors } from 'eth-rpc-errors';
 import { injectable } from 'tsyringe';
 import { NetworkService } from '../NetworkService';
@@ -56,6 +56,18 @@ export class WalletSwitchEthereumChainHandler extends DAppRequestHandler<
       Number(targetChainID),
     );
     const currentActiveNetwork = await this.networkService.getNetwork(scope);
+
+    // HyperCore is display-only (synthetic, no RPC), so dApps cannot switch to
+    // and transact on it despite it being modeled as an EVM network.
+    if (isHypercoreNetwork(supportedNetwork)) {
+      return {
+        ...request,
+        error: ethErrors.provider.custom({
+          code: 4901,
+          message: `Chain ID "${targetChainID}" is not available for dApp connections.`,
+        }),
+      };
+    }
 
     // If switch ethereum network is called, we need to verify the wallet
     // is not currently on the requested network. If it is, we just need to return early

--- a/packages/service-worker/src/services/network/hyperliquid-config.ts
+++ b/packages/service-worker/src/services/network/hyperliquid-config.ts
@@ -1,0 +1,63 @@
+import { Network, NetworkVMType } from '@avalabs/core-chains-sdk';
+import {
+  HYPERCORE_CHAIN_ID,
+  HYPERCORE_CHAIN_NAME,
+  HYPEREVM_CHAIN_ID,
+  HYPEREVM_CHAIN_NAME,
+} from '@core/common';
+
+const HYPERLIQUID_LOGO_URL =
+  'https://assets.coingecko.com/coins/images/50882/standard/hyperliquid.jpg';
+const HYPERLIQUID_PRIMARY_COLOR = '#97FCE4';
+
+export const HYPEREVM_NETWORK: Network = {
+  chainName: HYPEREVM_CHAIN_NAME,
+  chainId: HYPEREVM_CHAIN_ID,
+  vmName: NetworkVMType.EVM,
+  description: '',
+  rpcUrl: 'https://proxy-api.avax.network/proxy/nownodes/hype/evm',
+  isTestnet: false,
+  networkToken: {
+    name: 'Hyperliquid',
+    symbol: 'HYPE',
+    description: '',
+    decimals: 18,
+    logoUri: HYPERLIQUID_LOGO_URL,
+  },
+  logoUri: HYPERLIQUID_LOGO_URL,
+  primaryColor: HYPERLIQUID_PRIMARY_COLOR,
+  explorerUrl: 'https://hyperevmscan.io',
+  utilityAddresses: {
+    multicall: '0xca11bde05977b3631167028862be2a173976ca11',
+  },
+  pricingProviders: {
+    coingecko: {
+      assetPlatformId: 'hyperevm',
+      nativeTokenId: 'hyperliquid',
+    },
+  },
+};
+
+export const HYPERCORE_NETWORK: Network = {
+  chainName: HYPERCORE_CHAIN_NAME,
+  chainId: HYPERCORE_CHAIN_ID,
+  vmName: NetworkVMType.EVM,
+  description: '',
+  rpcUrl: '',
+  isTestnet: false,
+  networkToken: {
+    name: 'USD Coin',
+    symbol: 'USDC',
+    description: '',
+    decimals: 8,
+    logoUri: 'https://assets.coingecko.com/coins/images/6319/standard/usdc.png',
+  },
+  logoUri: HYPERLIQUID_LOGO_URL,
+  primaryColor: HYPERLIQUID_PRIMARY_COLOR,
+  explorerUrl: 'https://app.hyperliquid.xyz/explorer',
+  pricingProviders: {
+    coingecko: {
+      nativeTokenId: 'usd-coin',
+    },
+  },
+};


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-14551

## Notes

- Registers HyperEVM (ChainId 999) as a network
- Registers HyperCore as a synthetic, display-only network (ChainId 9999, no RPC) for surfacing perps/spot balances

## Testing
- Load up the extension and click on settings -> networks
- Search for HyperEVM and HyperCore

## Media

<img width="347" height="612" alt="Screenshot 2026-07-08 at 1 23 37 PM" src="https://github.com/user-attachments/assets/cb96ec9c-5098-4adb-8a03-57d01bcb1206" />
