### PR TITLE
fix: devnet mode, source maps shifting

### DIFF
--- a/packages/lavamoat-rspack/src/buildtime/emitSes.js
+++ b/packages/lavamoat-rspack/src/buildtime/emitSes.js
@@ -33,6 +33,41 @@ function shiftSourceMapDown(mapJson, lineCount) {
   return JSON.stringify(map);
 }
 
+/**
+ * Extracts the chunk's own inline source map from an asset's content.
+ *
+ * rspack appends the map as a `//# sourceMappingURL=` data URI on the asset's
+ * final line. Bundled dependencies (e.g. `@metamask/rpc-errors`) can ship their
+ * own inline maps embedded mid-file, so matching the marker anywhere would grab
+ * a dependency's map instead. We only accept the marker when it is the last
+ * line (nothing but whitespace follows) and read just that line — never to EOF.
+ *
+ * @param {string} content
+ * @returns {{ body: string, mapJson: string } | undefined}
+ */
+function extractTrailingInlineMap(content) {
+  let end = content.length;
+  while (end > 0 && /\s/.test(content[end - 1])) {
+    end--;
+  }
+  const lineStart = content.lastIndexOf('\n', end - 1) + 1;
+  const lastLine = content.slice(lineStart, end);
+  if (!lastLine.startsWith(INLINE_MAP_MARKER)) {
+    return undefined;
+  }
+  const b64Idx = lastLine.indexOf(BASE64_MARKER);
+  if (b64Idx === -1) {
+    return undefined;
+  }
+  return {
+    body: content.slice(0, lineStart),
+    mapJson: Buffer.from(
+      lastLine.slice(b64Idx + BASE64_MARKER.length),
+      'base64',
+    ).toString('utf-8'),
+  };
+}
+
 module.exports = {
   /**
    * @param {object} options
@@ -53,26 +88,18 @@ module.exports = {
         // Inline source map (dev): the map is baked into the asset content as
         // a trailing data URI. The devtool stage runs before this one, so the
         // embedded mappings have no idea the lockdown prefix is coming.
-        const markerIdx = content.lastIndexOf(INLINE_MAP_MARKER);
-        if (markerIdx !== -1) {
-          const b64Idx = content.indexOf(BASE64_MARKER, markerIdx);
-          if (b64Idx !== -1) {
-            const body = content.slice(0, markerIdx);
-            const b64 = content.slice(b64Idx + BASE64_MARKER.length).trim();
-            const shifted = shiftSourceMapDown(
-              Buffer.from(b64, 'base64').toString('utf-8'),
-              PREFIX_LINE_COUNT,
-            );
-            const rebuilt =
-              lockdownSourcePrefix +
-              body +
-              INLINE_MAP_MARKER +
-              ';charset=utf-8;' +
-              BASE64_MARKER +
-              Buffer.from(shifted, 'utf-8').toString('base64');
-            compilation.updateAsset(file, new RawSource(rebuilt));
-            continue;
-          }
+        const inline = extractTrailingInlineMap(content);
+        if (inline) {
+          const shifted = shiftSourceMapDown(inline.mapJson, PREFIX_LINE_COUNT);
+          const rebuilt =
+            lockdownSourcePrefix +
+            inline.body +
+            INLINE_MAP_MARKER +
+            ';charset=utf-8;' +
+            BASE64_MARKER +
+            Buffer.from(shifted, 'utf-8').toString('base64');
+          compilation.updateAsset(file, new RawSource(rebuilt));
+          continue;
         }
 
         // External source map (prod hidden-source-map): the JS asset has a

--- a/packages/lavamoat-rspack/src/buildtime/emitSes.js
+++ b/packages/lavamoat-rspack/src/buildtime/emitSes.js
@@ -8,6 +8,31 @@ const {
 const lockdownSource = readFileSync(require.resolve('ses'), 'utf-8');
 const lockdownSourcePrefix = `/*! SES sources included by LavaMoat. Do not optimize or minify. */\n;\n${lockdownSource}\n;/*! end SES */\n`;
 
+// ConcatSource places the original asset right after the prefix's final
+// newline, so the asset's first line moves down by exactly this many lines.
+const PREFIX_LINE_COUNT = (lockdownSourcePrefix.match(/\n/g) || []).length;
+
+const INLINE_MAP_MARKER = '//# sourceMappingURL=data:application/json';
+const BASE64_MARKER = 'base64,';
+
+/**
+ * Prepends empty lines to a source map's `mappings` so every mapping shifts
+ * down by `lineCount`. Mappings are line-delimited by `;`, so prepending
+ * `lineCount` semicolons inserts that many unmapped lines at the top without
+ * touching any VLQ segments.
+ *
+ * @param {string} mapJson
+ * @param {number} lineCount
+ * @returns {string}
+ */
+function shiftSourceMapDown(mapJson, lineCount) {
+  const map = JSON.parse(mapJson);
+  if (typeof map.mappings === 'string') {
+    map.mappings = ';'.repeat(lineCount) + map.mappings;
+  }
+  return JSON.stringify(map);
+}
+
 module.exports = {
   /**
    * @param {object} options
@@ -23,10 +48,51 @@ module.exports = {
           continue;
         }
         const asset = compilation.assets[file];
-        compilation.assets[file] = new ConcatSource(
-          lockdownSourcePrefix,
-          asset,
+        const content = asset.source().toString();
+
+        // Inline source map (dev): the map is baked into the asset content as
+        // a trailing data URI. The devtool stage runs before this one, so the
+        // embedded mappings have no idea the lockdown prefix is coming.
+        const markerIdx = content.lastIndexOf(INLINE_MAP_MARKER);
+        if (markerIdx !== -1) {
+          const b64Idx = content.indexOf(BASE64_MARKER, markerIdx);
+          if (b64Idx !== -1) {
+            const body = content.slice(0, markerIdx);
+            const b64 = content.slice(b64Idx + BASE64_MARKER.length).trim();
+            const shifted = shiftSourceMapDown(
+              Buffer.from(b64, 'base64').toString('utf-8'),
+              PREFIX_LINE_COUNT,
+            );
+            const rebuilt =
+              lockdownSourcePrefix +
+              body +
+              INLINE_MAP_MARKER +
+              ';charset=utf-8;' +
+              BASE64_MARKER +
+              Buffer.from(shifted, 'utf-8').toString('base64');
+            compilation.updateAsset(file, new RawSource(rebuilt));
+            continue;
+          }
+        }
+
+        // External source map (prod hidden-source-map): the JS asset has a
+        // sibling `.map` asset whose mappings must shift by the same amount.
+        const related = asset.info && asset.info.related;
+        const mapFile =
+          related && typeof related.sourceMap === 'string'
+            ? related.sourceMap
+            : undefined;
+        compilation.updateAsset(
+          file,
+          new ConcatSource(lockdownSourcePrefix, asset),
         );
+        if (mapFile && compilation.assets[mapFile]) {
+          const shifted = shiftSourceMapDown(
+            compilation.assets[mapFile].source().toString(),
+            PREFIX_LINE_COUNT,
+          );
+          compilation.updateAsset(mapFile, new RawSource(shifted));
+        }
       }
     },
   /**

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -686,7 +686,9 @@ describe('background/services/network/NetworkService', () => {
       expect(storageServiceMock.load).toHaveBeenCalledWith(
         NETWORK_LIST_STORAGE_KEY,
       );
-      expect(dispatchSpy).toHaveBeenCalledWith(cachedChainList);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining(cachedChainList),
+      );
     });
   });
 

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -387,6 +387,7 @@ export class NetworkService implements OnLock, OnStorageReady {
     this._customNetworks = storedState?.customNetworks || {};
     const fullChainlist = {
       ...chainlist,
+      ...this.#buildDevnetEntries(),
       ...this._customNetworks,
     };
 
@@ -414,6 +415,13 @@ export class NetworkService implements OnLock, OnStorageReady {
     }
 
     return networkList;
+  }
+
+  #buildDevnetEntries(): ChainList {
+    return {
+      [ChainId.AVALANCHE_DEVNET_P]: this._getPchainNetwork('devnet'),
+      [ChainId.AVALANCHE_DEVNET_X]: this._getXchainNetwork('devnet'),
+    };
   }
 
   private _getPchainNetwork(type: AvalancheNetworkType): NetworkWithCaipId {
@@ -682,9 +690,14 @@ export class NetworkService implements OnLock, OnStorageReady {
 
     await this.updateNetworkState();
 
-    // Dispatch _allNetworks signal so the changes are reflected in the UI
+    // Dispatch _allNetworks signal so the changes are reflected in the UI.
+    // The devnet entries embed the devnet RPC/explorer URLs at build time,
+    // so they must be rebuilt from the updated mode.
     const chainlist = await this._rawNetworks.promisify();
-    this._allNetworks.dispatch({ ...chainlist });
+    this._allNetworks.dispatch({
+      ...chainlist,
+      ...this.#buildDevnetEntries(),
+    });
 
     // Only dispatch the developer mode changed signal after chainlist has been rebuilt,
     // so the services depending on it can react to the updated configs.


### PR DESCRIPTION
# Summary

Jira tickets:
* https://ava-labs.atlassian.net/browse/CP-14740
* https://ava-labs.atlassian.net/browse/CP-14741

<!-- Describe the changes -->
<!-- Link the Jira ticket and Figma designs. Prefer listing expectations vs. linking large docs like PRD -->

## Notes
### Devnet mode
Updating custom Avalanche devnet RPC URLs used stale RPC URL built during extension startup. The new values were never propagated to the chain list.

### Source maps shifting
After modules are bundled, the Lavamoat plugin wraps them in SES compartments, effectively shifting the code a few lines down and therefore making the source maps unusable.
This PR checks how long the SES prefix is and fixes the inline source mappings.

## Testing
_Detailed in the tickets_
<!-- Add high-level testing information for the reviewer to properly QA (wallet setup, local storage overrides, etc.) -->

## Media

### Source maps

https://github.com/user-attachments/assets/4d5382b9-4cdd-4eea-b2b9-17c5ec7f0fd6


https://github.com/user-attachments/assets/e9bc9ab3-38f7-4572-9c0e-ae6ae202b3d4

