### PR TITLE
fix: avalanche cct qa fixes

### DIFF
--- a/apps/next/src/components/TokenAmountInput/TokenAmountInput.tsx
+++ b/apps/next/src/components/TokenAmountInput/TokenAmountInput.tsx
@@ -1,5 +1,6 @@
 import { TokenUnit } from '@avalabs/core-utils-sdk';
 import {
+  ButtonProps,
   CircularProgress,
   Collapse,
   Grow,
@@ -53,6 +54,7 @@ type TokenAmountInputProps = {
   disabled?: boolean;
   chainFilterMode?: ChainFilterMode;
   presetButtonsStartSlot?: ReactNode;
+  presetButtonSx?: ButtonProps['sx'];
 } & AmountInputProps;
 
 type AmountInputProps =
@@ -97,6 +99,7 @@ export const TokenAmountInput: FC<TokenAmountInputProps> = ({
   disabled,
   chainFilterMode,
   presetButtonsStartSlot,
+  presetButtonSx,
 }) => {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -264,12 +267,14 @@ export const TokenAmountInput: FC<TokenAmountInputProps> = ({
             <AmountPresetButton
               onClick={() => handlePresetClick(25)}
               disabled={arePresetButtonsDisabled}
+              sx={presetButtonSx}
             >
               {t('25%')}
             </AmountPresetButton>
             <AmountPresetButton
               onClick={() => handlePresetClick(50)}
               disabled={arePresetButtonsDisabled}
+              sx={presetButtonSx}
             >
               {t('50%')}
             </AmountPresetButton>
@@ -277,6 +282,7 @@ export const TokenAmountInput: FC<TokenAmountInputProps> = ({
               data-testid="amount-preset-max"
               onClick={() => handlePresetClick(100)}
               disabled={arePresetButtonsDisabled}
+              sx={presetButtonSx}
             >
               {t('Max')}
             </AmountPresetButton>

--- a/apps/next/src/pages/Fusion/components/SwapCctTransactionWarning.tsx
+++ b/apps/next/src/pages/Fusion/components/SwapCctTransactionWarning.tsx
@@ -29,10 +29,14 @@ export const SwapCctTransactionWarning = () => {
           <MdErrorOutline size={24} color={theme.palette.error.main} />
         </Stack>
         <Stack>
-          <Typography variant="body2" color="error.main">
+          <Typography variant="caption" color="error.main">
             {t('This swap will require two transactions.')}
           </Typography>
-          <Typography variant="body2" color="error.main">
+          <Typography
+            variant="caption"
+            color="error.main"
+            sx={{ textWrap: 'pretty' }}
+          >
             {t('You will need to sign twice. One export and one import.')}
           </Typography>
         </Stack>

--- a/apps/next/src/pages/Fusion/components/SwapPair.tsx
+++ b/apps/next/src/pages/Fusion/components/SwapPair.tsx
@@ -135,6 +135,7 @@ export const SwapPair = () => {
           tokenHint={sourceToken ? t('You pay') : undefined}
           withPresetButtons={minimumRequiredTokens.state === 'complete'}
           chainFilterMode={chainFilterMode}
+          presetButtonSx={selectUtxosUrl ? { px: 1 } : undefined}
           presetButtonsStartSlot={
             selectUtxosUrl ? (
               <Button

--- a/apps/next/src/pages/Notifications/components/TransferItem.tsx
+++ b/apps/next/src/pages/Notifications/components/TransferItem.tsx
@@ -1,8 +1,9 @@
 import { AnimatedSyncIcon } from '@/components/AnimatedSyncIcon';
+import { getChainFilterName } from '@/components/TokenSelect/utils';
 import { Box, useTheme } from '@avalabs/k2-alpine';
 import { FC } from 'react';
 import * as Styled from './Styled';
-import { Transfer } from '@avalabs/fusion-sdk';
+import { ServiceType, Transfer } from '@avalabs/fusion-sdk';
 import {
   isCompletedTransfer,
   isConcludedTransfer,
@@ -11,6 +12,7 @@ import {
   isTransferInProgress,
 } from '@core/types';
 import { useTransferTrackingContext } from '@core/ui';
+import { caipToChainId } from '@core/common';
 import { MdCheckCircle, MdError, MdReplay } from 'react-icons/md';
 import { TFunction, useTranslation } from 'react-i18next';
 import { getTransferTimestamp } from '../lib/getTransferTimestamp';
@@ -77,21 +79,38 @@ export const TransferItem: FC<Props> = ({ transfer, showSeparator }) => {
 };
 
 const getTransferTitle = (transfer: Transfer, t: TFunction) => {
+  const sourceToken = getTransferTokenLabel(transfer, 'source');
+  const targetToken = getTransferTokenLabel(transfer, 'target');
+
   if (isCompletedTransfer(transfer)) {
     return t('Swapped {{sourceToken}} to {{targetToken}}', {
-      sourceToken: transfer.sourceAsset.symbol,
-      targetToken: transfer.targetAsset.symbol,
+      sourceToken,
+      targetToken,
     });
   }
 
   if (isFailedTransfer(transfer)) {
     return t('Swapping {{sourceToken}} to {{targetToken}} failed', {
-      sourceToken: transfer.sourceAsset.symbol,
-      targetToken: transfer.targetAsset.symbol,
+      sourceToken,
+      targetToken,
     });
   }
   return t('Swapping {{sourceToken}} to {{targetToken}} in progress...', {
-    sourceToken: transfer.sourceAsset.symbol,
-    targetToken: transfer.targetAsset.symbol,
+    sourceToken,
+    targetToken,
   });
+};
+
+const getTransferTokenLabel = (
+  transfer: Transfer,
+  side: 'source' | 'target',
+) => {
+  const asset = side === 'source' ? transfer.sourceAsset : transfer.targetAsset;
+  const chain = side === 'source' ? transfer.sourceChain : transfer.targetChain;
+
+  if (transfer.type !== ServiceType.AVALANCHE_CCT) {
+    return asset.symbol;
+  }
+
+  return `${asset.symbol} (${getChainFilterName(caipToChainId(chain.chainId))})`;
 };

--- a/apps/next/src/pages/Portfolio/components/PortfolioHome/components/AtomicFundsBalance.tsx
+++ b/apps/next/src/pages/Portfolio/components/PortfolioHome/components/AtomicFundsBalance.tsx
@@ -1,14 +1,27 @@
 import { Card } from '@/components/Card';
 import { CORE_WEB_BASE_URL } from '@/config';
+import { ServiceType, Transfer } from '@avalabs/fusion-sdk';
 import { Box, Button, Stack, styled, Typography } from '@avalabs/k2-alpine';
-import { useBalancesContext } from '@core/ui/src/contexts/BalancesProvider';
-import { FC } from 'react';
+import { stripAddressPrefix } from '@core/common';
+import {
+  Account,
+  isCompletedTransfer,
+  isTransferInProgress,
+} from '@core/types';
+import {
+  useAccountsContext,
+  useBalancesContext,
+  useTransferTrackingContext,
+} from '@core/ui';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FiAlertCircle } from 'react-icons/fi';
 
 type Props = {
   accountId: string | undefined;
 };
+
+const RECENT_AVALANCHE_CCT_COMPLETION_GRACE_PERIOD_MS = 15_000;
 
 const StyledCard = styled(Card)(({ theme }) =>
   theme.palette.mode === 'light'
@@ -18,13 +31,89 @@ const StyledCard = styled(Card)(({ theme }) =>
     : {},
 );
 
+const normalizeAddress = (address: string | undefined) =>
+  address ? stripAddressPrefix(address).toLowerCase() : undefined;
+
+const isTransferForAccount = (transfer: Transfer, account: Account) => {
+  const accountAddresses = new Set(
+    [
+      account.addressC,
+      account.addressCoreEth,
+      account.addressAVM,
+      account.addressPVM,
+    ]
+      .map(normalizeAddress)
+      .filter(Boolean),
+  );
+
+  return (
+    accountAddresses.has(normalizeAddress(transfer.fromAddress)) ||
+    accountAddresses.has(normalizeAddress(transfer.toAddress))
+  );
+};
+
 // TODO: Multiple token support
 export const AtomicFundsBalance: FC<Props> = ({ accountId }) => {
   const { t } = useTranslation();
+  const {
+    accounts: { active },
+  } = useAccountsContext();
   const { getAtomicBalance } = useBalancesContext();
+  const { transfers } = useTransferTrackingContext();
+  const [now, setNow] = useState(() => Date.now());
   const atomicBalance = getAtomicBalance(accountId);
 
-  if (!accountId || !atomicBalance?.balanceDisplayValue) {
+  const suppressRecoveryBannerUntil = useMemo(() => {
+    if (!active) {
+      return 0;
+    }
+
+    return transfers.reduce((suppressUntil, { transfer }) => {
+      if (
+        transfer.type !== ServiceType.AVALANCHE_CCT ||
+        !isTransferForAccount(transfer, active)
+      ) {
+        return suppressUntil;
+      }
+
+      if (isTransferInProgress(transfer)) {
+        return Number.POSITIVE_INFINITY;
+      }
+
+      if (isCompletedTransfer(transfer)) {
+        return Math.max(
+          suppressUntil,
+          transfer.completedAtMs +
+            RECENT_AVALANCHE_CCT_COMPLETION_GRACE_PERIOD_MS,
+        );
+      }
+
+      return suppressUntil;
+    }, 0);
+  }, [active, transfers]);
+
+  useEffect(() => {
+    if (
+      suppressRecoveryBannerUntil === 0 ||
+      suppressRecoveryBannerUntil === Number.POSITIVE_INFINITY ||
+      suppressRecoveryBannerUntil <= now
+    ) {
+      return;
+    }
+
+    const timeout = setTimeout(
+      () => setNow(Date.now()),
+      suppressRecoveryBannerUntil - now,
+    );
+
+    return () => clearTimeout(timeout);
+  }, [now, suppressRecoveryBannerUntil]);
+
+  if (
+    !accountId ||
+    !atomicBalance?.balanceDisplayValue ||
+    suppressRecoveryBannerUntil > now
+  ) {
     return null;
   }
 

--- a/apps/next/src/pages/Portfolio/components/PortfolioHome/components/AtomicFundsBalance.tsx
+++ b/apps/next/src/pages/Portfolio/components/PortfolioHome/components/AtomicFundsBalance.tsx
@@ -34,21 +34,26 @@ const StyledCard = styled(Card)(({ theme }) =>
 const normalizeAddress = (address: string | undefined) =>
   address ? stripAddressPrefix(address).toLowerCase() : undefined;
 
-const isTransferForAccount = (transfer: Transfer, account: Account) => {
-  const accountAddresses = new Set(
+const getAccountAddresses = (account: Account) =>
+  new Set(
     [
-      account.addressC,
-      account.addressCoreEth,
-      account.addressAVM,
-      account.addressPVM,
-    ]
-      .map(normalizeAddress)
-      .filter(Boolean),
+      normalizeAddress(account.addressC),
+      normalizeAddress(account.addressCoreEth),
+      normalizeAddress(account.addressAVM),
+      normalizeAddress(account.addressPVM),
+    ].filter((address): address is string => Boolean(address)),
   );
 
-  return (
-    accountAddresses.has(normalizeAddress(transfer.fromAddress)) ||
-    accountAddresses.has(normalizeAddress(transfer.toAddress))
+const isTransferForAccount = (
+  transfer: Transfer,
+  accountAddresses: Set<string>,
+) => {
+  const fromAddress = normalizeAddress(transfer.fromAddress);
+  const toAddress = normalizeAddress(transfer.toAddress);
+
+  return Boolean(
+    (fromAddress && accountAddresses.has(fromAddress)) ||
+      (toAddress && accountAddresses.has(toAddress)),
   );
 };
 
@@ -68,10 +73,12 @@ export const AtomicFundsBalance: FC<Props> = ({ accountId }) => {
       return 0;
     }
 
+    const accountAddresses = getAccountAddresses(active);
+
     return transfers.reduce((suppressUntil, { transfer }) => {
       if (
         transfer.type !== ServiceType.AVALANCHE_CCT ||
-        !isTransferForAccount(transfer, active)
+        !isTransferForAccount(transfer, accountAddresses)
       ) {
         return suppressUntil;
       }
@@ -93,21 +100,29 @@ export const AtomicFundsBalance: FC<Props> = ({ accountId }) => {
   }, [active, transfers]);
 
   useEffect(() => {
+    const currentTime = Date.now();
+
     if (
       suppressRecoveryBannerUntil === 0 ||
-      suppressRecoveryBannerUntil === Number.POSITIVE_INFINITY ||
-      suppressRecoveryBannerUntil <= now
+      suppressRecoveryBannerUntil === Number.POSITIVE_INFINITY
     ) {
       return;
     }
 
+    if (suppressRecoveryBannerUntil <= currentTime) {
+      setNow(currentTime);
+      return;
+    }
+
+    setNow(currentTime);
+
     const timeout = setTimeout(
       () => setNow(Date.now()),
-      suppressRecoveryBannerUntil - now,
+      suppressRecoveryBannerUntil - currentTime,
     );
 
     return () => clearTimeout(timeout);
-  }, [now, suppressRecoveryBannerUntil]);
+  }, [suppressRecoveryBannerUntil]);
 
   if (
     !accountId ||


### PR DESCRIPTION
This PR addresses a couple small things caught by QA during review that need fixed before shipping.

1. "Select UTXOs" button gets squashed because of other inline button sizes.
2. "This swap will require two transactions" warning message for avalanche cct swaps text is to large and needs sized down
3. Avalanche CCT swap notification messages need more detail.
4. Message for stuck atomics recovery can display immediately after successful swap.

Fixes:
1. Decreased horizontal button padding for 25%, 50%, and Max buttons. All buttons now fit in default extension width.
2. Message text sized down to "caption" style.
3. Notification message for Avalanche CCT transfers now are formatted like: "Swapped AVAX (C-Chain) to AVAX (P-Chain)".
4. Adjusts logic for stuck atomics message display. Does not display if there are any pending avalanche cct transfers. Also waits for a grace period after completed transfers for balance service to refresh before displaying message.