### PR TITLE
fix: qa issues with avalanche cct

### DIFF
--- a/apps/next/package.json
+++ b/apps/next/package.json
@@ -22,7 +22,7 @@
     "@avalabs/core-chains-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/fusion-sdk": "0.26.0",
+    "@avalabs/fusion-sdk": "0.26.1",
     "@avalabs/k2-alpine": "1.266.0",
     "@avalabs/prediction-market-sdk": "1.1.4",
     "@avalabs/types": "3.1.0-alpha.87",

--- a/apps/next/src/pages/Fusion/contexts/hooks/useBridgeableTargetTokenList.test.ts
+++ b/apps/next/src/pages/Fusion/contexts/hooks/useBridgeableTargetTokenList.test.ts
@@ -1,0 +1,66 @@
+import { ChainId, NetworkVMType } from '@avalabs/core-chains-sdk';
+import { type BridgeableUiAsset, TokenType } from '@avalabs/fusion-sdk';
+import { TokenType as VmTokenType } from '@avalabs/vm-module-types';
+
+import { type NetworkWithCaipId } from '@core/types';
+
+import { mapBridgeableAsset } from './useBridgeableTargetTokenList';
+
+const nativeBridgeableAsset = (
+  overrides: Partial<BridgeableUiAsset> = {},
+): BridgeableUiAsset =>
+  ({
+    name: 'Avalanche',
+    symbol: 'AVAX',
+    decimals: 18,
+    type: TokenType.NATIVE,
+    ...overrides,
+  }) as BridgeableUiAsset;
+
+const network = (
+  overrides: Partial<NetworkWithCaipId> = {},
+): NetworkWithCaipId =>
+  ({
+    chainId: ChainId.AVALANCHE_MAINNET_ID,
+    chainName: 'Avalanche',
+    caipId: 'eip155:43114',
+    vmName: NetworkVMType.EVM,
+    rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+    explorerUrl: 'https://snowtrace.io',
+    networkToken: {
+      name: 'Avalanche',
+      symbol: 'AVAX',
+      decimals: 18,
+      logoUri: 'network-token-logo.svg',
+      description: 'Avalanche native token',
+    },
+    logoUri: 'network-logo.svg',
+    ...overrides,
+  }) as NetworkWithCaipId;
+
+describe('mapBridgeableAsset', () => {
+  it('uses destination network decimals for P/X native AVAX', () => {
+    const token = mapBridgeableAsset(
+      nativeBridgeableAsset({ decimals: 18 }),
+      network({
+        chainId: ChainId.AVALANCHE_X,
+        caipId: 'avax:x-chain',
+        vmName: NetworkVMType.AVM,
+        networkToken: {
+          name: 'Avalanche',
+          symbol: 'AVAX',
+          decimals: 9,
+          logoUri: 'x-chain-avax-logo.svg',
+          description: 'Avalanche native token',
+        },
+      }),
+      'c-chain-avax-logo.svg',
+    );
+
+    expect(token).toMatchObject({
+      type: VmTokenType.NATIVE,
+      assetType: 'avm_native',
+      decimals: 9,
+    });
+  });
+});

--- a/apps/next/src/pages/Fusion/contexts/hooks/useBridgeableTargetTokenList.ts
+++ b/apps/next/src/pages/Fusion/contexts/hooks/useBridgeableTargetTokenList.ts
@@ -63,7 +63,7 @@ const getHasMore = (
   return true;
 };
 
-const mapBridgeableAsset = (
+export const mapBridgeableAsset = (
   asset: BridgeableUiAsset,
   network: NetworkWithCaipId,
   cChainAvaxLogoUri: string | undefined,
@@ -71,9 +71,13 @@ const mapBridgeableAsset = (
   const isVerified =
     (asset.extras?.isVerified as boolean | null | undefined) ?? null;
   const logoUri =
-    isPchainNetworkId(network.chainId) || isXchainNetworkId(network.chainId)
-      ? cChainAvaxLogoUri
-      : (asset.logoUri ?? undefined);
+    typeof asset.logoUri === 'string' && asset.logoUri.trim() !== ''
+      ? asset.logoUri
+      : isPchainNetworkId(network.chainId) ||
+          isXchainNetworkId(network.chainId) ||
+          isAvalancheChainId(network.chainId)
+        ? cChainAvaxLogoUri
+        : undefined;
   const base = {
     name: asset.name,
     symbol: asset.symbol,
@@ -90,6 +94,7 @@ const mapBridgeableAsset = (
   if (asset.type === FusionTokenType.NATIVE) {
     return {
       ...base,
+      decimals: network.networkToken.decimals,
       type: TokenType.NATIVE,
       assetType: getNativeAssetType(network),
     } as unknown as FungibleTokenBalance;

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,7 +20,7 @@
     "@sentry/browser": "7.66.0"
   },
   "devDependencies": {
-    "@avalabs/fusion-sdk": "0.26.0",
+    "@avalabs/fusion-sdk": "0.26.1",
     "@eslint/compat": "1.2.4",
     "@eslint/eslintrc": "3.2.0",
     "@eslint/js": "9.16.0",

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -32,7 +32,7 @@
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
     "@avalabs/crypto-wasm": "0.3.0",
     "@avalabs/evm-module": "3.10.0",
-    "@avalabs/fusion-sdk": "0.26.0",
+    "@avalabs/fusion-sdk": "0.26.1",
     "@avalabs/glacier-sdk": "3.1.0-alpha.87",
     "@avalabs/hvm-module": "3.10.0",
     "@avalabs/hw-app-avalanche": "1.1.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "src/index.ts",
   "devDependencies": {
-    "@avalabs/fusion-sdk": "0.26.0",
+    "@avalabs/fusion-sdk": "0.26.1",
     "fireblocks-sdk": "5.20.0",
     "joi": "17.7.0",
     "jose": "4.15.5"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
     "@avalabs/core-token-prices-sdk": "3.1.0-alpha.87",
     "@avalabs/core-utils-sdk": "3.1.0-alpha.87",
     "@avalabs/core-wallets-sdk": "3.1.0-alpha.87",
-    "@avalabs/fusion-sdk": "0.26.0",
+    "@avalabs/fusion-sdk": "0.26.1",
     "@avalabs/glacier-sdk": "3.1.0-alpha.87",
     "@avalabs/hw-app-avalanche": "1.1.1",
     "@avalabs/types": "3.1.0-alpha.87",

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,9 +333,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avalabs/fusion-sdk@npm:0.26.0":
-  version: 0.26.0
-  resolution: "@avalabs/fusion-sdk@npm:0.26.0"
+"@avalabs/fusion-sdk@npm:0.26.1":
+  version: 0.26.1
+  resolution: "@avalabs/fusion-sdk@npm:0.26.1"
   dependencies:
     "@bitcoinerlab/secp256k1": "npm:^1.2.0"
     "@layerzerolabs/lz-v2-utilities": "npm:^3.0.17"
@@ -351,7 +351,7 @@ __metadata:
     "@solana/kit": ^5.0.0 || ^6.0.0
     viem: ^2.38.0
     zod: ^4.1.0
-  checksum: 10c0/6f93e4fad090903ecabe365efc8ce407b03d08911c2fcb97cdb2fbc5719518a70cc73f8d5d5a7ef1d97ed2a094b6a9fe33f3ebd8710841262ce1cf9bb9f9d1e0
+  checksum: 10c0/2e537935315d0262f500bef4dba92bb7547c804abe71c1d4191aa1565ae9d97e140ca24a96f7bfb837e46ce8c584d910c772f112782682123805c11afa2c0429
   languageName: node
   linkType: hard
 
@@ -2819,7 +2819,7 @@ __metadata:
     "@avalabs/core-chains-sdk": "npm:3.1.0-alpha.87"
     "@avalabs/core-utils-sdk": "npm:3.1.0-alpha.87"
     "@avalabs/core-wallets-sdk": "npm:3.1.0-alpha.87"
-    "@avalabs/fusion-sdk": "npm:0.26.0"
+    "@avalabs/fusion-sdk": "npm:0.26.1"
     "@avalabs/k2-alpine": "npm:1.266.0"
     "@avalabs/prediction-market-sdk": "npm:1.1.4"
     "@avalabs/types": "npm:3.1.0-alpha.87"
@@ -2940,7 +2940,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@core/common@workspace:packages/common"
   dependencies:
-    "@avalabs/fusion-sdk": "npm:0.26.0"
+    "@avalabs/fusion-sdk": "npm:0.26.1"
     "@eslint/compat": "npm:1.2.4"
     "@eslint/eslintrc": "npm:3.2.0"
     "@eslint/js": "npm:9.16.0"
@@ -3113,7 +3113,7 @@ __metadata:
     "@avalabs/core-wallets-sdk": "npm:3.1.0-alpha.87"
     "@avalabs/crypto-wasm": "npm:0.3.0"
     "@avalabs/evm-module": "npm:3.10.0"
-    "@avalabs/fusion-sdk": "npm:0.26.0"
+    "@avalabs/fusion-sdk": "npm:0.26.1"
     "@avalabs/glacier-sdk": "npm:3.1.0-alpha.87"
     "@avalabs/hvm-module": "npm:3.10.0"
     "@avalabs/hw-app-avalanche": "npm:1.1.1"
@@ -3260,7 +3260,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@core/types@workspace:packages/types"
   dependencies:
-    "@avalabs/fusion-sdk": "npm:0.26.0"
+    "@avalabs/fusion-sdk": "npm:0.26.1"
     fireblocks-sdk: "npm:5.20.0"
     joi: "npm:17.7.0"
     jose: "npm:4.15.5"
@@ -3282,7 +3282,7 @@ __metadata:
     "@avalabs/core-token-prices-sdk": "npm:3.1.0-alpha.87"
     "@avalabs/core-utils-sdk": "npm:3.1.0-alpha.87"
     "@avalabs/core-wallets-sdk": "npm:3.1.0-alpha.87"
-    "@avalabs/fusion-sdk": "npm:0.26.0"
+    "@avalabs/fusion-sdk": "npm:0.26.1"
     "@avalabs/glacier-sdk": "npm:3.1.0-alpha.87"
     "@avalabs/hw-app-avalanche": "npm:1.1.1"
     "@avalabs/types": "npm:3.1.0-alpha.87"


### PR DESCRIPTION
Fixes the latest round of issues found by QA when checking the blue build as it relates to Avalanche CCT in swap.

1. Logos were not displaying correctly for C-Chain AVAX in the destination picker.
2. X/P AVAX balance and output amount were not correct when they were the destination token.

---

Fixes:

1. Bumped fusion-sdk version. Assets and chain info coming out of SDK now include logoUri info. So we now default to using that info and then for the fallback we include c-chain AVAX checking and not just X/P.
2. X/P tokens were getting the wrong decimal precision and were off by 1e9. Setting them properly to network token decimal amount (ie 9 for P/X) fixes the issue.