### PR TITLE
chore: dependabot consolidated

### DIFF
--- a/apps/next/lavamoat/rspack/policy.json
+++ b/apps/next/lavamoat/rspack/policy.json
@@ -581,28 +581,28 @@
       "packages": {
         "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bytes": true,
         "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/logger": true,
-        "@core/ui>bn.js": true
+        "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bignumber>bn.js": true
       }
     },
     "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/address>@ethersproject/bignumber": {
       "packages": {
         "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/address>@ethersproject/bytes": true,
         "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/address>@ethersproject/logger": true,
-        "@core/ui>bn.js": true
+        "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/address>@ethersproject/bignumber>bn.js": true
       }
     },
     "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber": {
       "packages": {
         "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/bytes": true,
         "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber>@ethersproject/logger": true,
-        "@core/ui>bn.js": true
+        "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber>bn.js": true
       }
     },
     "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/bignumber": {
       "packages": {
         "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/bytes": true,
         "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/logger": true,
-        "@core/ui>bn.js": true
+        "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/bignumber>bn.js": true
       }
     },
     "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bytes": {
@@ -741,7 +741,7 @@
         "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key>@ethersproject/bytes": true,
         "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key>@ethersproject/logger": true,
         "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/properties": true,
-        "@core/ui>bn.js": true,
+        "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key>bn.js": true,
         "@keystonehq/hw-app-eth>elliptic>hash.js": true
       }
     },
@@ -1449,7 +1449,7 @@
         "@avalabs/fusion-sdk>@layerzerolabs/lz-v2-utilities>bs58": true,
         "@rsbuild/plugin-node-polyfill>buffer": true,
         "@core/service-worker>fireblocks-sdk>@notabene/pii-sdk>did-jwt": true,
-        "@core/ui>lodash": true,
+        "@core/service-worker>fireblocks-sdk>@notabene/pii-sdk>lodash": true,
         "@core/service-worker>fireblocks-sdk>@notabene/pii-sdk>multibase": true,
         "@core/service-worker>fireblocks-sdk>@notabene/pii-sdk>multicodec": true
       }
@@ -2546,7 +2546,42 @@
         "Buffer": true
       }
     },
+    "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/bignumber>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@avalabs/bridge-unified>@layerzerolabs/lz-v2-utilities>@ethersproject/address>@ethersproject/bignumber>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/abi>@ethersproject/constants>@ethersproject/bignumber>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/bignumber>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@core/ui>@ledgerhq/hw-app-eth>@ethersproject/transactions>@ethersproject/signing-key>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
     "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>parse-asn1>asn1.js>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": {
       "globals": {
         "Buffer": true
       }
@@ -2566,12 +2601,22 @@
         "Buffer": true
       }
     },
+    "@core/ui>@ethereumjs/tx>ethereumjs-util>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
     "@rsbuild/plugin-node-polyfill>crypto-browserify>diffie-hellman>miller-rabin>bn.js": {
       "globals": {
         "Buffer": true
       }
     },
     "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
+    "@keystonehq/hw-app-eth>rlp>bn.js": {
       "globals": {
         "Buffer": true
       }
@@ -2620,14 +2665,14 @@
         "Buffer": true
       },
       "packages": {
-        "@core/ui>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa>bn.js": true,
         "@rsbuild/plugin-node-polyfill>buffer": true,
         "@core/ui>bip39>randombytes": true
       }
     },
     "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign": {
       "packages": {
-        "@core/ui>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": true,
         "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa": true,
         "@avalabs/core-wallets-sdk>create-hash": true,
         "@core/ui>bip32>create-hmac": true,
@@ -3070,7 +3115,7 @@
       },
       "packages": {
         "@rsbuild/plugin-node-polyfill>assert": true,
-        "@core/ui>bn.js": true,
+        "@core/ui>@ethereumjs/tx>ethereumjs-util>bn.js": true,
         "@core/service-worker>buffer": true,
         "@rsbuild/plugin-node-polyfill>buffer": true,
         "@avalabs/core-wallets-sdk>create-hash": true,
@@ -3570,7 +3615,7 @@
         "@rsbuild/plugin-node-polyfill>buffer": true,
         "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
         "@core/service-worker>fireblocks-sdk>jsonwebtoken>jws": true,
-        "@core/ui>lodash": true,
+        "@core/service-worker>fireblocks-sdk>jsonwebtoken>lodash": true,
         "semantic-release>@semantic-release/npm>npm>ms": true,
         "@rsbuild/plugin-node-polyfill>process": true,
         "@core/ui>semver": true
@@ -3642,6 +3687,16 @@
       }
     },
     "@core/ui>lodash": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@core/service-worker>fireblocks-sdk>@notabene/pii-sdk>lodash": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@core/service-worker>fireblocks-sdk>jsonwebtoken>lodash": {
       "globals": {
         "define": true
       }
@@ -4333,7 +4388,7 @@
         "Buffer.isBuffer": true
       },
       "packages": {
-        "@core/ui>bn.js": true,
+        "@keystonehq/hw-app-eth>rlp>bn.js": true,
         "@rsbuild/plugin-node-polyfill>buffer": true
       }
     },

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -949,15 +949,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.2":
-  version: 7.5.6
-  resolution: "tar@npm:7.5.6"
+  version: 7.5.9
+  resolution: "tar@npm:7.5.9"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/08af3807035957650ad5f2a300c49ca4fe0566ac0ea5a23741a5b5103c6da42891a9eeaed39bc1fbcf21c5cac4dc846828a004727fb08b9d946322d3144d1fd2
+  checksum: 10c0/e870beb1b2477135ca2abe86b2d18f7b35d0a4e3a37bbc523d3b8f7adca268dfab543f26528a431d569897f8c53a7cac745cdfbc4411c2f89aeeacc652b81b0a
   languageName: node
   linkType: hard
 

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -13,11 +13,11 @@ __metadata:
   linkType: hard
 
 "@isaacs/brace-expansion@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@isaacs/brace-expansion@npm:5.0.0"
+  version: 5.0.1
+  resolution: "@isaacs/brace-expansion@npm:5.0.1"
   dependencies:
     "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
+  checksum: 10c0/e5d67c7bbf1f17b88132a35bc638af306d48acbb72810d48fa6e6edd8ab375854773108e8bf70f021f7ef6a8273455a6d1f0c3b5aa2aff06ce7894049ab77fb8
   languageName: node
   linkType: hard
 

--- a/packages/content-script/lavamoat/rspack/policy.json
+++ b/packages/content-script/lavamoat/rspack/policy.json
@@ -44,7 +44,7 @@
         "bs58": true,
         "@rsbuild/plugin-node-polyfill>buffer": true,
         "did-jwt": true,
-        "semantic-release>lodash": true,
+        "@semantic-release/commit-analyzer>lodash": true,
         "multibase": true,
         "multicodec": true
       }
@@ -196,6 +196,11 @@
         "Buffer": true
       }
     },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
     "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": {
       "globals": {
         "Buffer": true
@@ -265,7 +270,7 @@
         "Buffer": true
       },
       "packages": {
-        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa>bn.js": true,
         "@rsbuild/plugin-node-polyfill>buffer": true,
         "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true
       }
@@ -746,7 +751,7 @@
         "@rsbuild/plugin-node-polyfill>buffer": true,
         "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
         "jws": true,
-        "semantic-release>lodash": true,
+        "@semantic-release/commit-analyzer>lodash": true,
         "semantic-release>@semantic-release/npm>npm>ms": true,
         "@rsbuild/plugin-node-polyfill>process": true,
         "semantic-release>semver": true
@@ -780,7 +785,7 @@
         "setTimeout": true
       }
     },
-    "semantic-release>lodash": {
+    "@semantic-release/commit-analyzer>lodash": {
       "globals": {
         "define": true
       }

--- a/packages/offscreen/lavamoat/rspack/policy.json
+++ b/packages/offscreen/lavamoat/rspack/policy.json
@@ -56,7 +56,7 @@
         "bs58": true,
         "@rsbuild/plugin-node-polyfill>buffer": true,
         "did-jwt": true,
-        "semantic-release>lodash": true,
+        "@semantic-release/commit-analyzer>lodash": true,
         "multibase": true,
         "multicodec": true
       }
@@ -203,6 +203,11 @@
         "Buffer": true
       }
     },
+    "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa>bn.js": {
+      "globals": {
+        "Buffer": true
+      }
+    },
     "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": {
       "globals": {
         "Buffer": true
@@ -272,7 +277,7 @@
         "Buffer": true
       },
       "packages": {
-        "@rsbuild/plugin-node-polyfill>crypto-browserify>browserify-sign>bn.js": true,
+        "@rsbuild/plugin-node-polyfill>crypto-browserify>public-encrypt>browserify-rsa>bn.js": true,
         "@rsbuild/plugin-node-polyfill>buffer": true,
         "@rsbuild/plugin-node-polyfill>crypto-browserify>randombytes": true
       }
@@ -748,7 +753,7 @@
         "@rsbuild/plugin-node-polyfill>buffer": true,
         "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
         "jws": true,
-        "semantic-release>lodash": true,
+        "@semantic-release/commit-analyzer>lodash": true,
         "semantic-release>@semantic-release/npm>npm>ms": true,
         "@rsbuild/plugin-node-polyfill>process": true,
         "semantic-release>semver": true
@@ -782,7 +787,7 @@
         "setTimeout": true
       }
     },
-    "semantic-release>lodash": {
+    "@semantic-release/commit-analyzer>lodash": {
       "globals": {
         "define": true
       }

--- a/packages/service-worker/lavamoat/rspack/policy.json
+++ b/packages/service-worker/lavamoat/rspack/policy.json
@@ -73,7 +73,7 @@
         "@avalabs/bridge-unified>@noble/hashes": true,
         "@avalabs/bridge-unified>@scure/base": true,
         "@avalabs/fusion-sdk>coinselect": true,
-        "lodash": true,
+        "@avalabs/bridge-unified>lodash": true,
         "@avalabs/bridge-unified>viem": true,
         "@avalabs/bridge-unified>zod": true
       }
@@ -106,7 +106,6 @@
     "@avalabs/core-utils-sdk": {
       "globals": {
         "AbortController": true,
-        "URL": true,
         "URLSearchParams": true,
         "clearTimeout": true,
         "fetch": true,
@@ -114,8 +113,7 @@
       },
       "packages": {
         "@avalabs/core-utils-sdk>big.js": true,
-        "bn.js": true,
-        "@avalabs/core-utils-sdk>is-ipfs": true
+        "bn.js": true
       }
     },
     "@avalabs/avalanche-module>@avalabs/core-utils-sdk": {
@@ -137,6 +135,16 @@
         "clearTimeout": true,
         "fetch": true,
         "setTimeout": true
+      }
+    },
+    "@avalabs/evm-module>@avalabs/core-utils-sdk": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@avalabs/core-utils-sdk>big.js": true,
+        "bn.js": true,
+        "@avalabs/core-utils-sdk>is-ipfs": true
       }
     },
     "@avalabs/core-wallets-sdk": {
@@ -236,7 +244,7 @@
       "packages": {
         "@avalabs/core-chains-sdk": true,
         "@avalabs/core-coingecko-sdk": true,
-        "@avalabs/core-utils-sdk": true,
+        "@avalabs/evm-module>@avalabs/core-utils-sdk": true,
         "@avalabs/core-wallets-sdk": true,
         "@avalabs/evm-module>@avalabs/crypto-sdk": true,
         "@avalabs/glacier-sdk": true,
@@ -1599,7 +1607,7 @@
         "fireblocks-sdk>@notabene/pii-sdk>bs58": true,
         "buffer": true,
         "fireblocks-sdk>@notabene/pii-sdk>did-jwt": true,
-        "lodash": true,
+        "fireblocks-sdk>@notabene/pii-sdk>lodash": true,
         "fireblocks-sdk>@notabene/pii-sdk>multibase": true,
         "fireblocks-sdk>@notabene/pii-sdk>multicodec": true
       }
@@ -5792,7 +5800,7 @@
         "buffer": true,
         "@rsbuild/plugin-node-polyfill>crypto-browserify": true,
         "fireblocks-sdk>jsonwebtoken>jws": true,
-        "lodash": true,
+        "fireblocks-sdk>jsonwebtoken>lodash": true,
         "fireblocks-sdk>jsonwebtoken>ms": true,
         "@rsbuild/plugin-node-polyfill>process": true,
         "semver": true
@@ -5852,6 +5860,21 @@
       }
     },
     "lodash": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@avalabs/bridge-unified>lodash": {
+      "globals": {
+        "define": true
+      }
+    },
+    "fireblocks-sdk>@notabene/pii-sdk>lodash": {
+      "globals": {
+        "define": true
+      }
+    },
+    "fireblocks-sdk>jsonwebtoken>lodash": {
       "globals": {
         "define": true
       }

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -88,7 +88,7 @@
     "jose": "4.15.5",
     "json-rpc-engine": "6.1.0",
     "ledger-bitcoin": "0.2.3",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "lru-cache": "7.10.1",
     "micro-key-producer": "0.7.5",
     "micro-signals": "2.4.0",

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -71,7 +71,7 @@
     "bip32": "2.0.6",
     "bip39": "3.0.4",
     "bitcoinjs-lib": "5.2.0",
-    "bn.js": "5.2.1",
+    "bn.js": "5.2.3",
     "buffer": "6.0.3",
     "date-fns": "2.28.0",
     "detect-browser": "5.3.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,7 +29,7 @@
     "@ethereumjs/common": "2.6.5",
     "@ethereumjs/tx": "3.4.0",
     "@google/generative-ai": "0.22.0",
-    "@hpke/core": "1.2.5",
+    "@hpke/core": "1.7.5",
     "@keystonehq/alias-sampling": "0.1.2",
     "@keystonehq/animated-qr": "0.5.2",
     "@keystonehq/bc-ur-registry-eth": "0.15.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -59,7 +59,7 @@
     "bip32": "2.0.6",
     "bip39": "3.0.4",
     "bitcoinjs-lib": "5.2.0",
-    "bn.js": "5.2.1",
+    "bn.js": "5.2.3",
     "date-fns": "2.28.0",
     "detect-browser": "5.3.0",
     "eth-json-rpc-middleware": "8.0.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -70,7 +70,7 @@
     "i18next": "21.9.2",
     "i18next-http-backend": "1.4.4",
     "ledger-bitcoin": "0.2.3",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "lru-cache": "7.10.1",
     "micro-signals": "2.4.0",
     "qrcode.react": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3190,7 +3190,7 @@ __metadata:
     bip32: "npm:2.0.6"
     bip39: "npm:3.0.4"
     bitcoinjs-lib: "npm:5.2.0"
-    bn.js: "npm:5.2.1"
+    bn.js: "npm:5.2.3"
     buffer: "npm:6.0.3"
     conventional-changelog-cli: "npm:2.2.2"
     css-loader: "npm:5.2.4"
@@ -3359,7 +3359,7 @@ __metadata:
     bip32: "npm:2.0.6"
     bip39: "npm:3.0.4"
     bitcoinjs-lib: "npm:5.2.0"
-    bn.js: "npm:5.2.1"
+    bn.js: "npm:5.2.3"
     css-loader: "npm:5.2.4"
     date-fns: "npm:2.28.0"
     detect-browser: "npm:5.3.0"
@@ -12286,6 +12286,13 @@ __metadata:
   version: 5.2.1
   resolution: "bn.js@npm:5.2.1"
   checksum: 10c0/bed3d8bd34ec89dbcf9f20f88bd7d4a49c160fda3b561c7bb227501f974d3e435a48fb9b61bc3de304acab9215a3bda0803f7017ffb4d0016a0c3a740a283caa
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:5.2.3":
+  version: 5.2.3
+  resolution: "bn.js@npm:5.2.3"
+  checksum: 10c0/eef19cb9cf5e91e91e3e0f036b799ce6c72f79463c3934d62991c3dcdb58f6c94dc3d806495d9b0bf31cd121870ed79bb2115cea71b56c03e794fb71485031fa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3223,7 +3223,7 @@ __metadata:
     json-rpc-engine: "npm:6.1.0"
     ledger-bitcoin: "npm:0.2.3"
     lint-staged: "npm:12.3.1"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     lru-cache: "npm:7.10.1"
     micro-key-producer: "npm:0.7.5"
     micro-signals: "npm:2.4.0"
@@ -3385,7 +3385,7 @@ __metadata:
     jest-environment-jsdom: "npm:29.3.1"
     ledger-bitcoin: "npm:0.2.3"
     lint-staged: "npm:12.3.1"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     lru-cache: "npm:7.10.1"
     micro-signals: "npm:2.4.0"
     path-browserify: "npm:1.0.1"
@@ -20795,6 +20795,13 @@ __metadata:
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+  languageName: node
+  linkType: hard
+
+"lodash@npm:4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14695,9 +14695,9 @@ __metadata:
   linkType: hard
 
 "diff@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "diff@npm:4.0.2"
-  checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
+  version: 4.0.4
+  resolution: "diff@npm:4.0.4"
+  checksum: 10c0/855fb70b093d1d9643ddc12ea76dca90dc9d9cdd7f82c08ee8b9325c0dc5748faf3c82e2047ced5dcaa8b26e58f7903900be2628d0380a222c02d79d8de385df
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12638,7 +12638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-equal-constant-time@npm:1.0.1":
+"buffer-equal-constant-time@npm:^1.0.1":
   version: 1.0.1
   resolution: "buffer-equal-constant-time@npm:1.0.1"
   checksum: 10c0/fb2294e64d23c573d0dd1f1e7a466c3e978fe94a4e0f8183937912ca374619773bef8e2aceb854129d2efecbbc515bbd0cc78d2734a3e3031edb0888531bbc8e
@@ -20139,24 +20139,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jwa@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "jwa@npm:1.4.1"
+"jwa@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "jwa@npm:1.4.2"
   dependencies:
-    buffer-equal-constant-time: "npm:1.0.1"
+    buffer-equal-constant-time: "npm:^1.0.1"
     ecdsa-sig-formatter: "npm:1.0.11"
     safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/5c533540bf38702e73cf14765805a94027c66a0aa8b16bc3e89d8d905e61a4ce2791e87e21be97d1293a5ee9d4f3e5e47737e671768265ca4f25706db551d5e9
+  checksum: 10c0/210a544a42ca22203e8fc538835205155ba3af6a027753109f9258bdead33086bac3c25295af48ac1981f87f9c5f941bc8f70303670f54ea7dcaafb53993d92c
   languageName: node
   linkType: hard
 
 "jws@npm:^3.2.2":
-  version: 3.2.2
-  resolution: "jws@npm:3.2.2"
+  version: 3.2.3
+  resolution: "jws@npm:3.2.3"
   dependencies:
-    jwa: "npm:^1.4.1"
+    jwa: "npm:^1.4.2"
     safe-buffer: "npm:^5.0.1"
-  checksum: 10c0/e770704533d92df358adad7d1261fdecad4d7b66fa153ba80d047e03ca0f1f73007ce5ed3fbc04d2eba09ba6e7e6e645f351e08e5ab51614df1b0aa4f384dfff
+  checksum: 10c0/9fdf9d6783b1892ef413ef373cd351eacc847ba01deec6fbfea96830e93241863ccbee66f3b749fc2310c59b6db2209d3f4b52931c0c259b52b17de20715917f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11145,14 +11145,14 @@ __metadata:
   linkType: hard
 
 "ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
-  version: 6.12.6
-  resolution: "ajv@npm:6.12.6"
+  version: 6.14.0
+  resolution: "ajv@npm:6.14.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.1"
     fast-json-stable-stringify: "npm:^2.0.0"
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
-  checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
+  checksum: 10c0/a2bc39b0555dc9802c899f86990eb8eed6e366cddbf65be43d5aa7e4f3c4e1a199d5460fd7ca4fb3d864000dbbc049253b72faa83b3b30e641ca52cb29a68c22
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,7 +3295,7 @@ __metadata:
     "@ethereumjs/common": "npm:2.6.5"
     "@ethereumjs/tx": "npm:3.4.0"
     "@google/generative-ai": "npm:0.22.0"
-    "@hpke/core": "npm:1.2.5"
+    "@hpke/core": "npm:1.7.5"
     "@keystonehq/alias-sampling": "npm:0.1.2"
     "@keystonehq/animated-qr": "npm:0.5.2"
     "@keystonehq/bc-ur-registry-eth": "npm:0.15.2"


### PR DESCRIPTION
## Summary
Consolidates the open Dependabot dependency bumps into a single PR. Each
applicable update is a separate commit following the format
`chore: update <dependency-name> to <version>`.
## Consolidated PRs
| Dependency | Version | Scope | Dependabot PR(s) |
|---|---|---|---|
| `bn.js` | 5.2.1 → 5.2.3 | `service-worker`, `ui` + lockfile | #795 (covers #797, #794) |
| `lodash` | 4.17.21 → 4.17.23 | `service-worker`, `ui` + lockfile | #728 (covers #724, #720) |
| `ajv` | 6.12.6 → 6.14.0 | lockfile | #796 |
| `diff` | 4.0.2 → 4.0.4 | lockfile | #713 |
| `@hpke/core` | 1.2.5 → 1.7.5 | `ui` (aligns manifest with lockfile) | #683 |
| `tar` | 7.5.6 → 7.5.9 | `e2e` | #787 |
| `@isaacs/brace-expansion` | 5.0.0 → 5.0.1 | `e2e` | #786 |
| `jws` | 3.2.2 → 3.2.3 | lockfile (pulls in `jwa@1.4.2`) | #534 |


> `#534 (jws)` was applied manually rather than cherry-picked — its patch
> context had drifted against `main`, but the resulting dependency change is
> identical to Dependabot's.


## Not included (already resolved or superseded on `main`)
| Dependabot PR | Reason |
|---|---|
| #811 (`rollup` 4.55.3 → 4.59.0) | `rollup` is no longer present in the dependency tree |
| #749 (`@isaacs/brace-expansion` 5.0.0 → 5.0.1, root) | `main` is already at 5.0.1 |
| #781 (`pbkdf2` 3.1.2 → 3.1.5) | `main` already moved to 3.1.3, past the vulnerable 3.1.2; the 3.1.2-based patch no longer applies |
