### PR TITLE
feat: fusion swap add asset switcher button

### DIFF
--- a/apps/next/src/localization/locales/en/translation.json
+++ b/apps/next/src/localization/locales/en/translation.json
@@ -861,6 +861,7 @@
   "Swapped {{sourceToken}} to {{targetToken}}": "Swapped {{sourceToken}} to {{targetToken}}",
   "Swapping {{sourceToken}} to {{targetToken}} failed": "Swapping {{sourceToken}} to {{targetToken}} failed",
   "Swapping {{sourceToken}} to {{targetToken}} in progress...": "Swapping {{sourceToken}} to {{targetToken}} in progress...",
+  "Switch source and destination tokens": "Switch source and destination tokens",
   "System": "System",
   "Testnet mode": "Testnet mode",
   "Testnet mode is off": "Testnet mode is off",

--- a/apps/next/src/pages/Fusion/components/PairFlipper.tsx
+++ b/apps/next/src/pages/Fusion/components/PairFlipper.tsx
@@ -41,7 +41,8 @@ const FlipButton = styled(IconButton)(({ theme: { palette } }) => ({
     pointerEvents: 'auto',
     cursor: 'not-allowed',
     color: getHexAlpha(palette.text.primary, 70),
-    backgroundColor: palette.mode === 'light' ? 'glass.dark3' : 'glass.light2',
+    backgroundColor:
+      palette.mode === 'light' ? palette.glass.dark3 : palette.glass.light2,
   },
 }));
 
@@ -50,7 +51,7 @@ const FlipContainer = styled(Stack)(({ theme: { palette } }) => ({
   alignItems: 'center',
   justifyContent: 'center',
 
-  '::before, ::after': {
+  '&::before, &::after': {
     content: '""',
     position: 'absolute',
     height: '1px',
@@ -58,11 +59,11 @@ const FlipContainer = styled(Stack)(({ theme: { palette } }) => ({
     width: '50%',
     top: '50%',
   },
-  '::before': {
+  '&::before': {
     left: 0,
     transform: 'translateX(-18px)',
   },
-  '::after': {
+  '&::after': {
     left: '50%',
     transform: 'translateX(18px)',
   },

--- a/apps/next/src/pages/Fusion/components/PairFlipper.tsx
+++ b/apps/next/src/pages/Fusion/components/PairFlipper.tsx
@@ -1,0 +1,69 @@
+import { FC } from 'react';
+import {
+  getHexAlpha,
+  IconButton,
+  Stack,
+  styled,
+  SwapVerticalIcon,
+} from '@avalabs/k2-alpine';
+
+type PairFlipperProps = {
+  ariaLabel: string;
+  disabled: boolean;
+  onClick: () => void;
+};
+
+export const PairFlipper: FC<PairFlipperProps> = ({
+  ariaLabel,
+  disabled,
+  onClick,
+}) => (
+  <FlipContainer>
+    <FlipButton
+      aria-label={ariaLabel}
+      color="secondary"
+      data-testid="fusion-pair-flipper"
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <SwapVerticalIcon size={19} />
+    </FlipButton>
+  </FlipContainer>
+);
+
+const FlipButton = styled(IconButton)(({ theme: { palette } }) => ({
+  margin: 'auto',
+  color: palette.text.primary,
+  backgroundColor:
+    palette.mode === 'light' ? palette.glass.dark3 : palette.glass.light2,
+
+  '&.Mui-disabled': {
+    pointerEvents: 'auto',
+    cursor: 'not-allowed',
+    color: getHexAlpha(palette.text.primary, 70),
+    backgroundColor: palette.mode === 'light' ? 'glass.dark3' : 'glass.light2',
+  },
+}));
+
+const FlipContainer = styled(Stack)(({ theme: { palette } }) => ({
+  position: 'relative',
+  alignItems: 'center',
+  justifyContent: 'center',
+
+  '::before, ::after': {
+    content: '""',
+    position: 'absolute',
+    height: '1px',
+    backgroundColor: palette.divider,
+    width: '50%',
+    top: '50%',
+  },
+  '::before': {
+    left: 0,
+    transform: 'translateX(-18px)',
+  },
+  '::after': {
+    left: '50%',
+    transform: 'translateX(18px)',
+  },
+}));

--- a/apps/next/src/pages/Fusion/components/SwapPair.tsx
+++ b/apps/next/src/pages/Fusion/components/SwapPair.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Divider, Stack } from '@avalabs/k2-alpine';
+import { Button, Stack } from '@avalabs/k2-alpine';
 import { bigIntToString } from '@avalabs/core-utils-sdk';
 
 import {
@@ -18,6 +18,7 @@ import { CORE_WEB_BASE_URL } from '@/config';
 import { useFusionState } from '../contexts';
 import { calculateNativeFee } from '../lib/calculateNativeFee';
 import { usePinnedMaxAmount } from '../hooks/usePinnedMaxAmount';
+import { PairFlipper } from './PairFlipper';
 
 const NATIVE_AVAX_ASSET_ID = 'NATIVE-avax';
 const DEFAULT_CORE_WEB_BASE_URL = 'https://core.app';
@@ -58,6 +59,7 @@ export const SwapPair = () => {
     setSelectedTargetChainId,
     setIsTargetSelectOpen,
     onTargetTokenChange,
+    onTokenPairFlip,
     sourceToken,
     targetToken,
     userAmount,
@@ -72,6 +74,13 @@ export const SwapPair = () => {
   const targetTokenId = targetToken ? getUniqueTokenId(targetToken) : queryToId;
   const isTargetSameAsSource = targetTokenId === fromTokenId;
   const toTokenId = isTargetSameAsSource ? '' : targetTokenId;
+  const canFlip = Boolean(
+    sourceToken &&
+      targetToken &&
+      sourceTokenList.some(
+        (token) => getUniqueTokenId(token) === getUniqueTokenId(targetToken),
+      ),
+  );
   const isAvalancheCctEnabled = isFlagEnabled(
     FeatureGates.FUSION_AVALANCHE_CCT,
   );
@@ -162,7 +171,14 @@ export const SwapPair = () => {
             ) : undefined
           }
         />
-        <Divider sx={{ mx: 2 }} />
+        <PairFlipper
+          ariaLabel={t('Switch source and destination tokens')}
+          disabled={!canFlip}
+          onClick={() => {
+            unpin();
+            onTokenPairFlip();
+          }}
+        />
         <TokenAmountInput
           autoFocus={false}
           id="swap-to-amount"

--- a/apps/next/src/pages/Fusion/contexts/FusionStateContext.tsx
+++ b/apps/next/src/pages/Fusion/contexts/FusionStateContext.tsx
@@ -304,6 +304,30 @@ export const FusionStateContextProvider: FC<{ children: ReactNode }> = ({
     [browseTargetChainId, updateQuery, sourceTokenId, targetTokenList],
   );
 
+  const onTokenPairFlip = useCallback(() => {
+    if (
+      !sourceToken ||
+      !targetToken ||
+      !sourceTokenList.some(
+        (token) => getUniqueTokenId(token) === getUniqueTokenId(targetToken),
+      )
+    ) {
+      return;
+    }
+
+    setTargetToken(sourceToken);
+    setTargetTokenSourceTokenId(getUniqueTokenId(targetToken));
+    setCommittedTargetChainId(sourceToken.coreChainId);
+    setBrowseTargetChainId(sourceToken.coreChainId);
+    updateQuery({
+      from: getUniqueTokenId(targetToken),
+      fromQuery: '',
+      to: getUniqueTokenId(sourceToken),
+      toQuery: '',
+      userAmount: '',
+    });
+  }, [sourceToken, sourceTokenList, targetToken, updateQuery]);
+
   const { chain: sourceChain, asset: sourceAsset } =
     useAssetAndChain(sourceToken);
   const { chain: targetChain, asset: targetAsset } =
@@ -638,6 +662,7 @@ export const FusionStateContextProvider: FC<{ children: ReactNode }> = ({
         setSelectedTargetChainId: setBrowseTargetChainId,
         setIsTargetSelectOpen,
         onTargetTokenChange,
+        onTokenPairFlip,
         sourceToken,
         targetToken,
         account: activeAccount,

--- a/apps/next/src/pages/Fusion/types.ts
+++ b/apps/next/src/pages/Fusion/types.ts
@@ -91,6 +91,7 @@ export type FusionState = QueryState & {
   setSelectedTargetChainId: (id: number | 'avalanche' | null) => void;
   setIsTargetSelectOpen: (isOpen: boolean) => void;
   onTargetTokenChange: (tokenId: string) => void;
+  onTokenPairFlip: () => void;
   sourceToken: FungibleTokenBalance | undefined;
   targetToken: FungibleTokenBalance | undefined;
   account?: Account;

--- a/packages/service-worker/src/services/network/avalanche-config.ts
+++ b/packages/service-worker/src/services/network/avalanche-config.ts
@@ -17,8 +17,8 @@ export const BASE_NETWORK_CONFIG_BY_TYPE: Record<
 };
 
 export const LOGO_BY_ALIAS: Record<'p' | 'x', string> = {
-  x: 'https://images.ctfassets.net/gcj8jwzm6086/5xiGm7IBR6G44eeVlaWrxi/1b253c4744a3ad21a278091e3119feba/xchain-square.svg',
-  p: 'https://images.ctfassets.net/gcj8jwzm6086/42aMwoCLblHOklt6Msi6tm/1e64aa637a8cead39b2db96fe3225c18/pchain-square.svg',
+  x: 'https://images.ctfassets.net/gcj8jwzm6086/5xiGm7IBR6G44eeVlaWrxi/fa3ae7dad2d1d39720f4b132e6dfd63f/xchain-square.svg',
+  p: 'https://images.ctfassets.net/gcj8jwzm6086/42aMwoCLblHOklt6Msi6tm/b80574ddae50c0cebe904e0c09a60f00/pchain-square.svg',
 };
 
 export const getXPExplorerUrl = (


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-14843
Figma: N/A

Adds the Fusion swap asset flipper so users can swap the source and destination token selections when both fields are populated and the destination token is also available as a source token with a balance.

## Notes

The flipper clears the amount and token search state when switching the pair, and keeps the destination chain state aligned with the old source token.

## Testing Instructions

Open the Fusion swap form, select a source token, then select a destination token that is also present in the source token list. The flipper should become enabled. Click it and confirm the source and destination tokens swap, the amount clears, and quote/form state refreshes for the new pair.

Confirm the flipper remains disabled when the destination token is not available in the source token list.

## Media

https://github.com/user-attachments/assets/cf6570c0-6b62-4f00-bece-8c532938cf22

