### PR TITLE
fix: filter HyperCore out from send screen and enable default network

### DIFF
--- a/apps/next/src/pages/Send/Send.tsx
+++ b/apps/next/src/pages/Send/Send.tsx
@@ -1,9 +1,10 @@
 import { Stack } from '@avalabs/k2-alpine';
 import { TokenType } from '@avalabs/vm-module-types';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router-dom';
 
+import { isHypercoreNetwork } from '@core/common';
 import { getUniqueTokenId } from '@core/types';
 import {
   useAccountsContext,
@@ -32,11 +33,7 @@ import { getAddressByType } from '@/utils/getAddressByType';
 import { SendBody } from './components/SendBody';
 import { getAddressTypeForToken } from '../../lib/getAddressTypeForToken';
 
-const POLLED_BALANCES = [
-  TokenType.NATIVE,
-  TokenType.ERC20,
-  TokenType.HYPERCORE_SPOT,
-];
+const POLLED_BALANCES = [TokenType.NATIVE, TokenType.ERC20];
 
 export const Send = () => {
   useLiveBalance(POLLED_BALANCES);
@@ -78,7 +75,16 @@ export const Send = () => {
     [replace],
   );
 
-  const tokensForAccount = useTokensForAccount(activeAccount);
+  const allTokensForAccount = useTokensForAccount(activeAccount);
+
+  // filters out HyperCore network tokens
+  const tokensForAccount = useMemo(
+    () =>
+      allTokensForAccount.filter(
+        (token) => !isHypercoreNetwork(getNetwork(token.coreChainId)),
+      ),
+    [allTokensForAccount, getNetwork],
+  );
 
   // Allows us to show only those recipients that are compatible with the selected token
   const selectedToken = tokensForAccount.find(

--- a/packages/types/src/network.ts
+++ b/packages/types/src/network.ts
@@ -37,6 +37,8 @@ export const NETWORKS_ENABLED_BY_DEFAULT = [
   10, //Optimism Mainnet
   8453, //Base Mainnet
   137, //Polygon Mainnet
+  999, //HyperEVM
+  9999, //HyperCore
 ];
 
 export interface NetworkAvailability {


### PR DESCRIPTION
# Summary

Jira ticket: 
https://ava-labs.atlassian.net/browse/CP-14861
https://ava-labs.atlassian.net/browse/CP-14848

## Notes
- Removes HyperCore network tokens from the send page
- Enables hyperevm and hypercore as default networks

## Testing
- Navigate to send screen and verify you cannot select any HyperCore tokens

## Media
<img width="326" height="602" alt="Screenshot 2026-07-20 at 1 38 51 PM" src="https://github.com/user-attachments/assets/895056cc-5c55-4997-a976-0225ba12714a" />
