### PR TITLE
fix: p chain send flow lags

### DIFF
--- a/apps/next/src/hooks/useMaxAmountForTokenSend/useMaxAmountForTokenSend.ts
+++ b/apps/next/src/hooks/useMaxAmountForTokenSend/useMaxAmountForTokenSend.ts
@@ -25,8 +25,8 @@ import {
 import { getEvmMaxAmount } from './lib';
 import { getBtcMaxAmount } from './lib/getBtcMaxAmount';
 import { getXChainMaxAmount } from './lib/getXChainMaxAmount';
-import { getPChainMaxAmount } from './lib/getPChainMaxAmount';
 import { getSolanaMaxAmount } from './lib/getSolanaMaxAmount';
+import { usePChainMaxAmount } from './usePChainMaxAmount';
 import { useGetXPAddresses } from '../useGetXPAddresses';
 
 type MaxAmountInfo = {
@@ -50,8 +50,22 @@ export const useMaxAmountForTokenSend = (
     estimatedFee: undefined,
   });
 
+  const isPvmSend = Boolean(
+    from && isPvmCapableAccount(from) && token && isPChainToken(token),
+  );
+
+  // P-Chain is handled by a cached query (heavy UTXO packing) instead of the effect below.
+  const pChainMaxAmount = usePChainMaxAmount({
+    from: from && isPvmCapableAccount(from) ? from : undefined,
+    token: token && isPChainToken(token) ? token : undefined,
+    network: token ? getNetwork(token.coreChainId) : undefined,
+    isLedgerWallet,
+    filterSmallUtxos,
+    getAddresses: getXPAddresses('PVM'),
+  });
+
   useEffect(() => {
-    if (!token || !from) return;
+    if (!token || !from || isPvmSend) return;
 
     getNetworkFee(token.coreChainId)
       .then((networkFee) => {
@@ -75,14 +89,6 @@ export const useMaxAmountForTokenSend = (
             isLedgerWallet,
             filterSmallUtxos,
             getXPAddresses('AVM'),
-            getNetwork(token.coreChainId),
-          ).then(setResult);
-        } else if (isPvmCapableAccount(from) && isPChainToken(token)) {
-          getPChainMaxAmount(
-            from,
-            isLedgerWallet,
-            filterSmallUtxos,
-            getXPAddresses('PVM'),
             getNetwork(token.coreChainId),
           ).then(setResult);
         } else if (
@@ -113,7 +119,8 @@ export const useMaxAmountForTokenSend = (
     isLedgerWallet,
     getXPAddresses,
     filterSmallUtxos,
+    isPvmSend,
   ]);
 
-  return result;
+  return isPvmSend ? pChainMaxAmount : result;
 };

--- a/apps/next/src/hooks/useMaxAmountForTokenSend/usePChainMaxAmount.ts
+++ b/apps/next/src/hooks/useMaxAmountForTokenSend/usePChainMaxAmount.ts
@@ -1,0 +1,65 @@
+import { skipToken, useQuery } from '@tanstack/react-query';
+
+import {
+  NetworkWithCaipId,
+  PChainTokenBalance,
+  PvmCapableAccount,
+  XPAddresses,
+} from '@core/types';
+
+import { getPChainMaxAmount } from './lib/getPChainMaxAmount';
+
+type UsePChainMaxAmountArgs = {
+  from?: PvmCapableAccount;
+  token?: PChainTokenBalance;
+  network?: NetworkWithCaipId;
+  isLedgerWallet: boolean;
+  filterSmallUtxos: boolean;
+  getAddresses: () => Promise<XPAddresses>;
+};
+
+/**
+ * Estimating the P-Chain max sendable amount requires packing the whole UTXO set into a
+ * maximum-size transaction (see `getMaximumUtxoSet`), which is heavy and synchronous. Caching it
+ * with React Query — keyed on the account balance (a stable proxy for "the UTXO set changed") —
+ * means the packing runs once per real change and is shared across call sites, instead of
+ * re-running on every balance poll / render and janking the page on large-UTXO wallets.
+ */
+export const usePChainMaxAmount = ({
+  from,
+  token,
+  network,
+  isLedgerWallet,
+  filterSmallUtxos,
+  getAddresses,
+}: UsePChainMaxAmountArgs) => {
+  const { data } = useQuery({
+    queryKey: [
+      'pChainMaxAmount',
+      from?.addressPVM,
+      token?.balance?.toString(),
+      network?.caipId,
+      isLedgerWallet,
+      filterSmallUtxos,
+    ],
+    queryFn:
+      from && network
+        ? () =>
+            getPChainMaxAmount(
+              from,
+              isLedgerWallet,
+              filterSmallUtxos,
+              getAddresses,
+              network,
+            )
+        : skipToken,
+    // The result only changes when the UTXO set (≈ balance) or fee state changes, both captured
+    // by the key, so keep it fresh for a while to avoid needless recomputation.
+    staleTime: 30_000,
+  });
+
+  return {
+    maxAmount: data?.maxAmount,
+    estimatedFee: data?.estimatedFee,
+  };
+};

--- a/apps/next/src/hooks/useMaxAmountForTokenSend/usePChainMaxAmount.ts
+++ b/apps/next/src/hooks/useMaxAmountForTokenSend/usePChainMaxAmount.ts
@@ -43,7 +43,7 @@ export const usePChainMaxAmount = ({
       filterSmallUtxos,
     ],
     queryFn:
-      from && network
+      from && network && token
         ? () =>
             getPChainMaxAmount(
               from,
@@ -53,8 +53,8 @@ export const usePChainMaxAmount = ({
               network,
             )
         : skipToken,
-    // The result only changes when the UTXO set (≈ balance) or fee state changes, both captured
-    // by the key, so keep it fresh for a while to avoid needless recomputation.
+    // The result changes when the UTXO set (≈ balance) changes. Keep it fresh for a while to
+    // avoid needless recomputation on frequent balance polls/renders.
     staleTime: 30_000,
   });
 

--- a/packages/common/src/utils/balance/getMaxUtxos.test.ts
+++ b/packages/common/src/utils/balance/getMaxUtxos.test.ts
@@ -259,7 +259,7 @@ describe('src/pages/Send/utils/getMaxUtxos', () => {
       });
       jest
         .spyOn(Avalanche, 'sortUTXOsByAmount')
-        .mockReturnValue([smallUtxo, largeUtxo] as any);
+        .mockImplementation((utxos) => utxos as any);
 
       await getMaxUtxoSet({
         isLedgerWallet: false,

--- a/packages/common/src/utils/balance/getMaxUtxos.test.ts
+++ b/packages/common/src/utils/balance/getMaxUtxos.test.ts
@@ -213,9 +213,10 @@ describe('src/pages/Send/utils/getMaxUtxos', () => {
       getUTXOs.mockResolvedValue({
         getUTXOs: () => [smallUtxo, largeUtxo],
       });
+      // Dust is now filtered before sorting, so sort should preserve its (filtered) input.
       jest
         .spyOn(Avalanche, 'sortUTXOsByAmount')
-        .mockReturnValue([smallUtxo, largeUtxo] as any);
+        .mockImplementation((utxos) => utxos as any);
 
       await getMaxUtxoSet({
         isLedgerWallet: false,

--- a/packages/common/src/utils/balance/getMaxUtxos.ts
+++ b/packages/common/src/utils/balance/getMaxUtxos.ts
@@ -34,7 +34,17 @@ export async function getMaxUtxoSet({
     ? CHAIN_ALIAS.P
     : CHAIN_ALIAS.X;
   const utxos = preloadedUtxoSet ?? (await wallet.getUTXOs(chainAliasToUse));
-  let filteredUtxos = Avalanche.sortUTXOsByAmount(utxos.getUTXOs(), true);
+
+  // Filter out dust UTXOs up front, so the expensive getMaximumUtxoSet packing below runs over
+  // far fewer inputs. Wallets with many tiny staking-reward UTXOs are the main cause of the jank,
+  // and this mirrors Core Web, which filters small UTXOs before packing.
+  const candidateUtxos = filterSmallUtxos
+    ? utxos
+        .getUTXOs()
+        .filter((utxo) => utils.getUtxoInfo(utxo).amount >= DUST_THRESHOLD)
+    : utxos.getUTXOs();
+
+  let filteredUtxos = candidateUtxos;
 
   if (isPchainNetwork(network)) {
     assert(feeState, CommonError.UnknownNetworkFee);
@@ -42,7 +52,7 @@ export async function getMaxUtxoSet({
     try {
       filteredUtxos = Avalanche.getMaximumUtxoSet({
         wallet,
-        utxos: utxos.getUTXOs(),
+        utxos: candidateUtxos,
         sizeSupportedTx: Avalanche.SizeSupportedTx.BaseP,
         limit: isLedgerWallet ? LEDGER_TX_SIZE_LIMIT_BYTES : undefined,
         feeState,
@@ -54,12 +64,9 @@ export async function getMaxUtxoSet({
         utxos,
       });
     }
-  }
-
-  if (filterSmallUtxos) {
-    filteredUtxos = filteredUtxos.filter(
-      (utxo) => utils.getUtxoInfo(utxo).amount >= DUST_THRESHOLD,
-    );
+  } else {
+    // X-Chain has no size-limited packing step, just order the candidates by amount.
+    filteredUtxos = Avalanche.sortUTXOsByAmount(candidateUtxos, true);
   }
 
   filteredUtxos = isLedgerWallet

--- a/packages/common/src/utils/balance/getMaxUtxos.ts
+++ b/packages/common/src/utils/balance/getMaxUtxos.ts
@@ -44,7 +44,10 @@ export async function getMaxUtxoSet({
         .filter((utxo) => utils.getUtxoInfo(utxo).amount >= DUST_THRESHOLD)
     : utxos.getUTXOs();
 
-  let filteredUtxos = candidateUtxos;
+  // Sorted by amount (descending): used directly for X-Chain, and as a deterministic best-effort
+  // fallback for P-Chain if the size-limited packing below throws (so the later Ledger slice still
+  // picks the largest UTXOs rather than arbitrary ones).
+  let filteredUtxos = Avalanche.sortUTXOsByAmount(candidateUtxos, true);
 
   if (isPchainNetwork(network)) {
     assert(feeState, CommonError.UnknownNetworkFee);
@@ -64,9 +67,6 @@ export async function getMaxUtxoSet({
         utxos,
       });
     }
-  } else {
-    // X-Chain has no size-limited packing step, just order the candidates by amount.
-    filteredUtxos = Avalanche.sortUTXOsByAmount(candidateUtxos, true);
   }
 
   filteredUtxos = isLedgerWallet


### PR DESCRIPTION
# Summary

Jira ticket:
https://ava-labs.atlassian.net/browse/CP-14725
Figma:


https://github.com/user-attachments/assets/487b2bb9-053e-45d4-9f3a-7edbf6ba6032

1. Cache the max-amount computation. New `usePChainMaxAmount` hook wraps the expensive `getMaximumUtxoSet` (O(n·log n) tx-packing) in React Query, keyed on stable inputs (address + balance + network + isLedger + filterSmallUtxos). It previously ran in a raw effect keyed on the selectedToken object, so it recomputed on every balance poll — and twice `(Send.tsx + usePChainSend).` Now it runs once per real change and is shared across both call sites. useMaxAmountForTokenSend delegates the P-Chain branch to it.
2. Filter dust before packing. `getMaxUtxos.ts` fed all raw UTXOs into `getMaximumUtxoSet` and dust-filtered afterward; now it filters small UTXOs first (setting defaults on) and drops a redundant P-Chain sort — shrinking the input to the expensive loop and cutting the first-compute cost.

## Notes

<!-- Additional notes and context. Explain non-synchronized design, product, or architectural design decisions -->

## Testing

<!-- Add high-level testing information for the reviewer to properly QA (wallet setup, local storage overrides, etc.) -->

## Testing Instructions

<!-- Add expected testing steps - be specific about whether or not you have a wallet connected, new routes, etc. -->

## Media

<!-- Add screenshots and videos of the feature/changes. Great opportunity to self-QA before sharing PR -->
<!-- Bonus points for including a Loom demoing features and explaining code changes -->
