### PR TITLE
feat: list robinhood chain based on feature flags

### DIFF
--- a/packages/common/src/feature-flags.ts
+++ b/packages/common/src/feature-flags.ts
@@ -63,6 +63,7 @@ export const DISABLED_FLAG_VALUES: FeatureFlags = {
   [FeatureGates.FUSION_RECURRING_SWAPS]: false,
   [FeatureGates.FUSION_AVALANCHE_CCT]: false,
   [FeatureGates.HYPERLIQUID_FEATURE]: false,
+  [FeatureGates.ROBINHOOD_FEATURE]: false,
   [FeatureVars.SAE_OVERRIDE]: 'auto', // auto, enabled, disabled
 };
 
@@ -128,6 +129,7 @@ export const DEFAULT_FLAGS: FeatureFlags = {
   [FeatureGates.FUSION_RECURRING_SWAPS]: true,
   [FeatureGates.FUSION_AVALANCHE_CCT]: true,
   [FeatureGates.HYPERLIQUID_FEATURE]: false,
+  [FeatureGates.ROBINHOOD_FEATURE]: false,
   [FeatureVars.SAE_OVERRIDE]: 'auto', // auto, enabled, disabled
 };
 

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -73,6 +73,7 @@ export * from './network/isBitcoinNetwork';
 export * from './network/isEthereumNetwork';
 export * from './network/isSolanaNetwork';
 export * from './network/isHyperliquidNetwork';
+export * from './network/isRobinhoodNetwork';
 export * from './network/fusionCaipConversion';
 export * from './network/isValidHttpHeader';
 export * from './newsletter';

--- a/packages/common/src/utils/network/isRobinhoodNetwork.test.ts
+++ b/packages/common/src/utils/network/isRobinhoodNetwork.test.ts
@@ -1,0 +1,74 @@
+import { NetworkVMType } from '@avalabs/core-chains-sdk';
+import {
+  ROBINHOOD_MAINNET_CHAIN_ID,
+  ROBINHOOD_TESTNET_CHAIN_ID,
+  isRobinhoodChainId,
+  isRobinhoodNetwork,
+} from './isRobinhoodNetwork';
+
+const baseNetwork = {
+  chainId: 1,
+  chainName: 'Ethereum',
+  vmName: NetworkVMType.EVM,
+  rpcUrl: 'https://rpc.example',
+  explorerUrl: 'https://explorer.example',
+  networkToken: {
+    name: 'Ether',
+    symbol: 'ETH',
+    description: '',
+    decimals: 18,
+    logoUri: '',
+  },
+  logoUri: '',
+};
+
+describe('isRobinhoodChainId', () => {
+  it('returns true for the mainnet chain id', () => {
+    expect(isRobinhoodChainId(ROBINHOOD_MAINNET_CHAIN_ID)).toBe(true);
+  });
+
+  it('returns true for the testnet chain id', () => {
+    expect(isRobinhoodChainId(ROBINHOOD_TESTNET_CHAIN_ID)).toBe(true);
+  });
+
+  it('returns false for arbitrary chain ids', () => {
+    expect(isRobinhoodChainId(1)).toBe(false);
+    expect(isRobinhoodChainId(1337)).toBe(false);
+  });
+});
+
+describe('isRobinhoodNetwork', () => {
+  it('returns false for undefined network', () => {
+    expect(isRobinhoodNetwork(undefined)).toBe(false);
+  });
+
+  it('identifies Robinhood mainnet by chain id', () => {
+    expect(
+      isRobinhoodNetwork({
+        ...baseNetwork,
+        chainId: ROBINHOOD_MAINNET_CHAIN_ID,
+        chainName: 'Robinhood',
+      }),
+    ).toBe(true);
+  });
+
+  it('identifies Robinhood testnet by chain id', () => {
+    expect(
+      isRobinhoodNetwork({
+        ...baseNetwork,
+        chainId: ROBINHOOD_TESTNET_CHAIN_ID,
+        chainName: 'Robinhood Testnet',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat arbitrary networks as Robinhood', () => {
+    expect(
+      isRobinhoodNetwork({
+        ...baseNetwork,
+        chainId: 1337,
+        chainName: 'Local Devnet',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/common/src/utils/network/isRobinhoodNetwork.ts
+++ b/packages/common/src/utils/network/isRobinhoodNetwork.ts
@@ -1,0 +1,19 @@
+import { Network } from '@core/types';
+
+export const ROBINHOOD_MAINNET_CHAIN_ID = 4663;
+export const ROBINHOOD_TESTNET_CHAIN_ID = 46630;
+
+export const isRobinhoodChainId = (chainId: number) => {
+  return (
+    chainId === ROBINHOOD_MAINNET_CHAIN_ID ||
+    chainId === ROBINHOOD_TESTNET_CHAIN_ID
+  );
+};
+
+export const isRobinhoodNetwork = (network?: Network) => {
+  if (!network) {
+    return false;
+  }
+
+  return isRobinhoodChainId(network.chainId);
+};

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -50,7 +50,11 @@ import {
   getProviderForNetwork,
   isSyncDomain,
 } from '@core/common';
-import { isSolanaNetwork, isHyperliquidNetwork } from '@core/common';
+import {
+  isSolanaNetwork,
+  isHyperliquidNetwork,
+  isRobinhoodNetwork,
+} from '@core/common';
 import { GlacierService } from '../glacier/GlacierService';
 import {
   BASE_NETWORK_CONFIG_BY_TYPE,
@@ -59,6 +63,10 @@ import {
   LOGO_BY_ALIAS,
 } from './avalanche-config';
 import { HYPERCORE_NETWORK, HYPEREVM_NETWORK } from './hyperliquid-config';
+import {
+  ROBINHOOD_MAINNET_CHAIN_INFO,
+  ROBINHOOD_TESTNET_CHAIN_INFO,
+} from './robinhood-config';
 
 @singleton()
 export class NetworkService implements OnLock, OnStorageReady {
@@ -171,6 +179,7 @@ export class NetworkService implements OnLock, OnStorageReady {
     const trackedFlags = [
       FeatureGates.SOLANA_SUPPORT,
       FeatureGates.HYPERLIQUID_FEATURE,
+      FeatureGates.ROBINHOOD_FEATURE,
     ];
 
     return Object.fromEntries(
@@ -498,6 +507,8 @@ export class NetworkService implements OnLock, OnStorageReady {
           [ChainId.AVALANCHE_DEVNET_X]: this._getXchainNetwork('devnet'),
           [HYPEREVM_NETWORK.chainId]: HYPEREVM_NETWORK,
           [HYPERCORE_NETWORK.chainId]: HYPERCORE_NETWORK,
+          [ROBINHOOD_MAINNET_CHAIN_INFO.chainId]: ROBINHOOD_MAINNET_CHAIN_INFO,
+          [ROBINHOOD_TESTNET_CHAIN_INFO.chainId]: ROBINHOOD_TESTNET_CHAIN_INFO,
         };
       } else {
         attempt += 1;
@@ -863,13 +874,23 @@ export class NetworkService implements OnLock, OnStorageReady {
       );
     }
 
+    const isAddedByUser = Boolean(this._customNetworks[network.chainId]);
+
     if (isHyperliquidNetwork(network)) {
       return (
         Boolean(
           this.featureFlagService.featureFlags[
             FeatureGates.HYPERLIQUID_FEATURE
           ],
-        ) || Boolean(this._customNetworks[network.chainId])
+        ) || isAddedByUser
+      );
+    }
+
+    if (isRobinhoodNetwork(network)) {
+      return (
+        Boolean(
+          this.featureFlagService.featureFlags[FeatureGates.ROBINHOOD_FEATURE],
+        ) || isAddedByUser
       );
     }
 

--- a/packages/service-worker/src/services/network/robinhood-config.ts
+++ b/packages/service-worker/src/services/network/robinhood-config.ts
@@ -1,0 +1,62 @@
+import { NetworkVMType } from '@avalabs/core-chains-sdk';
+import {
+  ROBINHOOD_MAINNET_CHAIN_ID,
+  ROBINHOOD_TESTNET_CHAIN_ID,
+} from '@core/common';
+import { NetworkWithCaipId } from '@core/types';
+
+const ETH_CONTENTFUL_LOGO_URL =
+  'https://images.ctfassets.net/gcj8jwzm6086/6l56QLVZmvacuBfjHBTThP/791d743dd2c526692562780c2325fedf/eth-circle__1_.svg';
+
+const ROBINHOOD_CHAIN_LOGO_URL =
+  'https://images.ctfassets.net/gcj8jwzm6086/2PBxVg0TxrKFRCJqOlJomm/b421214db7aec4985b406e996e5c4c19/robinhood.png';
+
+// TODO(@meeh0w): remove the static configs once the feature goes live and everything lives in Contentful
+export const ROBINHOOD_MAINNET_CHAIN_INFO: NetworkWithCaipId = {
+  description:
+    'Robinhood Chain is a permissionless, Ethereum-compatible Layer-2 blockchain built for tokenized real-world assets.',
+  explorerUrl: 'https://robinhoodchain.blockscout.com',
+  isTestnet: false,
+  logoUri: ROBINHOOD_CHAIN_LOGO_URL,
+  chainName: 'Robinhood Chain',
+  chainId: ROBINHOOD_MAINNET_CHAIN_ID,
+  networkToken: {
+    description: 'Ether',
+    decimals: 18,
+    logoUri: ETH_CONTENTFUL_LOGO_URL,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  primaryColor: '#00C900',
+  vmName: NetworkVMType.EVM,
+  caipId: 'eip155:4663',
+  rpcUrl: 'https://rpc.mainnet.chain.robinhood.com',
+  utilityAddresses: {
+    multicall: '0xca11bde05977b3631167028862be2a173976ca11',
+  },
+};
+
+export const ROBINHOOD_TESTNET_CHAIN_INFO: NetworkWithCaipId = {
+  description:
+    'Robinhood Chain Testnet is an Ethereum-compatible Layer-2 test network.',
+  explorerUrl: 'https://robinhoodchain.blockscout.com',
+  isTestnet: true,
+  logoUri: ROBINHOOD_CHAIN_LOGO_URL,
+  chainName: 'Robinhood Chain Testnet',
+  chainId: ROBINHOOD_TESTNET_CHAIN_ID,
+  networkToken: {
+    description: 'Ether',
+    decimals: 18,
+    logoUri: ETH_CONTENTFUL_LOGO_URL,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  primaryColor: '#00C900',
+  vmName: NetworkVMType.EVM,
+  caipId: 'eip155:46630',
+  rpcUrl: 'https://rpc.testnet.chain.robinhood.com',
+  mainnetChainId: ROBINHOOD_MAINNET_CHAIN_ID,
+  utilityAddresses: {
+    multicall: '0xca11bde05977b3631167028862be2a173976ca11',
+  },
+};

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -53,6 +53,7 @@ export enum FeatureGates {
   FUSION_RECURRING_SWAPS = 'fusion-recurring-swaps',
   FUSION_AVALANCHE_CCT = 'fusion-avalanche-cct',
   HYPERLIQUID_FEATURE = 'hyperliquid-feature',
+  ROBINHOOD_FEATURE = 'robinhood-feature',
 }
 
 export enum FeatureVars {


### PR DESCRIPTION
# Summary

Jira tickets:
* https://ava-labs.atlassian.net/browse/CP-14822
* https://ava-labs.atlassian.net/browse/CP-14823

## Notes
1. Hardcodes Robinhood chain configs until the feature goes live and we can switch `Display in Core` to `Yes` in Contentful.
2. Lists the Robinhood chains only when `robinhood-feature` feature flag is enabled.

## Testing
1. Toggle `robinhood-feature` feature flag in Posthog and watch the `Robinhood Chain` appear and disappear from the network list.

## Media

https://github.com/user-attachments/assets/96dea34b-84c8-4b8a-815d-be184163ab96


<!-- Add screenshots and videos of the feature/changes. Great opportunity to self-QA before sharing PR -->
<!-- Bonus points for including a Loom demoing features and explaining code changes -->
