### PR TITLE
feat: ledger support for Robinhood chain

### DIFF
--- a/apps/next/src/pages/Approve/components/hardware/ledger/useLedgerApprovalState.ts
+++ b/apps/next/src/pages/Approve/components/hardware/ledger/useLedgerApprovalState.ts
@@ -3,7 +3,7 @@ import { DisplayData, TokenDiff, TokenType } from '@avalabs/vm-module-types';
 import {
   isAvalanchePrimaryNetwork,
   isBitcoinNetwork,
-  isEthereumNetwork,
+  isEthereumAppRequired,
   isLedgerVersionCompatible,
   isSolanaNetwork,
 } from '@core/common';
@@ -38,7 +38,7 @@ const requiresBlindSigning = (
   network: NetworkWithCaipId,
   action: Action<DisplayData>,
 ) => {
-  if (!isEthereumNetwork(network) || !isTransactionApproval(action)) {
+  if (!isEthereumAppRequired(network) || !isTransactionApproval(action)) {
     return false;
   }
 
@@ -159,7 +159,7 @@ const getRequiredApp = (network: NetworkWithCaipId) => {
     return LedgerAppType.AVALANCHE;
   }
 
-  if (isEthereumNetwork(network)) {
+  if (isEthereumAppRequired(network)) {
     return LedgerAppType.ETHEREUM;
   }
 

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -58,6 +58,7 @@ export * from './keystore';
 export * from './logging';
 export * from './lowerCaseKeys';
 export * from './ledger/ensureLedgerAppOpen';
+export * from './ledger/isEthereumAppRequired';
 export * from './makeBNLike';
 export * from './measureDuration';
 export * from './network/addGlacierAPIKeyIfNeeded';

--- a/packages/common/src/utils/ledger/isEthereumAppRequired.test.ts
+++ b/packages/common/src/utils/ledger/isEthereumAppRequired.test.ts
@@ -1,0 +1,82 @@
+import { ChainId, NetworkVMType } from '@avalabs/core-chains-sdk';
+import { Network } from '@core/types';
+
+import {
+  ROBINHOOD_MAINNET_CHAIN_ID,
+  ROBINHOOD_TESTNET_CHAIN_ID,
+} from '../network/isRobinhoodNetwork';
+import { isEthereumAppRequired } from './isEthereumAppRequired';
+
+const baseNetwork: Network = {
+  chainId: 1,
+  chainName: 'Ethereum',
+  vmName: NetworkVMType.EVM,
+  rpcUrl: 'https://rpc.example',
+  explorerUrl: 'https://explorer.example',
+  networkToken: {
+    name: 'Ether',
+    symbol: 'ETH',
+    description: '',
+    decimals: 18,
+    logoUri: '',
+  },
+  logoUri: '',
+};
+
+describe('isEthereumAppRequired', () => {
+  it('returns true for Ethereum mainnet', () => {
+    expect(
+      isEthereumAppRequired({
+        ...baseNetwork,
+        chainId: ChainId.ETHEREUM_HOMESTEAD,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for Ethereum testnets', () => {
+    expect(
+      isEthereumAppRequired({
+        ...baseNetwork,
+        chainId: ChainId.ETHEREUM_TEST_SEPOLIA,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for Robinhood mainnet', () => {
+    expect(
+      isEthereumAppRequired({
+        ...baseNetwork,
+        chainId: ROBINHOOD_MAINNET_CHAIN_ID,
+        chainName: 'Robinhood',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for Robinhood testnet', () => {
+    expect(
+      isEthereumAppRequired({
+        ...baseNetwork,
+        chainId: ROBINHOOD_TESTNET_CHAIN_ID,
+        chainName: 'Robinhood Testnet',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for non-Ethereum, non-Robinhood networks', () => {
+    expect(
+      isEthereumAppRequired({
+        ...baseNetwork,
+        chainId: ChainId.AVALANCHE_MAINNET_ID,
+        chainName: 'Avalanche',
+      }),
+    ).toBe(false);
+
+    expect(
+      isEthereumAppRequired({
+        ...baseNetwork,
+        chainId: 1337,
+        chainName: 'Local Devnet',
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/common/src/utils/ledger/isEthereumAppRequired.ts
+++ b/packages/common/src/utils/ledger/isEthereumAppRequired.ts
@@ -1,0 +1,8 @@
+import { Network } from '@core/types';
+
+import { isEthereumNetwork } from '../network/isEthereumNetwork';
+import { isRobinhoodNetwork } from '../network/isRobinhoodNetwork';
+
+export const isEthereumAppRequired = (network: Network) => {
+  return isEthereumNetwork(network) || isRobinhoodNetwork(network);
+};

--- a/packages/service-worker/lavamoat/rspack/policy.json
+++ b/packages/service-worker/lavamoat/rspack/policy.json
@@ -5042,6 +5042,12 @@
         "buffer": true
       }
     },
+    "external:../common/src/utils/ledger/isEthereumAppRequired.ts": {
+      "packages": {
+        "external:../common/src/utils/network/isEthereumNetwork.ts": true,
+        "external:../common/src/utils/network/isRobinhoodNetwork.ts": true
+      }
+    },
     "external:../common/src/utils/logging.ts": {
       "globals": {
         "console.groupCollapsed": true,

--- a/packages/service-worker/src/services/wallet/WalletService.ts
+++ b/packages/service-worker/src/services/wallet/WalletService.ts
@@ -24,7 +24,6 @@ import {
   getLegacyXPDerivationPath,
   getProviderForNetwork,
   hasAtLeastOneElement,
-  isEthereumNetwork,
   isDirectLedgerHyperEvmTransactionUnsupported,
   isNotNullish,
   isPchainNetwork,
@@ -33,6 +32,7 @@ import {
   isXchainNetwork,
   Monitoring,
   omitUndefined,
+  isEthereumAppRequired,
 } from '@core/common';
 import {
   Account,
@@ -692,7 +692,7 @@ export class WalletService implements OnUnlock {
     const transport = this.#requireLedgerTransport();
     await ensureLedgerAppOpen(
       transport,
-      isEthereumNetwork(network) ? 'Ethereum' : 'Avalanche',
+      isEthereumAppRequired(network) ? 'Ethereum' : 'Avalanche',
     );
   }
 

--- a/packages/service-worker/src/services/wallet/WalletService.ts
+++ b/packages/service-worker/src/services/wallet/WalletService.ts
@@ -685,8 +685,11 @@ export class WalletService implements OnUnlock {
   }
 
   /**
-   * Match approval UI `getRequiredApp`: Ethereum (homestead + listed testnets) →
-   * Ethereum app; Avalanche C/X/P and all other EVM chains → Avalanche app.
+   * Match approval UI `getRequiredApp`:
+   *
+   * - Ethereum (homestead + listed testnets) → Ethereum app
+   * - Robinhood networks → Ethereum app
+   * - all other EVM chains → Avalanche app.
    */
   async #ensureEvmLedgerAppOpenForSigning(network: Network): Promise<void> {
     const transport = this.#requireLedgerTransport();


### PR DESCRIPTION
# Summary

⚠️ **Based on https://github.com/ava-labs/core-extension/pull/996**
Jira ticket: https://ava-labs.atlassian.net/browse/CP-14827
Figma: _n/a_

<!-- Describe the changes -->
<!-- Link the Jira ticket and Figma designs. Prefer listing expectations vs. linking large docs like PRD -->

## Notes
Makes `Ethereum` app required for signing Robinhood transactions.
<!-- Additional notes and context. Explain non-synchronized design, product, or architectural design decisions -->

## Testing
1. Onboard using Ledger, have Ethereum app installed.
2. Go to https://app.uniswap.org/swap to perform some swaps (including stock tokens, like `APPL`)
3. When signing tx, extension should prompt you to switch to Ethereum app and enable blind signing (if you haven't already).

## Media
