### PR TITLE
fix: policy fix attempt

### DIFF
--- a/.github/workflows/validate-lavamoat-policies.yaml
+++ b/.github/workflows/validate-lavamoat-policies.yaml
@@ -97,15 +97,14 @@ jobs:
         run: |
           yarn install --check-cache
           yarn allow-scripts
-      # Mirrors `main_branch.yaml`'s shipping command so we're regenerating
-      # under the same rsbuild config that produces the alpha bundles.
-      # Functionally identical to `yarn build` today (both alpha and prod
-      # configs use `generateLavaMoatPolicy: true` + `getEnvVars('production')`),
-      # but parity protects us if the two configs ever diverge.
+      # Must match `main_branch.yaml`'s shipping command exactly, including
+      # source maps. Source map generation changes Rspack's codegen/runtime
+      # module ordering, which the LavaMoat plugin is sensitive to — disabling
+      # them here (e.g. via NO_SOURCE_MAPS for speed) would let this gate pass
+      # on a build that then fails when the release workflow ships with source
+      # maps enabled.
       - name: Build (regenerates LavaMoat policies)
         run: yarn build:alpha
-        env:
-          NO_SOURCE_MAPS: 'true'
       - name: Detect policy drift
         id: drift
         # The pathspec matches `policy.json` under any `lavamoat/rspack/`

--- a/apps/next/lavamoat/rspack/policy.json
+++ b/apps/next/lavamoat/rspack/policy.json
@@ -2,7 +2,7 @@
   "resources": {
     "@avalabs/avalanchejs": {
       "globals": {
-        "TextDecoder": false,
+        "TextDecoder": true,
         "TextEncoder": true,
         "console.log": true,
         "crypto": true,

--- a/apps/next/lavamoat/rspack/policy.json
+++ b/apps/next/lavamoat/rspack/policy.json
@@ -2,7 +2,7 @@
   "resources": {
     "@avalabs/avalanchejs": {
       "globals": {
-        "TextDecoder": true,
+        "TextDecoder": false,
         "TextEncoder": true,
         "console.log": true,
         "crypto": true,

--- a/packages/lavamoat-rspack/jest.config.js
+++ b/packages/lavamoat-rspack/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  clearMocks: true,
+  testEnvironment: 'node',
+  transform: {},
+  testMatch: ['<rootDir>/src/**/*.test.js'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+};

--- a/packages/lavamoat-rspack/package.json
+++ b/packages/lavamoat-rspack/package.json
@@ -4,6 +4,10 @@
   "description": "LavaMoat Rspack plugin for running dependencies in Compartments without eval",
   "main": "src/plugin.js",
   "types": "types/plugin.d.ts",
+  "scripts": {
+    "test": "yarn jest",
+    "test:watch": "yarn jest --watch"
+  },
   "exports": {
     ".": {
       "types": "./types/plugin.d.ts",
@@ -40,6 +44,7 @@
     "ses": "1.15.0"
   },
   "devDependencies": {
-    "@types/browser-resolve": "2.0.5"
+    "@types/browser-resolve": "2.0.5",
+    "jest": "29.7.0"
   }
 }

--- a/packages/lavamoat-rspack/src/buildtime/utils.js
+++ b/packages/lavamoat-rspack/src/buildtime/utils.js
@@ -19,7 +19,18 @@ const diag = require('./diagnostics');
  */
 
 /**
- * Monitors progress along a linear sequence of steps.
+ * Monitors progress along an ordered sequence of steps.
+ *
+ * A step may carry `:`-separated flags after its name:
+ *
+ * - `repeats`: the step may be reported more than once without erroring.
+ * - `unordered`: the step belongs to a group whose members may be reported in
+ *   any order relative to one another. Consecutive `unordered` steps form a
+ *   single group; the sequence only advances past the group once every member
+ *   has been reported. This exists because bundler hook firing order isn't
+ *   guaranteed for some phases (e.g. Rspack can emit runtime requirements for a
+ *   chunk before any covered module's source is generated), so requiring a
+ *   fixed order between such steps would make the build fail nondeterministically.
  *
  * @param {object} options
  * @param {string[]} options.steps
@@ -39,15 +50,40 @@ function progress({ steps }) {
   };
   const canRepeat = new Set();
 
-  steps = steps.map((step) => {
-    const [st, info] = step.split(':');
-    if (info === 'repeats') {
-      canRepeat.add(st);
+  /** @type {{ members: string[]; unordered: boolean }[]} */
+  const slots = [];
+  /** @type {Map<string, number>} */
+  const slotByStep = new Map();
+
+  steps.forEach((step) => {
+    const [name, ...flags] = step.split(':');
+    if (flags.includes('repeats')) {
+      canRepeat.add(name);
     }
-    return st;
+    const unordered = flags.includes('unordered');
+    const lastSlot = slots[slots.length - 1];
+    if (unordered && lastSlot?.unordered) {
+      lastSlot.members.push(name);
+    } else {
+      slots.push({ members: [name], unordered });
+    }
+    slotByStep.set(name, slots.length - 1);
   });
-  let currentStep = 0;
+
+  let currentSlot = 0;
   const done = new Set();
+
+  /**
+   * @param {number} slotIndex
+   */
+  const describeSlot = (slotIndex) => {
+    const slot = slots[slotIndex];
+    if (!slot) {
+      return String(undefined);
+    }
+    const pending = slot.members.filter((member) => !done.has(member));
+    return (pending.length > 0 ? pending : slot.members).join(' or ');
+  };
 
   const API = {};
 
@@ -57,34 +93,48 @@ function progress({ steps }) {
    * @param {string} step - The step to report progress for.
    */
   API.report = (step) => {
-    if (canRepeat.has(step) && steps[currentStep] === step) {
+    const slotIndex = slotByStep.get(step);
+    const nextSlot = currentSlot + 1;
+
+    if (
+      canRepeat.has(step) &&
+      done.has(step) &&
+      (slotIndex === currentSlot || slotIndex === nextSlot)
+    ) {
       diag.rawDebug(4, `  progress  Reporting ${step} again`);
       return;
     }
-    done.add(step);
-    if (steps[currentStep + 1] !== step) {
+
+    if (slotIndex !== nextSlot) {
       reportError(
         Error(
-          `LavaMoatPlugin: Progress reported '${step}' but the next step was expected to be '${
-            steps[currentStep + 1]
-          }'`,
+          `LavaMoatPlugin: Progress reported '${step}' but the next step was expected to be '${describeSlot(
+            nextSlot,
+          )}'`,
         ),
       );
-    } else {
-      diag.rawDebug(2, `  progress  ${steps[currentStep]}->${step}`);
-      currentStep += 1;
+      return;
+    }
+
+    done.add(step);
+    if (slots[nextSlot].members.every((member) => done.has(member))) {
+      diag.rawDebug(
+        2,
+        `  progress  ${describeSlot(currentSlot)}->${describeSlot(nextSlot)}`,
+      );
+      currentSlot = nextSlot;
     }
   };
   /**
    * @param {string} query - Step name
    */
   API.is = (query) => {
-    const current = steps[currentStep];
+    const current = describeSlot(currentSlot);
     diag.rawDebug(3, `  progress  Checking (${current}).is(${query})`);
-    return current === query;
+    return slots[currentSlot]?.members.includes(query) ?? false;
   };
   API.get = () => {
-    return steps[currentStep];
+    return describeSlot(currentSlot);
   };
   /**
    * @param {string} query - Step name
@@ -101,7 +151,9 @@ function progress({ steps }) {
     }
     reportError(
       Error(
-        `LavaMoatPlugin: Expected '${query}' to be done, but we're at '${steps[currentStep]}'`,
+        `LavaMoatPlugin: Expected '${query}' to be done, but we're at '${describeSlot(
+          currentSlot,
+        )}'`,
       ),
     );
   };
@@ -119,7 +171,7 @@ function progress({ steps }) {
   };
   API.isCancelled = () => cancelled;
 
-  diag.rawDebug(2, `  progress  ${steps[currentStep]}`);
+  diag.rawDebug(2, `  progress  ${describeSlot(currentSlot)}`);
 
   return API;
 }

--- a/packages/lavamoat-rspack/src/buildtime/utils.test.js
+++ b/packages/lavamoat-rspack/src/buildtime/utils.test.js
@@ -1,0 +1,113 @@
+const { progress } = require('./utils.js');
+
+/**
+ * @param {string[]} steps
+ */
+const setup = (steps) => {
+  const PROGRESS = progress({ steps });
+  /** @type {Error[]} */
+  const errors = [];
+  PROGRESS.reportErrorsTo(errors);
+  return { PROGRESS, errors };
+};
+
+const LINEAR_STEPS = ['start', 'a', 'b', 'c'];
+
+const UNORDERED_STEPS = [
+  'start',
+  'pathsProcessed',
+  'generatorCalled:repeats:unordered',
+  'runtimeAdded:repeats:unordered',
+  'finish',
+];
+
+describe('progress', () => {
+  describe('linear sequence', () => {
+    it('advances through steps reported in order', () => {
+      const { PROGRESS, errors } = setup(LINEAR_STEPS);
+
+      PROGRESS.report('a');
+      PROGRESS.report('b');
+      PROGRESS.report('c');
+
+      expect(errors).toHaveLength(0);
+      expect(PROGRESS.done('a')).toBe(true);
+      expect(PROGRESS.done('c')).toBe(true);
+    });
+
+    it('errors when a step is reported out of order', () => {
+      const { PROGRESS, errors } = setup(LINEAR_STEPS);
+
+      PROGRESS.report('c');
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain(
+        "Progress reported 'c' but the next step was expected to be 'a'",
+      );
+    });
+  });
+
+  describe('unordered group', () => {
+    it('accepts runtimeAdded before generatorCalled', () => {
+      const { PROGRESS, errors } = setup(UNORDERED_STEPS);
+
+      PROGRESS.report('pathsProcessed');
+      PROGRESS.report('runtimeAdded');
+      PROGRESS.report('generatorCalled');
+      PROGRESS.report('finish');
+
+      expect(errors).toHaveLength(0);
+      expect(PROGRESS.done('generatorCalled')).toBe(true);
+      expect(PROGRESS.done('runtimeAdded')).toBe(true);
+      expect(PROGRESS.done('finish')).toBe(true);
+    });
+
+    it('accepts generatorCalled before runtimeAdded', () => {
+      const { PROGRESS, errors } = setup(UNORDERED_STEPS);
+
+      PROGRESS.report('pathsProcessed');
+      PROGRESS.report('generatorCalled');
+      PROGRESS.report('runtimeAdded');
+      PROGRESS.report('finish');
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('tolerates repeated reports of group members in any order', () => {
+      const { PROGRESS, errors } = setup(UNORDERED_STEPS);
+
+      PROGRESS.report('pathsProcessed');
+      PROGRESS.report('generatorCalled');
+      PROGRESS.report('generatorCalled');
+      PROGRESS.report('runtimeAdded');
+      PROGRESS.report('generatorCalled');
+      PROGRESS.report('finish');
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('does not advance past the group until every member is reported', () => {
+      const { PROGRESS, errors } = setup(UNORDERED_STEPS);
+
+      PROGRESS.report('pathsProcessed');
+      PROGRESS.report('generatorCalled');
+      PROGRESS.report('finish');
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain(
+        "Progress reported 'finish' but the next step was expected to be 'runtimeAdded'",
+      );
+    });
+
+    it('errors when entering the group before its predecessor is done', () => {
+      const { PROGRESS, errors } = setup(UNORDERED_STEPS);
+
+      PROGRESS.report('runtimeAdded');
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain(
+        "the next step was expected to be 'pathsProcessed'",
+      );
+    });
+  });
+});

--- a/packages/lavamoat-rspack/src/plugin.js
+++ b/packages/lavamoat-rspack/src/plugin.js
@@ -279,8 +279,13 @@ class LavaMoatRspackPlugin {
             'canonicalNameMap',
             'pathsCollected',
             'pathsProcessed',
-            'generatorCalled:repeats',
-            'runtimeAdded:repeats',
+            // Rspack doesn't guarantee module codegen (generatorCalled, via
+            // Rsdoctor moduleSources) runs before a runtime chunk's requirements
+            // (runtimeAdded, via additionalTreeRuntimeRequirements). Enabling
+            // source maps shifts that order, so these two must be interchangeable
+            // or the build fails nondeterministically depending on config/host.
+            'generatorCalled:repeats:unordered',
+            'runtimeAdded:repeats:unordered',
             'finish',
           ],
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3056,6 +3056,7 @@ __metadata:
     "@rspack/lite-tapable": "npm:1.0.1"
     "@types/browser-resolve": "npm:2.0.5"
     browser-resolve: "npm:2.0.0"
+    jest: "npm:29.7.0"
     lavamoat-core: "npm:18.0.0"
     ses: "npm:1.15.0"
   peerDependencies:


### PR DESCRIPTION
# Summary

Jira ticket:
Figma:

<!-- Describe the changes -->
<!-- Link the Jira ticket and Figma designs. Prefer listing expectations vs. linking large docs like PRD -->

## Notes

The Release Main Branch workflow failed on chore: update sdks, ajs and vm modules (#1000) during Build app, even though the PR's Validate LavaMoat policies check passed:

```
× Error: LavaMoatPlugin: Progress reported 'runtimeAdded' but the next step was expected to be 'generatorCalled'
    at API.report (packages/lavamoat-rspack/src/buildtime/utils.js:67:9)
    at getLavaMoatRuntimeModules (packages/lavamoat-rspack/src/runtime/runtimeBuilder.js:393:22)
    at Object.fn (packages/lavamoat-rspack/src/plugin.js:686:48)
```

This PR fixes the underlying ordering bug in the LavaMoat plugin and closes the CI gap that let it reach main undetected.


### Why the PR check missed it
`validate-lavamoat-policies.yaml` and `main_branch.yaml` run the same command (`yarn build:alpha`) in the same `alpha` environment — but the validate job set `NO_SOURCE_MAPS: 'true'`, while the release job did not:

```ts
// packages/service-worker/rsbuild.worker.prod.ts
const skipSourceMap = process.env.NO_SOURCE_MAPS === 'true';
sourceMap: skipSourceMap ? false : { js: 'hidden-source-map' },
```

So the PR gate built the service worker without source maps and never exercised the code path that fails when they're enabled — meaning it structurally could not catch this class of failure.


