### PR TITLE
refactor: get network enablement state from API

### DIFF
--- a/apps/next/src/pages/Settings/components/NetworkManagement/components/NetworkToggle/NetworkToggleList.tsx
+++ b/apps/next/src/pages/Settings/components/NetworkManagement/components/NetworkToggle/NetworkToggleList.tsx
@@ -14,7 +14,7 @@ type NetworkToggleListProps = {
   networks: NetworkWithCaipId[];
 };
 
-const defaultNetworkSet = new Set(NETWORKS_ENABLED_FOREVER);
+const alwaysEnabledNetworkSet = new Set(NETWORKS_ENABLED_FOREVER);
 export const NetworkToggleList = ({ networks }: NetworkToggleListProps) => {
   const { enabledNetworks, enableNetwork, disableNetwork } =
     useNetworkContext();
@@ -104,7 +104,10 @@ export const NetworkToggleList = ({ networks }: NetworkToggleListProps) => {
           key={network.chainId}
           network={network}
           isEnabled={enabledNetworksArray.includes(network.chainId)}
-          isDefault={defaultNetworkSet.has(network.chainId)}
+          isAlwaysEnabled={
+            Boolean(network.isAlwaysEnabled) ||
+            alwaysEnabledNetworkSet.has(network.chainId)
+          }
           onToggle={() => {
             if (enabledNetworksArray.includes(network.chainId)) {
               disableNetwork(network.chainId);

--- a/apps/next/src/pages/Settings/components/NetworkManagement/components/NetworkToggle/NetworkToggleList.tsx
+++ b/apps/next/src/pages/Settings/components/NetworkManagement/components/NetworkToggle/NetworkToggleList.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@avalabs/k2-alpine';
-import { NETWORKS_ENABLED_FOREVER, NetworkWithCaipId } from '@core/types';
+import { NetworkWithCaipId } from '@core/types';
 import {
   useAccountsContext,
   useBalancesContext,
@@ -14,7 +14,6 @@ type NetworkToggleListProps = {
   networks: NetworkWithCaipId[];
 };
 
-const alwaysEnabledNetworkSet = new Set(NETWORKS_ENABLED_FOREVER);
 export const NetworkToggleList = ({ networks }: NetworkToggleListProps) => {
   const { enabledNetworks, enableNetwork, disableNetwork } =
     useNetworkContext();
@@ -104,10 +103,7 @@ export const NetworkToggleList = ({ networks }: NetworkToggleListProps) => {
           key={network.chainId}
           network={network}
           isEnabled={enabledNetworksArray.includes(network.chainId)}
-          isAlwaysEnabled={
-            Boolean(network.isAlwaysEnabled) ||
-            alwaysEnabledNetworkSet.has(network.chainId)
-          }
+          isAlwaysEnabled={Boolean(network.isAlwaysEnabled)}
           onToggle={() => {
             if (enabledNetworksArray.includes(network.chainId)) {
               disableNetwork(network.chainId);

--- a/apps/next/src/pages/Settings/components/NetworkManagement/components/NetworkToggle/NetworkToggleListItem.tsx
+++ b/apps/next/src/pages/Settings/components/NetworkManagement/components/NetworkToggle/NetworkToggleListItem.tsx
@@ -19,7 +19,7 @@ type NetworkToggleListItemProps = {
 export const NetworkToggleListItem = ({
   network,
   isEnabled,
-  isAlwaysEnabled: isDefault,
+  isAlwaysEnabled,
   onToggle,
   onClick,
 }: NetworkToggleListItemProps) => {
@@ -42,12 +42,12 @@ export const NetworkToggleListItem = ({
         />
       </ListItemIcon>
       <ListItemText primary={network.chainName} />
-      {isDefault ? null : (
+      {isAlwaysEnabled ? null : (
         <Switch
           data-testid={`network-toggle-${network.chainId}`}
           size="small"
           checked={isEnabled}
-          disabled={isDefault}
+          disabled={isAlwaysEnabled}
           onChange={onToggle}
           onClick={(e) => e.stopPropagation()}
         />

--- a/apps/next/src/pages/Settings/components/NetworkManagement/components/NetworkToggle/NetworkToggleListItem.tsx
+++ b/apps/next/src/pages/Settings/components/NetworkManagement/components/NetworkToggle/NetworkToggleListItem.tsx
@@ -11,7 +11,7 @@ import { NetworkAvatar } from '../NetworkAvatar/NetworkAvatar';
 type NetworkToggleListItemProps = {
   network: NetworkWithCaipId;
   isEnabled: boolean;
-  isDefault: boolean;
+  isAlwaysEnabled: boolean;
   onToggle: () => void;
   onClick: () => void;
 };
@@ -19,7 +19,7 @@ type NetworkToggleListItemProps = {
 export const NetworkToggleListItem = ({
   network,
   isEnabled,
-  isDefault,
+  isAlwaysEnabled: isDefault,
   onToggle,
   onClick,
 }: NetworkToggleListItemProps) => {

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -63,6 +63,7 @@ export * from './measureDuration';
 export * from './network/addGlacierAPIKeyIfNeeded';
 export * from './network/buildCoreEth';
 export * from './network/buildGlacierAuthHeaders';
+export * from './network/getNetworkEnablement';
 export * from './network/getProviderForNetwork';
 export * from './network/isDirectLedgerHyperEvmTransactionUnsupported';
 export * from './network/isAvalancheNetwork';

--- a/packages/common/src/utils/network/getNetworkEnablement.test.ts
+++ b/packages/common/src/utils/network/getNetworkEnablement.test.ts
@@ -1,4 +1,4 @@
-import { NetworkVMType } from '@avalabs/core-chains-sdk';
+import { NetworkVMType, ChainId } from '@avalabs/core-chains-sdk';
 import {
   ChainList,
   Network,
@@ -66,13 +66,17 @@ describe('getAlwaysEnabledNetworkIds', () => {
     expect(result.filter((id) => id === firstForeverId)).toHaveLength(1);
   });
 
-  it('removes floor ids when the API flags them isAlwaysEnabled false', () => {
-    const firstForeverId = NETWORKS_ENABLED_FOREVER[0]!;
+  it('keeps C-Chain in the floor when the API sends isAlwaysEnabled false', () => {
     const chainList = buildChainList([
-      buildNetwork({ chainId: firstForeverId, isAlwaysEnabled: false }),
+      buildNetwork({
+        chainId: ChainId.AVALANCHE_MAINNET_ID,
+        isAlwaysEnabled: false,
+      }),
     ]);
 
-    expect(getAlwaysEnabledNetworkIds(chainList)).not.toContain(firstForeverId);
+    expect(getAlwaysEnabledNetworkIds(chainList)).toContain(
+      ChainId.AVALANCHE_MAINNET_ID,
+    );
   });
 
   it('keeps floor ids when the API flag is undefined', () => {

--- a/packages/common/src/utils/network/getNetworkEnablement.test.ts
+++ b/packages/common/src/utils/network/getNetworkEnablement.test.ts
@@ -1,0 +1,144 @@
+import { NetworkVMType } from '@avalabs/core-chains-sdk';
+import {
+  ChainList,
+  Network,
+  NETWORKS_ENABLED_BY_DEFAULT,
+  NETWORKS_ENABLED_FOREVER,
+} from '@core/types';
+import {
+  getAlwaysEnabledNetworkIds,
+  getDefaultEnabledNetworkIds,
+} from './getNetworkEnablement';
+
+const buildNetwork = (network: Partial<Network> & { chainId: number }) =>
+  ({
+    chainName: `Network ${network.chainId}`,
+    vmName: NetworkVMType.EVM,
+    rpcUrl: 'https://rpc.example',
+    explorerUrl: 'https://explorer.example',
+    networkToken: {
+      name: 'Token',
+      symbol: 'TKN',
+      description: '',
+      decimals: 18,
+      logoUri: '',
+    },
+    logoUri: '',
+    ...network,
+  }) as Network;
+
+const buildChainList = (networks: Network[]): ChainList =>
+  networks.reduce<ChainList>((acc, network) => {
+    acc[network.chainId] = network;
+    return acc;
+  }, {});
+
+describe('getAlwaysEnabledNetworkIds', () => {
+  it('returns the hardcoded floor when no network is flagged', () => {
+    const chainList = buildChainList([buildNetwork({ chainId: 111 })]);
+
+    expect(getAlwaysEnabledNetworkIds(chainList)).toEqual(
+      NETWORKS_ENABLED_FOREVER,
+    );
+  });
+
+  it('augments the floor with API isAlwaysEnabled networks', () => {
+    const chainList = buildChainList([
+      buildNetwork({ chainId: 111, isAlwaysEnabled: true }),
+      buildNetwork({ chainId: 222, isAlwaysEnabled: false }),
+    ]);
+
+    const result = getAlwaysEnabledNetworkIds(chainList);
+
+    expect(result).toEqual(expect.arrayContaining(NETWORKS_ENABLED_FOREVER));
+    expect(result).toContain(111);
+    expect(result).not.toContain(222);
+  });
+
+  it('does not duplicate ids already in the floor', () => {
+    const firstForeverId = NETWORKS_ENABLED_FOREVER[0]!;
+    const chainList = buildChainList([
+      buildNetwork({ chainId: firstForeverId, isAlwaysEnabled: true }),
+    ]);
+
+    const result = getAlwaysEnabledNetworkIds(chainList);
+
+    expect(result.filter((id) => id === firstForeverId)).toHaveLength(1);
+  });
+
+  it('removes floor ids when the API flags them isAlwaysEnabled false', () => {
+    const firstForeverId = NETWORKS_ENABLED_FOREVER[0]!;
+    const chainList = buildChainList([
+      buildNetwork({ chainId: firstForeverId, isAlwaysEnabled: false }),
+    ]);
+
+    expect(getAlwaysEnabledNetworkIds(chainList)).not.toContain(firstForeverId);
+  });
+
+  it('keeps floor ids when the API flag is undefined', () => {
+    const firstForeverId = NETWORKS_ENABLED_FOREVER[0]!;
+    const chainList = buildChainList([
+      buildNetwork({ chainId: firstForeverId }),
+    ]);
+
+    expect(getAlwaysEnabledNetworkIds(chainList)).toContain(firstForeverId);
+  });
+});
+
+describe('getDefaultEnabledNetworkIds', () => {
+  it('returns the hardcoded floor when no network is flagged', () => {
+    const chainList = buildChainList([buildNetwork({ chainId: 111 })]);
+
+    const result = getDefaultEnabledNetworkIds(chainList);
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        ...NETWORKS_ENABLED_BY_DEFAULT,
+        ...NETWORKS_ENABLED_FOREVER,
+      ]),
+    );
+  });
+
+  it('augments the floor with API isEnabledByDefault networks', () => {
+    const chainList = buildChainList([
+      buildNetwork({ chainId: 111, isEnabledByDefault: true }),
+      buildNetwork({ chainId: 222, isEnabledByDefault: false }),
+    ]);
+
+    const result = getDefaultEnabledNetworkIds(chainList);
+
+    expect(result).toContain(111);
+    expect(result).not.toContain(222);
+  });
+
+  it('includes always-enabled networks as enabled by default', () => {
+    const chainList = buildChainList([
+      buildNetwork({ chainId: 333, isAlwaysEnabled: true }),
+    ]);
+
+    expect(getDefaultEnabledNetworkIds(chainList)).toContain(333);
+  });
+
+  it('removes floor ids when the API flags them isEnabledByDefault false', () => {
+    const firstDefaultId = NETWORKS_ENABLED_BY_DEFAULT[0]!;
+    const chainList = buildChainList([
+      buildNetwork({ chainId: firstDefaultId, isEnabledByDefault: false }),
+    ]);
+
+    expect(getDefaultEnabledNetworkIds(chainList)).not.toContain(
+      firstDefaultId,
+    );
+  });
+
+  it('keeps always-enabled networks even when flagged isEnabledByDefault false', () => {
+    const chainList = buildChainList([
+      buildNetwork({
+        chainId: 444,
+        isAlwaysEnabled: true,
+        isEnabledByDefault: false,
+      }),
+    ]);
+
+    expect(getDefaultEnabledNetworkIds(chainList)).toContain(444);
+  });
+});

--- a/packages/common/src/utils/network/getNetworkEnablement.ts
+++ b/packages/common/src/utils/network/getNetworkEnablement.ts
@@ -6,9 +6,11 @@ import {
 
 /**
  * Hybrid resolution (always-enabled networks):
- *   - the hardcoded `NETWORKS_ENABLED_FOREVER` is the base set
- *   - the API's `isAlwaysEnabled` flag overrides the base set: `true` adds a
- *     network, `false` removes it, `undefined` leaves the base set untouched
+ *   - the hardcoded `NETWORKS_ENABLED_FOREVER` is a floor that the API cannot
+ *     remove from. `/tokenlist` always sends `isAlwaysEnabled` as a boolean
+ *     (never `undefined`); untagged chains come back `false`, so honoring
+ *     `false` would make C-Chain / ETH user-disableable after a Contentful miss.
+ *   - `true` adds a network; `false` / `undefined` leave the floor untouched.
  *
  * Hybrid resolution (default-enabled networks):
  *   - the hardcoded `NETWORKS_ENABLED_BY_DEFAULT` is the base set
@@ -23,8 +25,6 @@ export function getAlwaysEnabledNetworkIds(chainList: ChainList): number[] {
   for (const network of Object.values(chainList)) {
     if (network.isAlwaysEnabled === true) {
       ids.add(network.chainId);
-    } else if (network.isAlwaysEnabled === false) {
-      ids.delete(network.chainId);
     }
   }
 

--- a/packages/common/src/utils/network/getNetworkEnablement.ts
+++ b/packages/common/src/utils/network/getNetworkEnablement.ts
@@ -1,0 +1,50 @@
+import {
+  ChainList,
+  NETWORKS_ENABLED_BY_DEFAULT,
+  NETWORKS_ENABLED_FOREVER,
+} from '@core/types';
+
+/**
+ * Hybrid resolution (always-enabled networks):
+ *   - the hardcoded `NETWORKS_ENABLED_FOREVER` is the base set
+ *   - the API's `isAlwaysEnabled` flag overrides the base set: `true` adds a
+ *     network, `false` removes it, `undefined` leaves the base set untouched
+ *
+ * Hybrid resolution (default-enabled networks):
+ *   - the hardcoded `NETWORKS_ENABLED_BY_DEFAULT` is the base set
+ *   - the API's `isEnabledByDefault` flag overrides the base set: `true` adds a
+ *     network, `false` removes it, `undefined` leaves the base set untouched
+ *   - always-enabled networks are always included, regardless of the flag
+ */
+
+export function getAlwaysEnabledNetworkIds(chainList: ChainList): number[] {
+  const ids = new Set<number>(NETWORKS_ENABLED_FOREVER);
+
+  for (const network of Object.values(chainList)) {
+    if (network.isAlwaysEnabled === true) {
+      ids.add(network.chainId);
+    } else if (network.isAlwaysEnabled === false) {
+      ids.delete(network.chainId);
+    }
+  }
+
+  return [...ids];
+}
+
+export function getDefaultEnabledNetworkIds(chainList: ChainList): number[] {
+  const ids = new Set<number>(NETWORKS_ENABLED_BY_DEFAULT);
+
+  for (const network of Object.values(chainList)) {
+    if (network.isEnabledByDefault === true) {
+      ids.add(network.chainId);
+    } else if (network.isEnabledByDefault === false) {
+      ids.delete(network.chainId);
+    }
+  }
+
+  for (const id of getAlwaysEnabledNetworkIds(chainList)) {
+    ids.add(id);
+  }
+
+  return [...ids];
+}

--- a/packages/service-worker/lavamoat/rspack/policy.json
+++ b/packages/service-worker/lavamoat/rspack/policy.json
@@ -5078,6 +5078,11 @@
         "@avalabs/core-chains-sdk": true
       }
     },
+    "external:../common/src/utils/network/getNetworkEnablement.ts": {
+      "packages": {
+        "external:../types/src/index.ts": true
+      }
+    },
     "external:../common/src/utils/network/getProviderForNetwork.ts": {
       "globals": {
         "process.env.GLACIER_API_KEY": true,

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -13,6 +13,7 @@ import {
   NETWORK_OVERRIDES_STORAGE_KEY,
   NETWORK_STORAGE_KEY,
   NETWORKS_ENABLED_BY_DEFAULT,
+  NETWORKS_ENABLED_FOREVER,
   FeatureGates,
 } from '@core/types';
 import { FeatureFlagService } from '../featureFlags/FeatureFlagService';
@@ -918,7 +919,7 @@ describe('background/services/network/NetworkService', () => {
 
         expect(signalSpy).toHaveBeenCalled();
         expect(signalSpy).toHaveBeenCalledWith(
-          expect.arrayContaining([chainId]),
+          expect.arrayContaining([chainId, ...NETWORKS_ENABLED_FOREVER]),
         );
       });
     });
@@ -1059,8 +1060,6 @@ describe('background/services/network/NetworkService', () => {
       it('treats a network flagged isAlwaysEnabled as non-disableable', async () => {
         const alwaysOnChainId = 424242;
 
-        // Simulate the chainlist arriving with the API flag set. This updates
-        // the derived always-enabled set via the _allNetworks subscription.
         service['_allNetworks'].dispatch({
           [alwaysOnChainId]: mockNetwork(NetworkVMType.EVM, false, {
             chainId: alwaysOnChainId,
@@ -1068,15 +1067,10 @@ describe('background/services/network/NetworkService', () => {
           }),
         });
 
-        // Enabling any network runs the enabled-networks setter, which unions
-        // the always-enabled set in (mirrors what init/storage load does).
-        await service.enableNetwork(1337);
         expect(service['_enabledNetworks']).toContain(alwaysOnChainId);
 
         jest.clearAllMocks();
 
-        // Disabling an always-enabled network is a no-op: it stays enabled and
-        // no stale disabled record is persisted.
         await service.disableNetwork(alwaysOnChainId);
 
         expect(service['_enabledNetworks']).toContain(alwaysOnChainId);
@@ -1103,6 +1097,24 @@ describe('background/services/network/NetworkService', () => {
           service['_networkAvailability'][alwaysOnChainId],
         ).toBeUndefined();
       });
+
+      it('does not treat a feature-gated network as always-enabled', async () => {
+        const hyperEvm = mockNetwork(NetworkVMType.EVM, false, {
+          chainId: 999,
+          chainName: 'HyperEVM',
+          isAlwaysEnabled: true,
+        });
+
+        service['_allNetworks'].dispatch({
+          [hyperEvm.chainId]: hyperEvm,
+        });
+
+        expect(service['_enabledNetworks']).not.toContain(hyperEvm.chainId);
+
+        await service.disableNetwork(hyperEvm.chainId);
+
+        expect(service.updateNetworkState).toHaveBeenCalled();
+      });
     });
 
     describe('getNetworksEnabledByDefault', () => {
@@ -1125,6 +1137,25 @@ describe('background/services/network/NetworkService', () => {
           expect.arrayContaining(NETWORKS_ENABLED_BY_DEFAULT),
         );
         expect(result).toContain(defaultOnChainId);
+      });
+
+      it('does not default-enable feature-gated networks', async () => {
+        const hyperEvm = mockNetwork(NetworkVMType.EVM, false, {
+          chainId: 999,
+          chainName: 'HyperEVM',
+          isEnabledByDefault: true,
+        });
+
+        jest.spyOn(service.allNetworks, 'promisify').mockResolvedValue(
+          Promise.resolve({
+            [ethMainnet.chainId]: ethMainnet,
+            [hyperEvm.chainId]: hyperEvm,
+          }),
+        );
+
+        const result = await service.getNetworksEnabledByDefault();
+
+        expect(result).not.toContain(hyperEvm.chainId);
       });
     });
   });
@@ -1293,7 +1324,7 @@ describe('background/services/network/NetworkService', () => {
       );
     });
 
-    it('lets the API isAlwaysEnabled:false override the hardcoded floor', async () => {
+    it('keeps C-Chain always-enabled when the API sends isAlwaysEnabled: false', async () => {
       const networkService = new NetworkService(
         storageServiceMock,
         featureFlagsServiceMock,
@@ -1301,22 +1332,19 @@ describe('background/services/network/NetworkService', () => {
       );
       jest.spyOn(networkService, 'isMainnet').mockReturnValue(true);
 
-      // ChainId 1 (Ethereum) is part of NETWORKS_ENABLED_FOREVER, but the API
-      // explicitly opts it out.
-      const overriddenFloorNetwork = mockNetwork(NetworkVMType.EVM, false, {
-        chainId: 1,
+      const cChain = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: ChainId.AVALANCHE_MAINNET_ID,
         isAlwaysEnabled: false,
       });
 
       networkService['_allNetworks'].dispatch({
-        [overriddenFloorNetwork.chainId]: overriddenFloorNetwork,
+        [cChain.chainId]: cChain,
       });
 
       const activeNetworks = await networkService.activeNetworks.promisify();
 
-      expect(
-        activeNetworks[overriddenFloorNetwork.chainId]?.isAlwaysEnabled,
-      ).toBe(false);
+      expect(activeNetworks[cChain.chainId]?.isAlwaysEnabled).toBe(true);
+      expect(networkService['_enabledNetworks']).toContain(cChain.chainId);
     });
   });
 

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -12,6 +12,7 @@ import {
   NETWORK_LIST_STORAGE_KEY,
   NETWORK_OVERRIDES_STORAGE_KEY,
   NETWORK_STORAGE_KEY,
+  NETWORKS_ENABLED_BY_DEFAULT,
   FeatureGates,
 } from '@core/types';
 import { FeatureFlagService } from '../featureFlags/FeatureFlagService';
@@ -1047,6 +1048,68 @@ describe('background/services/network/NetworkService', () => {
         ).length;
 
         expect(duplicateCount).toBe(1);
+      });
+    });
+
+    describe('API-driven enablement flags', () => {
+      it('treats a network flagged isAlwaysEnabled as non-disableable', async () => {
+        const alwaysOnChainId = 424242;
+
+        // Simulate the chainlist arriving with the API flag set. This updates
+        // the derived always-enabled set via the _allNetworks subscription.
+        service['_allNetworks'].dispatch({
+          [alwaysOnChainId]: mockNetwork(NetworkVMType.EVM, false, {
+            chainId: alwaysOnChainId,
+            isAlwaysEnabled: true,
+          }),
+        });
+
+        // Attempting to disable it keeps it enabled, as the always-enabled set
+        // is unioned back in by the enabled-networks setter.
+        await service.disableNetwork(alwaysOnChainId);
+
+        expect(service['_enabledNetworks']).toContain(alwaysOnChainId);
+      });
+
+      it('does not persist availability for a network flagged isAlwaysEnabled', async () => {
+        const alwaysOnChainId = 424242;
+
+        service['_allNetworks'].dispatch({
+          [alwaysOnChainId]: mockNetwork(NetworkVMType.EVM, false, {
+            chainId: alwaysOnChainId,
+            isAlwaysEnabled: true,
+          }),
+        });
+
+        await service.enableNetwork(alwaysOnChainId);
+
+        expect(service.updateNetworkState).not.toHaveBeenCalled();
+        expect(
+          service['_networkAvailability'][alwaysOnChainId],
+        ).toBeUndefined();
+      });
+    });
+
+    describe('getNetworksEnabledByDefault', () => {
+      it('returns the hardcoded default networks augmented with API-flagged ones', async () => {
+        const defaultOnChainId = 555555;
+
+        jest.spyOn(service.allNetworks, 'promisify').mockResolvedValue(
+          Promise.resolve({
+            [ethMainnet.chainId]: ethMainnet,
+            [defaultOnChainId]: mockNetwork(NetworkVMType.EVM, false, {
+              chainId: defaultOnChainId,
+              isEnabledByDefault: true,
+            }),
+          }),
+        );
+
+        const result = await service.getNetworksEnabledByDefault();
+
+        expect(result).toEqual(
+          expect.arrayContaining(NETWORKS_ENABLED_BY_DEFAULT),
+        );
+        expect(result).toContain(defaultOnChainId);
       });
     });
   });

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -357,7 +357,9 @@ describe('background/services/network/NetworkService', () => {
 
       const network = await service.getInitialNetworkForDapp('test.app');
 
-      expect(network).toEqual(avaxMainnet);
+      // C-Chain (43114) is part of NETWORKS_ENABLED_FOREVER, so the network
+      // resolved through the activeNetworks pipeline carries the flag.
+      expect(network).toEqual({ ...avaxMainnet, isAlwaysEnabled: true });
     });
 
     it('defaults to C-Chain when there is no active network for UI (extension is locked)', async () => {
@@ -372,7 +374,9 @@ describe('background/services/network/NetworkService', () => {
 
       const network = await service.getInitialNetworkForDapp('test.app');
 
-      expect(network).toEqual(avaxMainnet);
+      // C-Chain (43114) is part of NETWORKS_ENABLED_FOREVER, so the network
+      // resolved through the activeNetworks pipeline carries the flag.
+      expect(network).toEqual({ ...avaxMainnet, isAlwaysEnabled: true });
     });
   });
 
@@ -1064,11 +1068,22 @@ describe('background/services/network/NetworkService', () => {
           }),
         });
 
-        // Attempting to disable it keeps it enabled, as the always-enabled set
-        // is unioned back in by the enabled-networks setter.
+        // Enabling any network runs the enabled-networks setter, which unions
+        // the always-enabled set in (mirrors what init/storage load does).
+        await service.enableNetwork(1337);
+        expect(service['_enabledNetworks']).toContain(alwaysOnChainId);
+
+        jest.clearAllMocks();
+
+        // Disabling an always-enabled network is a no-op: it stays enabled and
+        // no stale disabled record is persisted.
         await service.disableNetwork(alwaysOnChainId);
 
         expect(service['_enabledNetworks']).toContain(alwaysOnChainId);
+        expect(service.updateNetworkState).not.toHaveBeenCalled();
+        expect(
+          service['_networkAvailability'][alwaysOnChainId],
+        ).toBeUndefined();
       });
 
       it('does not persist availability for a network flagged isAlwaysEnabled', async () => {
@@ -1175,10 +1190,15 @@ describe('background/services/network/NetworkService', () => {
       const networksPromise = await networkService.activeNetworks.promisify();
 
       expect(await networksPromise).toEqual({
-        ...originalChainList,
+        // ChainId 1 (Ethereum) is part of NETWORKS_ENABLED_FOREVER.
+        '1': {
+          ...originalChainList['1'],
+          isAlwaysEnabled: true,
+        },
         '1337': {
           ...originalChainList['1337'],
           rpcUrl: 'http://my.custom.rpc',
+          isAlwaysEnabled: false,
         },
       });
     });
@@ -1219,6 +1239,8 @@ describe('background/services/network/NetworkService', () => {
         caipId: 'eip155:1',
         chainId: 1,
         isTestnet: false,
+        // ChainId 1 (Ethereum) is part of NETWORKS_ENABLED_FOREVER.
+        isAlwaysEnabled: true,
       },
     });
 
@@ -1236,7 +1258,65 @@ describe('background/services/network/NetworkService', () => {
         caipId: 'eip155:1337',
         chainId: 1337,
         isTestnet: true,
+        isAlwaysEnabled: false,
       },
+    });
+  });
+
+  describe('isAlwaysEnabled decoration (via activeNetworks signal)', () => {
+    it('resolves isAlwaysEnabled from the hardcoded floor when the API omits the flag', async () => {
+      const networkService = new NetworkService(
+        storageServiceMock,
+        featureFlagsServiceMock,
+        glacierServiceMock,
+      );
+      jest.spyOn(networkService, 'isMainnet').mockReturnValue(true);
+
+      // ChainId 1 (Ethereum) is part of NETWORKS_ENABLED_FOREVER.
+      const floorNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 1,
+      });
+      const regularNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 1234,
+      });
+
+      networkService['_allNetworks'].dispatch({
+        [floorNetwork.chainId]: floorNetwork,
+        [regularNetwork.chainId]: regularNetwork,
+      });
+
+      const activeNetworks = await networkService.activeNetworks.promisify();
+
+      expect(activeNetworks[floorNetwork.chainId]?.isAlwaysEnabled).toBe(true);
+      expect(activeNetworks[regularNetwork.chainId]?.isAlwaysEnabled).toBe(
+        false,
+      );
+    });
+
+    it('lets the API isAlwaysEnabled:false override the hardcoded floor', async () => {
+      const networkService = new NetworkService(
+        storageServiceMock,
+        featureFlagsServiceMock,
+        glacierServiceMock,
+      );
+      jest.spyOn(networkService, 'isMainnet').mockReturnValue(true);
+
+      // ChainId 1 (Ethereum) is part of NETWORKS_ENABLED_FOREVER, but the API
+      // explicitly opts it out.
+      const overriddenFloorNetwork = mockNetwork(NetworkVMType.EVM, false, {
+        chainId: 1,
+        isAlwaysEnabled: false,
+      });
+
+      networkService['_allNetworks'].dispatch({
+        [overriddenFloorNetwork.chainId]: overriddenFloorNetwork,
+      });
+
+      const activeNetworks = await networkService.activeNetworks.promisify();
+
+      expect(
+        activeNetworks[overriddenFloorNetwork.chainId]?.isAlwaysEnabled,
+      ).toBe(false);
     });
   });
 

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -176,6 +176,7 @@ export class NetworkService implements OnLock, OnStorageReady {
       .map(this.#filterBasedOnFeatureFlags)
       .map(this.#applyOverrides)
       .map(this.#applyChainAgnosticIds)
+      .map(this.#applyEnablementFlags)
       .readOnly();
   }
 
@@ -320,6 +321,10 @@ export class NetworkService implements OnLock, OnStorageReady {
   }
 
   async disableNetwork(chainId: number) {
+    if (this.#alwaysEnabledNetworks.includes(chainId)) {
+      return this._enabledNetworks;
+    }
+
     this.networkAvailability = {
       ...this._networkAvailability,
       [chainId]: {
@@ -950,6 +955,28 @@ export class NetworkService implements OnLock, OnStorageReady {
       Object.entries(chainList ?? {}).map(([chainId, network]) => [
         chainId,
         decorateWithCaipId(network),
+      ]),
+    );
+  };
+
+  #applyEnablementFlags = async (
+    chainListPromise: Promise<ChainListWithCaipIds>,
+  ): Promise<ChainListWithCaipIds> => {
+    const chainList = await chainListPromise;
+
+    if (!chainList) {
+      return chainList;
+    }
+
+    const alwaysEnabledIds = new Set(getAlwaysEnabledNetworkIds(chainList));
+
+    return Object.fromEntries(
+      Object.entries(chainList).map(([chainId, network]) => [
+        chainId,
+        {
+          ...network,
+          isAlwaysEnabled: alwaysEnabledIds.has(network.chainId),
+        },
       ]),
     );
   };

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -48,6 +48,8 @@ import {
   getSyncDomain,
   getExponentialBackoffDelay,
   getProviderForNetwork,
+  getAlwaysEnabledNetworkIds,
+  getDefaultEnabledNetworkIds,
   isSyncDomain,
 } from '@core/common';
 import { isSolanaNetwork, isHyperliquidNetwork } from '@core/common';
@@ -68,6 +70,11 @@ export class NetworkService implements OnLock, OnStorageReady {
 
   // Complete list of enabled networks ID
   private _enabledNetworks: number[] = [...NETWORKS_ENABLED_FOREVER];
+  // Networks that cannot be disabled by the user. Used synchronously by the
+  // enabled-networks setter, so it is cached rather than derived on demand.
+  // Derived from the chainlist (API `isAlwaysEnabled` flag) with the hardcoded
+  // list as a floor.
+  #alwaysEnabledNetworks: number[] = [...NETWORKS_ENABLED_FOREVER];
   // Network data that is stored in storage
   private _networkAvailability: Record<number, { isEnabled: boolean }> = {};
 
@@ -150,6 +157,11 @@ export class NetworkService implements OnLock, OnStorageReady {
     private glacierService: GlacierService,
   ) {
     this._initChainList();
+
+    // Keep the always/default enabled sets in sync with the chainlist, so the
+    // API `isAlwaysEnabled`/`isEnabledByDefault` flags are honored as soon as
+    // the chainlist is available (and before storage-driven availability is applied).
+    this._allNetworks.add(this.#updateEnablementFromChainList);
 
     this.allNetworks = this._allNetworks
       .cache(new ValueCache<ChainList>())
@@ -257,7 +269,7 @@ export class NetworkService implements OnLock, OnStorageReady {
 
   private set enabledNetworks(networkIds: number[]) {
     const uniqueNetworkIds = [
-      ...new Set([...NETWORKS_ENABLED_FOREVER, ...networkIds]),
+      ...new Set([...this.#alwaysEnabledNetworks, ...networkIds]),
     ];
 
     this._enabledNetworks = uniqueNetworkIds;
@@ -276,6 +288,15 @@ export class NetworkService implements OnLock, OnStorageReady {
     return this.#filterByEnvironment(this._enabledNetworks);
   }
 
+  /**
+   * Networks that should be enabled by default on onboarding. Derived from the
+   * chainlist (API `isEnabledByDefault` flag) with the hardcoded list as a floor.
+   */
+  async getNetworksEnabledByDefault(): Promise<number[]> {
+    const chainList = await this.allNetworks.promisify();
+    return getDefaultEnabledNetworkIds(chainList);
+  }
+
   public get customNetworks() {
     return this._customNetworks;
   }
@@ -283,7 +304,7 @@ export class NetworkService implements OnLock, OnStorageReady {
   async enableNetwork(chainId: number) {
     if (
       this._enabledNetworks.includes(chainId) ||
-      NETWORKS_ENABLED_FOREVER.includes(chainId)
+      this.#alwaysEnabledNetworks.includes(chainId)
     ) {
       return this._enabledNetworks;
     }
@@ -313,6 +334,7 @@ export class NetworkService implements OnLock, OnStorageReady {
     this.uiActiveNetwork = undefined;
     this._customNetworks = {};
     this._enabledNetworks = [];
+    this.#alwaysEnabledNetworks = [...NETWORKS_ENABLED_FOREVER];
     this._networkAvailability = {};
     this.#dappScopes = {};
     this.#avalancheDevnetMode = DEFAULT_AVALANCHE_DEVNET_MODE;
@@ -813,7 +835,7 @@ export class NetworkService implements OnLock, OnStorageReady {
       .filter(
         (chainId) =>
           this._networkAvailability[chainId] === undefined &&
-          !NETWORKS_ENABLED_FOREVER.includes(Number(chainId)),
+          !this.#alwaysEnabledNetworks.includes(Number(chainId)),
       )
       .map(Number);
     unknownChains.forEach((chainId) => {
@@ -930,6 +952,14 @@ export class NetworkService implements OnLock, OnStorageReady {
         decorateWithCaipId(network),
       ]),
     );
+  };
+
+  #updateEnablementFromChainList = (chainList?: ChainList) => {
+    if (!chainList) {
+      return;
+    }
+
+    this.#alwaysEnabledNetworks = getAlwaysEnabledNetworkIds(chainList);
   };
 
   #convertNetworkAvailabilityToEnabledNetworks = (

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -72,8 +72,8 @@ export class NetworkService implements OnLock, OnStorageReady {
   private _enabledNetworks: number[] = [...NETWORKS_ENABLED_FOREVER];
   // Networks that cannot be disabled by the user. Used synchronously by the
   // enabled-networks setter, so it is cached rather than derived on demand.
-  // Derived from the chainlist (API `isAlwaysEnabled` flag) with the hardcoded
-  // list as a floor.
+  // Derived from the feature-flag-filtered chainlist (API `isAlwaysEnabled`
+  // is additive) with `NETWORKS_ENABLED_FOREVER` as a floor.
   #alwaysEnabledNetworks: number[] = [...NETWORKS_ENABLED_FOREVER];
   // Network data that is stored in storage
   private _networkAvailability: Record<number, { isEnabled: boolean }> = {};
@@ -274,7 +274,7 @@ export class NetworkService implements OnLock, OnStorageReady {
     ];
 
     this._enabledNetworks = uniqueNetworkIds;
-    this.enabledNetworksUpdated.dispatch(networkIds);
+    this.enabledNetworksUpdated.dispatch(uniqueNetworkIds);
   }
 
   private set networkAvailability(
@@ -289,13 +289,15 @@ export class NetworkService implements OnLock, OnStorageReady {
     return this.#filterByEnvironment(this._enabledNetworks);
   }
 
-  /**
-   * Networks that should be enabled by default on onboarding. Derived from the
-   * chainlist (API `isEnabledByDefault` flag) with the hardcoded list as a floor.
-   */
   async getNetworksEnabledByDefault(): Promise<number[]> {
     const chainList = await this.allNetworks.promisify();
-    return getDefaultEnabledNetworkIds(chainList);
+    // Feature-gated ids are excluded so onboarding cannot persist them as already-on.
+    return getDefaultEnabledNetworkIds(
+      this.#filterBasedOnFeatureFlags(chainList),
+    ).filter((id) => {
+      const network = chainList[id];
+      return !network || this.isNetworkEnabledByFeatureFlags(network);
+    });
   }
 
   public get customNetworks() {
@@ -968,7 +970,7 @@ export class NetworkService implements OnLock, OnStorageReady {
       return chainList;
     }
 
-    const alwaysEnabledIds = new Set(getAlwaysEnabledNetworkIds(chainList));
+    const alwaysEnabledIds = new Set(this.#alwaysEnabledNetworks);
 
     return Object.fromEntries(
       Object.entries(chainList).map(([chainId, network]) => [
@@ -986,7 +988,14 @@ export class NetworkService implements OnLock, OnStorageReady {
       return;
     }
 
-    this.#alwaysEnabledNetworks = getAlwaysEnabledNetworkIds(chainList);
+    this.#alwaysEnabledNetworks = getAlwaysEnabledNetworkIds(
+      this.#filterBasedOnFeatureFlags(chainList),
+    );
+    // Re-run the setter so a chainlist that arrives after init() still unions
+    // newly always-enabled ids into `_enabledNetworks`.
+    this.enabledNetworks = this.#convertNetworkAvailabilityToEnabledNetworks(
+      this._networkAvailability,
+    );
   };
 
   #convertNetworkAvailabilityToEnabledNetworks = (

--- a/packages/service-worker/src/services/onboarding/finalizeOnboarding.test.ts
+++ b/packages/service-worker/src/services/onboarding/finalizeOnboarding.test.ts
@@ -40,6 +40,7 @@ describe('src/background/services/onboarding/finalizeOnboarding.test.ts', () => 
     setNetwork: jest.fn(),
     enableNetwork: jest.fn(),
     getAvalancheNetwork: jest.fn(),
+    getNetworksEnabledByDefault: jest.fn(),
   } as unknown as NetworkService;
 
   const accountMock = {
@@ -60,6 +61,9 @@ describe('src/background/services/onboarding/finalizeOnboarding.test.ts', () => 
     jest
       .mocked(networkServiceMock.getAvalancheNetwork)
       .mockResolvedValue({ chainId: 43114 } as any);
+    jest
+      .mocked(networkServiceMock.getNetworksEnabledByDefault)
+      .mockResolvedValue([...NETWORKS_ENABLED_BY_DEFAULT]);
   });
   it('sets up an mnemonic wallet correctly', async () => {
     await finalizeOnboarding({

--- a/packages/service-worker/src/services/onboarding/finalizeOnboarding.ts
+++ b/packages/service-worker/src/services/onboarding/finalizeOnboarding.ts
@@ -1,4 +1,3 @@
-import { NETWORKS_ENABLED_BY_DEFAULT } from '@core/types';
 import { NetworkService } from '../network/NetworkService';
 import { AccountsService } from '../accounts/AccountsService';
 import { OnboardingService } from './OnboardingService';
@@ -22,7 +21,9 @@ export async function finalizeOnboarding({
   lockService,
   password,
 }: FinalizeOnboardingParams) {
-  for (const chainId of NETWORKS_ENABLED_BY_DEFAULT) {
+  const networksEnabledByDefault =
+    await networkService.getNetworksEnabledByDefault();
+  for (const chainId of networksEnabledByDefault) {
     await networkService.enableNetwork(chainId);
   }
 

--- a/packages/service-worker/src/services/onboarding/handlers/keystoneOnboardingHandler.test.ts
+++ b/packages/service-worker/src/services/onboarding/handlers/keystoneOnboardingHandler.test.ts
@@ -68,6 +68,7 @@ describe('src/background/services/onboarding/handlers/keystoneOnboardingHandler.
   const networkServiceMock = {
     enableNetwork: jest.fn(),
     getAvalancheNetwork: jest.fn(),
+    getNetworksEnabledByDefault: jest.fn(),
     setNetwork: jest.fn(),
   } as unknown as NetworkService;
 
@@ -108,6 +109,9 @@ describe('src/background/services/onboarding/handlers/keystoneOnboardingHandler.
     jest
       .mocked(networkServiceMock.getAvalancheNetwork)
       .mockResolvedValue({ chainId: 43114 } as any);
+    jest
+      .mocked(networkServiceMock.getNetworksEnabledByDefault)
+      .mockResolvedValue([]);
   });
 
   it('sets up a keystone wallet with xpub correctly', async () => {

--- a/packages/service-worker/src/services/onboarding/handlers/ledgerOnboardingHandler.test.ts
+++ b/packages/service-worker/src/services/onboarding/handlers/ledgerOnboardingHandler.test.ts
@@ -70,6 +70,7 @@ describe('src/background/services/onboarding/handlers/ledgerOnboardingHandler.ts
   const networkServiceMock = {
     enableNetwork: jest.fn(),
     getAvalancheNetwork: jest.fn(),
+    getNetworksEnabledByDefault: jest.fn(),
     setNetwork: jest.fn(),
   } as unknown as NetworkService;
 
@@ -110,6 +111,9 @@ describe('src/background/services/onboarding/handlers/ledgerOnboardingHandler.ts
     jest
       .mocked(networkServiceMock.getAvalancheNetwork)
       .mockResolvedValue({ chainId: 43114 } as any);
+    jest
+      .mocked(networkServiceMock.getNetworksEnabledByDefault)
+      .mockResolvedValue([]);
   });
   it('sets up a ledger wallet with xpub correctly', async () => {
     const handler = getHandler();

--- a/packages/service-worker/src/services/onboarding/handlers/mnemonicOnboardingHandler.test.ts
+++ b/packages/service-worker/src/services/onboarding/handlers/mnemonicOnboardingHandler.test.ts
@@ -68,6 +68,7 @@ describe('src/background/services/onboarding/handlers/mnemonicOnboardingHandler.
   const networkServiceMock = {
     enableNetwork: jest.fn(),
     getAvalancheNetwork: jest.fn(),
+    getNetworksEnabledByDefault: jest.fn(),
     setNetwork: jest.fn(),
   } as unknown as NetworkService;
 
@@ -108,6 +109,9 @@ describe('src/background/services/onboarding/handlers/mnemonicOnboardingHandler.
     jest
       .mocked(networkServiceMock.getAvalancheNetwork)
       .mockResolvedValue({ chainId: 43114 } as any);
+    jest
+      .mocked(networkServiceMock.getNetworksEnabledByDefault)
+      .mockResolvedValue([]);
   });
 
   it('is not case sensitive', async () => {

--- a/packages/service-worker/src/services/onboarding/handlers/seedlessOnboardingHandler.test.ts
+++ b/packages/service-worker/src/services/onboarding/handlers/seedlessOnboardingHandler.test.ts
@@ -75,6 +75,7 @@ describe('src/background/services/onboarding/handlers/seedlessOnboardingHandler.
   const networkServiceMock = {
     enableNetwork: jest.fn(),
     getAvalancheNetwork: jest.fn(),
+    getNetworksEnabledByDefault: jest.fn(),
     setNetwork: jest.fn(),
   } as unknown as NetworkService;
   const secretsServiceMock = {
@@ -119,6 +120,9 @@ describe('src/background/services/onboarding/handlers/seedlessOnboardingHandler.
     jest
       .mocked(networkServiceMock.getAvalancheNetwork)
       .mockResolvedValue({ chainId: 43114 } as any);
+    jest
+      .mocked(networkServiceMock.getNetworksEnabledByDefault)
+      .mockResolvedValue([]);
   });
 
   it('sets up seedless wallets correctly', async () => {

--- a/packages/types/src/network.ts
+++ b/packages/types/src/network.ts
@@ -73,6 +73,8 @@ export type Network = _Network &
   AdvancedNetworkConfig & {
     isDevnet?: boolean;
     caipId?: string;
+    isAlwaysEnabled?: boolean;
+    isEnabledByDefault?: boolean;
   };
 
 export type NetworkWithCaipId = EnsureDefined<Network, 'caipId'>;

--- a/packages/ui/src/contexts/NetworkProvider/networkSortingFn.test.ts
+++ b/packages/ui/src/contexts/NetworkProvider/networkSortingFn.test.ts
@@ -152,6 +152,42 @@ describe('contexts/NetworkProvider/networkSortingFn', () => {
       });
     });
 
+    describe('when comparing API-flagged always-enabled networks', () => {
+      it('should prioritize a network flagged isAlwaysEnabled over a non-promoted network', () => {
+        const apiFlagged = { chainId: 99999, isAlwaysEnabled: true } as Network;
+        const other = createMockNetwork(12345);
+
+        const testArray = [other, apiFlagged];
+        testArray.sort(promoteNetworks);
+
+        expect(testArray).toEqual([apiFlagged, other]);
+      });
+
+      it('should keep hardcoded floor order ahead of API-flagged extras', () => {
+        const cChain = createMockNetwork(ChainId.AVALANCHE_MAINNET_ID);
+        const apiFlagged = { chainId: 99999, isAlwaysEnabled: true } as Network;
+        const other = createMockNetwork(12345);
+
+        const testArray = [other, apiFlagged, cChain];
+        testArray.sort(promoteNetworks);
+
+        expect(testArray).toEqual([cChain, apiFlagged, other]);
+      });
+
+      it('should still promote a floor network when isAlwaysEnabled is false', () => {
+        const cChain = {
+          chainId: ChainId.AVALANCHE_MAINNET_ID,
+          isAlwaysEnabled: false,
+        } as Network;
+        const other = createMockNetwork(12345);
+
+        const testArray = [other, cChain];
+        testArray.sort(promoteNetworks);
+
+        expect(testArray).toEqual([cChain, other]);
+      });
+    });
+
     describe('when neither network is promoted', () => {
       it('should maintain order for non-promoted networks', () => {
         const network1 = createMockNetwork(12345);

--- a/packages/ui/src/contexts/NetworkProvider/networkSortingFn.ts
+++ b/packages/ui/src/contexts/NetworkProvider/networkSortingFn.ts
@@ -4,17 +4,24 @@ function getChainId(network: Network | Network['chainId']) {
   return typeof network === 'number' ? network : network.chainId;
 }
 
-function getPriority(chainId: number) {
-  const index = NETWORKS_ENABLED_FOREVER.indexOf(chainId);
-  return index;
+function getPriority(network: Network | Network['chainId']) {
+  const chainId = getChainId(network);
+  const hardcodedIndex = NETWORKS_ENABLED_FOREVER.indexOf(chainId);
+  if (hardcodedIndex !== -1) {
+    return hardcodedIndex;
+  }
+  if (typeof network !== 'number' && network.isAlwaysEnabled) {
+    return NETWORKS_ENABLED_FOREVER.length;
+  }
+  return -1;
 }
 
 export function promoteNetworks<T extends Network | Network['chainId']>(
   one: T,
   another: T,
 ) {
-  const onePriority = getPriority(getChainId(one));
-  const anotherPriority = getPriority(getChainId(another));
+  const onePriority = getPriority(one);
+  const anotherPriority = getPriority(another);
 
   if (onePriority === -1 && anotherPriority === -1) {
     return 0;


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-14920
Figma: n/a

## Notes
* Makes use of the `isAlwaysEnabled` and `isEnabledByDefault` flags returned by the new `/tokenlist` endpoint.
* Still leaves the hardcoded list of always-enabled chains, but when API response comes in, it will take the priority.

## Testing
* Make sure the networks returned as `isAlwaysEnabled` from `/tokenlist` are in fact enabled (and disabling them is not possible)
* Make sure the networks returned as `IsEnabledByDefault` from `/tokenlist` are in fact enabled (but the users can still disable them and their choice takes priority)
* Make sure the networks enabled-state retains its functionality.
