### PR TITLE
fix: pin crypto-js to 4.2.0 to close CVE-2023-46233 (CP-14930)

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "@avalabs/hypercore-module": "4.0.1",
     "@solana/kit": "5.4.0",
     "cipher-base": "1.0.5",
+    "crypto-js": "4.2.0",
     "elliptic": "6.6.1",
     "form-data@npm:^4.0.0": "4.0.5",
     "form-data@npm:^4.0.4": "4.0.5",


### PR DESCRIPTION
# Summary

Jira ticket: [CP-14930](https://ava-labs.atlassian.net/browse/CP-14930)
Figma:

Adds `crypto-js: 4.2.0` to the root `resolutions` so no copy of the affected 4.1.x can enter the lockfile.

To be clear about what this does and does not do: core-extension already resolves crypto-js to 4.2.0, so this is **not** fixing a live vulnerability here. It is a forward guard. Versions before 4.2.0 are affected by CVE-2023-46233, where PBKDF2 defaults to 1 iteration and SHA-1, making any password derived key cheap to brute force.

The guard is worth having because several `@avalabs/*` packages still pin `crypto-js: 4.1.1` exactly. `@avalabs/hw-app-avalanche` is one of them, and it is already in this repo's `resolutions` at 1.1.1, so it is very much in the dependency path. Without this entry, a bump elsewhere could quietly pull the vulnerable version back in. That is not hypothetical: in avalanche-wallet, bumping the direct dependency alone left 4.1.1 in the tree, and only a `resolutions` entry forced those transitive exact-pins up.

## Notes

`yarn.lock` is deliberately untouched, and that is the point worth checking in review. crypto-js already resolved to a single `crypto-js@npm:4.2.0` entry, so adding the resolution produces no lockfile change at all. The installed dependency tree is byte identical before and after. The diff is one line.

This is part of a set applying the same pin across the wallet repos. core-mobile was the only one carrying an actual vulnerable copy, 4.1.1 nested under `redux-persist-transform-encrypt`, along with avalanche-wallet. The rest, including this repo, take the pin purely as a guard.

Worth flagging separately: npm marks crypto-js 4.2.0 itself as deprecated, since active development has been discontinued. 4.2.0 is the terminal release, so this closes the CVE but the library stays unmaintained. Migrating off it would be the durable fix and deserves its own ticket.

Companion PRs: ava-labs/core-mobile#4032, ava-labs/core-web (branch `boyer/crypto-js-4.2.0-cve-2023-46233`).

Disclosure: this PR was prepared by an agent, model `claude-opus-5[1m]`, and reviewed before submission.

## Testing

No wallet setup, local storage overrides, or extension reload steps are needed. This only touches dependency resolution, so the meaningful check is that resolution is unchanged.

Full unit suite on this branch: 216 suites, 1785 tests, all passing, with no failing workspace.

## Testing Instructions

1. `yarn install` and confirm `yarn.lock` comes back with no diff
2. Confirm a single crypto-js entry at 4.2.0: `grep '"crypto-js@' yarn.lock`
3. `yarn test` to confirm the suite is still green

## Media

Not applicable. There are no user facing or UI changes.


[CP-14930]: https://ava-labs.atlassian.net/browse/CP-14930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ