### PR TITLE
Added 3rd party wallet domain wallet.avax.to to WHITELISTED_DOMAINS

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -37,6 +37,10 @@ const KNOWN_AVACLOUD_DOMAINS = [
 
 const PLAYGROUND_APP = 'ava-labs.github.io' as const;
 
+export const THIRD_PARTY_WALLET_DOMAINS = [
+  "wallet.avax.to"
+] as const;
+
 export const KNOWN_CORE_DOMAINS = [
   CORE_WEB_DOMAIN,
   PLAYGROUND_APP,
@@ -49,6 +53,7 @@ export const WHITELISTED_DOMAINS = [
   ...KNOWN_CORE_DOMAINS,
   ...KNOWN_AVACLOUD_DOMAINS,
   ...DAPP_DEV_DOMAINS,
+  ...THIRD_PARTY_WALLET_DOMAINS,
 ];
 
 export const SYNCED_DOMAINS = isProductionBuild()


### PR DESCRIPTION
# Summary

Added wallet.avax.to to WHITELISTED_DOMAINS so AVXTO Wallet can access Core Extension's avalanche_* methods 

## Notes

Extensive AVXTO Wallet functionality works locally on the dev environment, but breaks when deployed to wallet.avax.to

