### PR TITLE
refactor: migrate away from /tokenlist [part 3]

### DIFF
--- a/packages/common/src/monitoring/sentryCaptureException.ts
+++ b/packages/common/src/monitoring/sentryCaptureException.ts
@@ -45,10 +45,15 @@ export enum SentryExceptionTypes {
   NOTIFICATIONS = 'notifications',
 
   ACCOUNTS = 'accounts',
+
+  NETWORKS = 'networks',
 }
 
 // wrapper to make error reporting contexts unfirom accross the codebase
-const sentryCaptureException = (error: Error, type: SentryExceptionTypes) =>
-  Sentry.captureException(error, { tags: { type } });
+const sentryCaptureException = (
+  error: Error,
+  type: SentryExceptionTypes,
+  extras?: Record<string, unknown>,
+) => Sentry.captureException(error, { tags: { type }, extra: extras });
 
 export default sentryCaptureException;

--- a/packages/common/src/monitoring/sentryCaptureException.ts
+++ b/packages/common/src/monitoring/sentryCaptureException.ts
@@ -45,15 +45,10 @@ export enum SentryExceptionTypes {
   NOTIFICATIONS = 'notifications',
 
   ACCOUNTS = 'accounts',
-
-  NETWORKS = 'networks',
 }
 
 // wrapper to make error reporting contexts unfirom accross the codebase
-const sentryCaptureException = (
-  error: Error,
-  type: SentryExceptionTypes,
-  extras?: Record<string, unknown>,
-) => Sentry.captureException(error, { tags: { type }, extra: extras });
+const sentryCaptureException = (error: Error, type: SentryExceptionTypes) =>
+  Sentry.captureException(error, { tags: { type } });
 
 export default sentryCaptureException;

--- a/packages/service-worker/lavamoat/rspack/policy.json
+++ b/packages/service-worker/lavamoat/rspack/policy.json
@@ -78,11 +78,6 @@
         "@avalabs/bridge-unified>zod": true
       }
     },
-    "@avalabs/core-chains-sdk": {
-      "packages": {
-        "@avalabs/core-utils-sdk": true
-      }
-    },
     "@avalabs/core-coingecko-sdk": {
       "globals": {
         "URLSearchParams": true

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -955,6 +955,24 @@ describe('background/services/network/NetworkService', () => {
       );
     });
 
+    it('reports a clear reason when /v2/networks succeeds but returns no usable networks', async () => {
+      jest.mocked(getV2Networks).mockResolvedValue(v2Response({}));
+      jest.mocked(getChainsAndTokens).mockResolvedValue({
+        1: { chainId: 1, chainName: 'Legacy' } as any,
+      });
+
+      await freshService()['_initChainList']();
+
+      expect(Monitoring.sentryCaptureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        Monitoring.SentryExceptionTypes.NETWORKS,
+        expect.objectContaining({
+          attempt: 1,
+          reason: '/v2/networks returned no usable networks',
+        }),
+      );
+    });
+
     it('reports a distinct message so a transport outage is not dropped by ignoreErrors', async () => {
       jest
         .mocked(getV2Networks)

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -5,7 +5,10 @@ import {
 } from '@avalabs/core-chains-sdk';
 import { FetchRequest } from 'ethers';
 import { Signal } from 'micro-signals';
+import { container } from 'tsyringe';
 
+import { getV2Networks } from '~/api-clients/token-aggregator';
+import { AppCheckService } from '../appcheck/AppCheckService';
 import { StorageService } from '../storage/StorageService';
 import { NetworkService } from './NetworkService';
 import {
@@ -18,7 +21,7 @@ import {
 } from '@core/types';
 import { FeatureFlagService } from '../featureFlags/FeatureFlagService';
 import { runtime } from 'webextension-polyfill';
-import { decorateWithCaipId } from '@core/common';
+import { decorateWithCaipId, Monitoring } from '@core/common';
 import { GlacierService } from '../glacier/GlacierService';
 
 jest.mock('@avalabs/core-wallets-sdk', () => {
@@ -51,6 +54,21 @@ jest.mock('@avalabs/core-chains-sdk', () => ({
   ...jest.requireActual('@avalabs/core-chains-sdk'),
   getChainsAndTokens: jest.fn(),
 }));
+
+jest.mock('~/api-clients/token-aggregator', () => ({
+  getV2Networks: jest.fn(),
+}));
+
+jest.mock('@core/common', () => {
+  const actual = jest.requireActual('@core/common');
+  return {
+    ...actual,
+    Monitoring: {
+      ...actual.Monitoring,
+      sentryCaptureException: jest.fn(),
+    },
+  };
+});
 
 const mockNetwork = (
   vmName: NetworkVMType,
@@ -154,6 +172,11 @@ describe('background/services/network/NetworkService', () => {
     jest.resetAllMocks();
 
     jest.mocked(getChainsAndTokens).mockResolvedValue({});
+    // Default to the legacy tokenlist path; individual tests opt into /v2/networks.
+    jest.mocked(getV2Networks).mockRejectedValue(new Error('no v2'));
+    container.registerInstance(AppCheckService, {
+      getAppcheckToken: jest.fn().mockResolvedValue({ token: 'appcheck' }),
+    } as unknown as AppCheckService);
 
     jest.mocked(FetchRequest).mockImplementation((url) => ({ url }) as any);
     mockChainList(service);
@@ -817,6 +840,129 @@ describe('background/services/network/NetworkService', () => {
           rpcUrl: '',
         }),
       );
+    });
+  });
+
+  describe('/v2/networks startup migration', () => {
+    const v2ApiNetwork = (overrides = {}) => ({
+      chainId: 99991,
+      chainName: 'V2 Net',
+      caip2Id: 'eip155:99991',
+      description: null,
+      explorerUrl: 'https://explorer.example',
+      isTestnet: false,
+      isAlwaysEnabled: false,
+      isEnabledByDefault: false,
+      logoUri: '',
+      networkToken: {
+        name: 'V2 Token',
+        symbol: 'V2',
+        decimals: 18,
+        internalId: 'native-v2',
+      },
+      pricingProviders: null,
+      primaryColor: '#000000',
+      rpcUrl: 'https://rpc.example',
+      wsUrl: null,
+      subnetExplorerUriId: 'v2',
+      vmName: 'EVM',
+      ...overrides,
+    });
+
+    const v2Response = (networks: Record<string, unknown>) =>
+      ({ data: { data: networks } }) as any;
+
+    const freshService = () =>
+      new NetworkService(
+        storageServiceMock,
+        featureFlagsServiceMock,
+        glacierServiceMock,
+      );
+
+    it('loads networks from /v2/networks and skips the legacy tokenlist', async () => {
+      jest
+        .mocked(getV2Networks)
+        .mockResolvedValue(v2Response({ 'eip155:99991': v2ApiNetwork() }));
+
+      const fetched = await freshService()['_initChainList']();
+
+      expect(getChainsAndTokens).not.toHaveBeenCalled();
+      expect(fetched[99991]).toEqual(
+        expect.objectContaining({ chainId: 99991, chainName: 'V2 Net' }),
+      );
+      // Local networks are still injected on top of the /v2/networks result.
+      expect(fetched[999]).toEqual(
+        expect.objectContaining({ chainName: 'HyperEVM' }),
+      );
+    });
+
+    it('preserves the API enablement flags from /v2/networks', async () => {
+      jest.mocked(getV2Networks).mockResolvedValue(
+        v2Response({
+          'eip155:99991': v2ApiNetwork({
+            isAlwaysEnabled: true,
+            isEnabledByDefault: false,
+          }),
+        }),
+      );
+
+      const fetched = await freshService()['_initChainList']();
+
+      expect(fetched[99991]?.isAlwaysEnabled).toBe(true);
+      expect(fetched[99991]?.isEnabledByDefault).toBe(false);
+    });
+
+    it('falls back to the legacy tokenlist when /v2/networks returns no networks', async () => {
+      jest.mocked(getV2Networks).mockResolvedValue(v2Response({}));
+      jest.mocked(getChainsAndTokens).mockResolvedValue({
+        1: { chainId: 1, chainName: 'Legacy' } as any,
+      });
+
+      const fetched = await freshService()['_initChainList']();
+
+      expect(getChainsAndTokens).toHaveBeenCalled();
+      expect(fetched[1]).toEqual(
+        expect.objectContaining({ chainName: 'Legacy' }),
+      );
+    });
+
+    it('falls back to the legacy tokenlist when /v2/networks fails', async () => {
+      jest.mocked(getV2Networks).mockRejectedValue(new Error('v2 down'));
+      jest.mocked(getChainsAndTokens).mockResolvedValue({
+        1: { chainId: 1, chainName: 'Legacy' } as any,
+      });
+
+      const fetched = await freshService()['_initChainList']();
+
+      expect(getChainsAndTokens).toHaveBeenCalled();
+      expect(fetched[1]).toEqual(
+        expect.objectContaining({ chainName: 'Legacy' }),
+      );
+    });
+
+    it('reports the fallback to Sentry so it can be monitored', async () => {
+      jest.mocked(getV2Networks).mockRejectedValue(new Error('v2 down'));
+      jest.mocked(getChainsAndTokens).mockResolvedValue({
+        1: { chainId: 1, chainName: 'Legacy' } as any,
+      });
+
+      await freshService()['_initChainList']();
+
+      expect(Monitoring.sentryCaptureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        Monitoring.SentryExceptionTypes.NETWORKS,
+        { attempt: 1 },
+      );
+    });
+
+    it('does not report to Sentry when /v2/networks succeeds', async () => {
+      jest
+        .mocked(getV2Networks)
+        .mockResolvedValue(v2Response({ 'eip155:99991': v2ApiNetwork() }));
+
+      await freshService()['_initChainList']();
+
+      expect(Monitoring.sentryCaptureException).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -951,8 +951,25 @@ describe('background/services/network/NetworkService', () => {
       expect(Monitoring.sentryCaptureException).toHaveBeenCalledWith(
         expect.any(Error),
         Monitoring.SentryExceptionTypes.NETWORKS,
-        { attempt: 1 },
+        expect.objectContaining({ attempt: 1, reason: 'v2 down' }),
       );
+    });
+
+    it('reports a distinct message so a transport outage is not dropped by ignoreErrors', async () => {
+      jest
+        .mocked(getV2Networks)
+        .mockRejectedValue(new TypeError('Failed to fetch'));
+      jest.mocked(getChainsAndTokens).mockResolvedValue({
+        1: { chainId: 1, chainName: 'Legacy' } as any,
+      });
+
+      await freshService()['_initChainList']();
+
+      const [capturedError] = jest.mocked(Monitoring.sentryCaptureException)
+        .mock.calls[0]!;
+      // The captured message must not be "Failed to fetch" (which Sentry drops).
+      expect((capturedError as Error).message).not.toMatch(/Failed to fetch$/);
+      expect((capturedError as Error).message).toContain('/tokenlist');
     });
 
     it('does not report to Sentry when /v2/networks succeeds', async () => {

--- a/packages/service-worker/src/services/network/NetworkService.test.ts
+++ b/packages/service-worker/src/services/network/NetworkService.test.ts
@@ -1,8 +1,4 @@
-import {
-  ChainId,
-  getChainsAndTokens,
-  NetworkVMType,
-} from '@avalabs/core-chains-sdk';
+import { ChainId, NetworkVMType } from '@avalabs/core-chains-sdk';
 import { FetchRequest } from 'ethers';
 import { Signal } from 'micro-signals';
 import { container } from 'tsyringe';
@@ -21,7 +17,7 @@ import {
 } from '@core/types';
 import { FeatureFlagService } from '../featureFlags/FeatureFlagService';
 import { runtime } from 'webextension-polyfill';
-import { decorateWithCaipId, Monitoring } from '@core/common';
+import { decorateWithCaipId } from '@core/common';
 import { GlacierService } from '../glacier/GlacierService';
 
 jest.mock('@avalabs/core-wallets-sdk', () => {
@@ -48,11 +44,6 @@ jest.mock('@avalabs/core-wallets-sdk', () => {
 jest.mock('ethers', () => ({
   ...jest.requireActual('ethers'),
   FetchRequest: jest.fn(),
-}));
-
-jest.mock('@avalabs/core-chains-sdk', () => ({
-  ...jest.requireActual('@avalabs/core-chains-sdk'),
-  getChainsAndTokens: jest.fn(),
 }));
 
 jest.mock('~/api-clients/token-aggregator', () => ({
@@ -138,6 +129,36 @@ describe('background/services/network/NetworkService', () => {
     chainId: 11155111,
   });
 
+  const defaultV2Response = {
+    data: {
+      data: {
+        'eip155:1': {
+          chainId: 1,
+          chainName: 'Default Net',
+          caip2Id: 'eip155:1',
+          description: null,
+          explorerUrl: 'https://explorer.example',
+          isTestnet: false,
+          isAlwaysEnabled: false,
+          isEnabledByDefault: false,
+          logoUri: '',
+          networkToken: {
+            name: 'Ether',
+            symbol: 'ETH',
+            decimals: 18,
+            internalId: 'native-eth',
+          },
+          pricingProviders: null,
+          primaryColor: '#000000',
+          rpcUrl: 'https://rpc.example',
+          wsUrl: null,
+          subnetExplorerUriId: 'eth',
+          vmName: 'EVM',
+        },
+      },
+    },
+  } as any;
+
   const mockChainList = (instance: NetworkService) => {
     // eslint-disable-next-line
     // @ts-ignore
@@ -171,9 +192,7 @@ describe('background/services/network/NetworkService', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    jest.mocked(getChainsAndTokens).mockResolvedValue({});
-    // Default to the legacy tokenlist path; individual tests opt into /v2/networks.
-    jest.mocked(getV2Networks).mockRejectedValue(new Error('no v2'));
+    jest.mocked(getV2Networks).mockResolvedValue(defaultV2Response);
     container.registerInstance(AppCheckService, {
       getAppcheckToken: jest.fn().mockResolvedValue({ token: 'appcheck' }),
     } as unknown as AppCheckService);
@@ -785,9 +804,7 @@ describe('background/services/network/NetworkService', () => {
   describe('when chain list is not available through Glacier', () => {
     beforeEach(() => {
       jest.useFakeTimers();
-      jest
-        .mocked(getChainsAndTokens)
-        .mockRejectedValue(new Error('Unavailable'));
+      jest.mocked(getV2Networks).mockRejectedValue(new Error('Unavailable'));
     });
 
     it('falls back to the chainlist cached in storage when unlocked', async () => {
@@ -820,8 +837,6 @@ describe('background/services/network/NetworkService', () => {
 
   describe('Hyperliquid networks injection', () => {
     it('injects HyperEVM and HyperCore into the fetched chain list', async () => {
-      jest.mocked(getChainsAndTokens).mockResolvedValue({});
-
       const freshService = new NetworkService(
         storageServiceMock,
         featureFlagsServiceMock,
@@ -879,14 +894,13 @@ describe('background/services/network/NetworkService', () => {
         glacierServiceMock,
       );
 
-    it('loads networks from /v2/networks and skips the legacy tokenlist', async () => {
+    it('loads networks from /v2/networks', async () => {
       jest
         .mocked(getV2Networks)
         .mockResolvedValue(v2Response({ 'eip155:99991': v2ApiNetwork() }));
 
       const fetched = await freshService()['_initChainList']();
 
-      expect(getChainsAndTokens).not.toHaveBeenCalled();
       expect(fetched[99991]).toEqual(
         expect.objectContaining({ chainId: 99991, chainName: 'V2 Net' }),
       );
@@ -910,94 +924,6 @@ describe('background/services/network/NetworkService', () => {
 
       expect(fetched[99991]?.isAlwaysEnabled).toBe(true);
       expect(fetched[99991]?.isEnabledByDefault).toBe(false);
-    });
-
-    it('falls back to the legacy tokenlist when /v2/networks returns no networks', async () => {
-      jest.mocked(getV2Networks).mockResolvedValue(v2Response({}));
-      jest.mocked(getChainsAndTokens).mockResolvedValue({
-        1: { chainId: 1, chainName: 'Legacy' } as any,
-      });
-
-      const fetched = await freshService()['_initChainList']();
-
-      expect(getChainsAndTokens).toHaveBeenCalled();
-      expect(fetched[1]).toEqual(
-        expect.objectContaining({ chainName: 'Legacy' }),
-      );
-    });
-
-    it('falls back to the legacy tokenlist when /v2/networks fails', async () => {
-      jest.mocked(getV2Networks).mockRejectedValue(new Error('v2 down'));
-      jest.mocked(getChainsAndTokens).mockResolvedValue({
-        1: { chainId: 1, chainName: 'Legacy' } as any,
-      });
-
-      const fetched = await freshService()['_initChainList']();
-
-      expect(getChainsAndTokens).toHaveBeenCalled();
-      expect(fetched[1]).toEqual(
-        expect.objectContaining({ chainName: 'Legacy' }),
-      );
-    });
-
-    it('reports the fallback to Sentry so it can be monitored', async () => {
-      jest.mocked(getV2Networks).mockRejectedValue(new Error('v2 down'));
-      jest.mocked(getChainsAndTokens).mockResolvedValue({
-        1: { chainId: 1, chainName: 'Legacy' } as any,
-      });
-
-      await freshService()['_initChainList']();
-
-      expect(Monitoring.sentryCaptureException).toHaveBeenCalledWith(
-        expect.any(Error),
-        Monitoring.SentryExceptionTypes.NETWORKS,
-        expect.objectContaining({ attempt: 1, reason: 'v2 down' }),
-      );
-    });
-
-    it('reports a clear reason when /v2/networks succeeds but returns no usable networks', async () => {
-      jest.mocked(getV2Networks).mockResolvedValue(v2Response({}));
-      jest.mocked(getChainsAndTokens).mockResolvedValue({
-        1: { chainId: 1, chainName: 'Legacy' } as any,
-      });
-
-      await freshService()['_initChainList']();
-
-      expect(Monitoring.sentryCaptureException).toHaveBeenCalledWith(
-        expect.any(Error),
-        Monitoring.SentryExceptionTypes.NETWORKS,
-        expect.objectContaining({
-          attempt: 1,
-          reason: '/v2/networks returned no usable networks',
-        }),
-      );
-    });
-
-    it('reports a distinct message so a transport outage is not dropped by ignoreErrors', async () => {
-      jest
-        .mocked(getV2Networks)
-        .mockRejectedValue(new TypeError('Failed to fetch'));
-      jest.mocked(getChainsAndTokens).mockResolvedValue({
-        1: { chainId: 1, chainName: 'Legacy' } as any,
-      });
-
-      await freshService()['_initChainList']();
-
-      const [capturedError] = jest.mocked(Monitoring.sentryCaptureException)
-        .mock.calls[0]!;
-      // The captured message must not be "Failed to fetch" (which Sentry drops).
-      expect((capturedError as Error).message).not.toMatch(/Failed to fetch$/);
-      expect((capturedError as Error).message).toContain('/tokenlist');
-    });
-
-    it('does not report to Sentry when /v2/networks succeeds', async () => {
-      jest
-        .mocked(getV2Networks)
-        .mockResolvedValue(v2Response({ 'eip155:99991': v2ApiNetwork() }));
-
-      await freshService()['_initChainList']();
-
-      expect(Monitoring.sentryCaptureException).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -540,14 +540,13 @@ export class NetworkService implements OnLock, OnStorageReady {
       return v2Networks;
     }
 
-    // Report every fall back to the legacy endpoint so we can monitor
-    // if (or how often) /v2/networks is unavailable before removing the legacy path.
     Monitoring.sentryCaptureException(
-      v2Error instanceof Error
-        ? v2Error
-        : new Error('Falling back to the legacy /tokenlist endpoint'),
+      new Error('NetworkService fell back to the legacy /tokenlist endpoint'),
       Monitoring.SentryExceptionTypes.NETWORKS,
-      { attempt },
+      {
+        attempt,
+        reason: v2Error instanceof Error ? v2Error.message : String(v2Error),
+      },
     );
 
     const [legacyChainList] = await resolve(

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -545,7 +545,11 @@ export class NetworkService implements OnLock, OnStorageReady {
       Monitoring.SentryExceptionTypes.NETWORKS,
       {
         attempt,
-        reason: v2Error instanceof Error ? v2Error.message : String(v2Error),
+        reason: v2Error
+          ? v2Error instanceof Error
+            ? v2Error.message
+            : String(v2Error)
+          : '/v2/networks returned no usable networks',
       },
     );
 

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -52,8 +52,15 @@ import {
   getDefaultEnabledNetworkIds,
   isSyncDomain,
 } from '@core/common';
-import { isSolanaNetwork, isHyperliquidNetwork } from '@core/common';
+import {
+  isSolanaNetwork,
+  isHyperliquidNetwork,
+  Monitoring,
+} from '@core/common';
 import { GlacierService } from '../glacier/GlacierService';
+import { getAuthHeaders } from '../appcheck/utils/getAuthHeaders';
+import { getV2Networks } from '~/api-clients/token-aggregator';
+import { mapV2NetworksToChainList } from './utils/mapV2Networks';
 import {
   BASE_NETWORK_CONFIG_BY_TYPE,
   getXPChainId,
@@ -507,27 +514,10 @@ export class NetworkService implements OnLock, OnStorageReady {
     let attempt = 1;
 
     do {
-      const [result] = await resolve(
-        getChainsAndTokens(
-          process.env.RELEASE === 'production',
-          `${process.env.PROXY_URL}/tokenlist?includeSolana`,
-        ),
-      );
+      const result = await this.#fetchChainList(attempt);
 
       if (result) {
-        chainlist = {
-          ...result,
-          [BITCOIN_NETWORK.chainId]: BITCOIN_NETWORK,
-          [BITCOIN_TEST_NETWORK.chainId]: BITCOIN_TEST_NETWORK,
-          [ChainId.AVALANCHE_P]: this._getPchainNetwork('mainnet'),
-          [ChainId.AVALANCHE_X]: this._getXchainNetwork('mainnet'),
-          [ChainId.AVALANCHE_TEST_P]: this._getPchainNetwork('testnet'),
-          [ChainId.AVALANCHE_TEST_X]: this._getXchainNetwork('testnet'),
-          [ChainId.AVALANCHE_DEVNET_P]: this._getPchainNetwork('devnet'),
-          [ChainId.AVALANCHE_DEVNET_X]: this._getXchainNetwork('devnet'),
-          [HYPEREVM_NETWORK.chainId]: HYPEREVM_NETWORK,
-          [HYPERCORE_NETWORK.chainId]: HYPERCORE_NETWORK,
-        };
+        chainlist = this.#injectLocalNetworks(result);
       } else {
         attempt += 1;
         await wait(getExponentialBackoffDelay({ attempt }));
@@ -541,6 +531,62 @@ export class NetworkService implements OnLock, OnStorageReady {
     this._allNetworks.dispatch(chainlist);
 
     return chainlist;
+  }
+
+  async #fetchChainList(attempt: number): Promise<ChainList | undefined> {
+    const [v2Networks, v2Error] = await resolve(this.#fetchNetworksFromApi());
+
+    if (v2Networks && Object.keys(v2Networks).length > 0) {
+      return v2Networks;
+    }
+
+    // Report every fall back to the legacy endpoint so we can monitor
+    // if (or how often) /v2/networks is unavailable before removing the legacy path.
+    Monitoring.sentryCaptureException(
+      v2Error instanceof Error
+        ? v2Error
+        : new Error('Falling back to the legacy /tokenlist endpoint'),
+      Monitoring.SentryExceptionTypes.NETWORKS,
+      { attempt },
+    );
+
+    const [legacyChainList] = await resolve(
+      getChainsAndTokens(
+        process.env.RELEASE === 'production',
+        `${process.env.PROXY_URL}/tokenlist?includeSolana`,
+      ),
+    );
+
+    return legacyChainList ?? undefined;
+  }
+
+  async #fetchNetworksFromApi(): Promise<ChainList | undefined> {
+    const response = await getV2Networks<true>({
+      baseUrl: process.env.TOKEN_AGGREGATOR_SERVICE_URL,
+      throwOnError: true,
+      headers: await getAuthHeaders(),
+      query: { includeSolana: true },
+    });
+
+    const data = response.data?.data;
+
+    return data ? mapV2NetworksToChainList(data) : undefined;
+  }
+
+  #injectLocalNetworks(base: ChainList): ChainList {
+    return {
+      ...base,
+      [BITCOIN_NETWORK.chainId]: BITCOIN_NETWORK,
+      [BITCOIN_TEST_NETWORK.chainId]: BITCOIN_TEST_NETWORK,
+      [ChainId.AVALANCHE_P]: this._getPchainNetwork('mainnet'),
+      [ChainId.AVALANCHE_X]: this._getXchainNetwork('mainnet'),
+      [ChainId.AVALANCHE_TEST_P]: this._getPchainNetwork('testnet'),
+      [ChainId.AVALANCHE_TEST_X]: this._getXchainNetwork('testnet'),
+      [ChainId.AVALANCHE_DEVNET_P]: this._getPchainNetwork('devnet'),
+      [ChainId.AVALANCHE_DEVNET_X]: this._getXchainNetwork('devnet'),
+      [HYPEREVM_NETWORK.chainId]: HYPEREVM_NETWORK,
+      [HYPERCORE_NETWORK.chainId]: HYPERCORE_NETWORK,
+    };
   }
 
   async getNetwork(caipScope: string): Promise<NetworkWithCaipId | undefined>;

--- a/packages/service-worker/src/services/network/NetworkService.ts
+++ b/packages/service-worker/src/services/network/NetworkService.ts
@@ -28,7 +28,6 @@ import {
   ChainId,
   Network,
   NetworkVMType,
-  getChainsAndTokens,
 } from '@avalabs/core-chains-sdk';
 import { ReadableSignal, Signal, ValueCache } from 'micro-signals';
 import {
@@ -52,11 +51,7 @@ import {
   getDefaultEnabledNetworkIds,
   isSyncDomain,
 } from '@core/common';
-import {
-  isSolanaNetwork,
-  isHyperliquidNetwork,
-  Monitoring,
-} from '@core/common';
+import { isSolanaNetwork, isHyperliquidNetwork } from '@core/common';
 import { GlacierService } from '../glacier/GlacierService';
 import { getAuthHeaders } from '../appcheck/utils/getAuthHeaders';
 import { getV2Networks } from '~/api-clients/token-aggregator';
@@ -514,10 +509,10 @@ export class NetworkService implements OnLock, OnStorageReady {
     let attempt = 1;
 
     do {
-      const result = await this.#fetchChainList(attempt);
+      const [networks] = await resolve(this.#fetchNetworksFromApi());
 
-      if (result) {
-        chainlist = this.#injectLocalNetworks(result);
+      if (networks && Object.keys(networks).length > 0) {
+        chainlist = this.#injectLocalNetworks(networks);
       } else {
         attempt += 1;
         await wait(getExponentialBackoffDelay({ attempt }));
@@ -531,36 +526,6 @@ export class NetworkService implements OnLock, OnStorageReady {
     this._allNetworks.dispatch(chainlist);
 
     return chainlist;
-  }
-
-  async #fetchChainList(attempt: number): Promise<ChainList | undefined> {
-    const [v2Networks, v2Error] = await resolve(this.#fetchNetworksFromApi());
-
-    if (v2Networks && Object.keys(v2Networks).length > 0) {
-      return v2Networks;
-    }
-
-    Monitoring.sentryCaptureException(
-      new Error('NetworkService fell back to the legacy /tokenlist endpoint'),
-      Monitoring.SentryExceptionTypes.NETWORKS,
-      {
-        attempt,
-        reason: v2Error
-          ? v2Error instanceof Error
-            ? v2Error.message
-            : String(v2Error)
-          : '/v2/networks returned no usable networks',
-      },
-    );
-
-    const [legacyChainList] = await resolve(
-      getChainsAndTokens(
-        process.env.RELEASE === 'production',
-        `${process.env.PROXY_URL}/tokenlist?includeSolana`,
-      ),
-    );
-
-    return legacyChainList ?? undefined;
   }
 
   async #fetchNetworksFromApi(): Promise<ChainList | undefined> {

--- a/packages/service-worker/src/services/network/utils/mapV2Networks.test.ts
+++ b/packages/service-worker/src/services/network/utils/mapV2Networks.test.ts
@@ -112,4 +112,17 @@ describe('mapV2NetworksToChainList', () => {
 
     expect(result).toEqual({});
   });
+
+  it('skips networks with an unrecognized vmName', () => {
+    const result = mapV2NetworksToChainList({
+      'eip155:43114': apiNetwork() as any,
+      'eip155:1': apiNetwork({
+        chainId: 1,
+        caip2Id: 'eip155:1',
+        vmName: 'TOTALLY_UNKNOWN_VM',
+      }) as any,
+    });
+
+    expect(Object.keys(result)).toEqual(['43114']);
+  });
 });

--- a/packages/service-worker/src/services/network/utils/mapV2Networks.test.ts
+++ b/packages/service-worker/src/services/network/utils/mapV2Networks.test.ts
@@ -1,0 +1,115 @@
+import { NetworkVMType } from '@avalabs/core-chains-sdk';
+import { mapV2NetworksToChainList } from './mapV2Networks';
+
+const apiNetwork = (overrides: Record<string, unknown> = {}) => ({
+  chainId: 43114,
+  chainName: 'Avalanche C-Chain',
+  caip2Id: 'eip155:43114',
+  description: null,
+  explorerUrl: 'https://snowtrace.io',
+  isTestnet: false,
+  isAlwaysEnabled: true,
+  isEnabledByDefault: true,
+  logoUri: 'https://logo/avax',
+  networkToken: {
+    name: 'Avalanche',
+    decimals: 18,
+    symbol: 'AVAX',
+    internalId: 'NATIVE-avax',
+    description: null,
+    logoUri: 'https://logo/avax-token',
+  },
+  pricingProviders: {
+    coingecko: { nativeTokenId: 'avalanche-2', assetPlatformId: 'avalanche' },
+  },
+  primaryColor: '#E84142',
+  rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+  wsUrl: null,
+  subnetExplorerUriId: 'c-chain',
+  vmName: 'EVM',
+  utilityAddresses: { multicall: '0xmulticall' },
+  platformChainId: null,
+  subnetId: null,
+  vmId: null,
+  ...overrides,
+});
+
+describe('mapV2NetworksToChainList', () => {
+  it('re-keys CAIP-2 entries by numeric chainId and maps core fields', () => {
+    const result = mapV2NetworksToChainList({
+      'eip155:43114': apiNetwork() as any,
+    });
+
+    expect(Object.keys(result)).toEqual(['43114']);
+    expect(result[43114]).toMatchObject({
+      chainId: 43114,
+      chainName: 'Avalanche C-Chain',
+      caip2Id: 'eip155:43114',
+      vmName: NetworkVMType.EVM,
+      rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+      explorerUrl: 'https://snowtrace.io',
+      isTestnet: false,
+      networkToken: {
+        name: 'Avalanche',
+        symbol: 'AVAX',
+        decimals: 18,
+        description: '',
+        logoUri: 'https://logo/avax-token',
+      },
+      utilityAddresses: { multicall: '0xmulticall' },
+    });
+  });
+
+  it('preserves the API enablement flags', () => {
+    const result = mapV2NetworksToChainList({
+      'eip155:43114': apiNetwork({
+        isAlwaysEnabled: false,
+        isEnabledByDefault: true,
+      }) as any,
+    });
+
+    expect(result[43114]?.isAlwaysEnabled).toBe(false);
+    expect(result[43114]?.isEnabledByDefault).toBe(true);
+  });
+
+  it('normalizes nullable logoUri and native-token description', () => {
+    const result = mapV2NetworksToChainList({
+      'eip155:43114': apiNetwork({
+        logoUri: null,
+        networkToken: {
+          name: 'X',
+          symbol: 'X',
+          decimals: 18,
+          internalId: 'x',
+          description: null,
+          logoUri: null,
+        },
+      }) as any,
+    });
+
+    expect(result[43114]?.logoUri).toBe('');
+    expect(result[43114]?.networkToken.description).toBe('');
+    expect(result[43114]?.networkToken.logoUri).toBe('');
+  });
+
+  it('skips networks without an rpc url (e.g. X/P-Chain, injected locally)', () => {
+    const result = mapV2NetworksToChainList({
+      'eip155:43114': apiNetwork() as any,
+      'avax:pchain': apiNetwork({
+        chainId: 111111,
+        rpcUrl: null,
+        caip2Id: 'avax:pchain',
+      }) as any,
+    });
+
+    expect(Object.keys(result)).toEqual(['43114']);
+  });
+
+  it('skips networks without a native token', () => {
+    const result = mapV2NetworksToChainList({
+      'eip155:1': apiNetwork({ chainId: 1, networkToken: null }) as any,
+    });
+
+    expect(result).toEqual({});
+  });
+});

--- a/packages/service-worker/src/services/network/utils/mapV2Networks.ts
+++ b/packages/service-worker/src/services/network/utils/mapV2Networks.ts
@@ -5,11 +5,16 @@ import type { NetworkListV2Response } from '~/api-clients/token-aggregator';
 type ApiNetworks = NetworkListV2Response['data'];
 type ApiNetwork = ApiNetworks[string];
 
+const isKnownVmType = (vmName: string): vmName is NetworkVMType =>
+  (Object.values(NetworkVMType) as string[]).includes(vmName);
+
 const toNetwork = (api: ApiNetwork): Network | undefined => {
   // A network without an RPC URL or native token can't be used here. The
   // Avalanche X/P-Chains (which come back with a null rpcUrl) are injected
-  // from local config instead, so skipping them is expected.
-  if (!api.rpcUrl || !api.networkToken) {
+  // from local config instead, so skipping them is expected. An unrecognized
+  // vmName is a free-form string from the API that would slip past typing and
+  // break VM-specific logic downstream, so skip those too.
+  if (!api.rpcUrl || !api.networkToken || !isKnownVmType(api.vmName)) {
     return undefined;
   }
 
@@ -17,7 +22,7 @@ const toNetwork = (api: ApiNetwork): Network | undefined => {
     chainId: api.chainId,
     chainName: api.chainName,
     caip2Id: api.caip2Id,
-    vmName: api.vmName as NetworkVMType,
+    vmName: api.vmName,
     rpcUrl: api.rpcUrl,
     wsUrl: api.wsUrl ?? undefined,
     isTestnet: api.isTestnet,

--- a/packages/service-worker/src/services/network/utils/mapV2Networks.ts
+++ b/packages/service-worker/src/services/network/utils/mapV2Networks.ts
@@ -1,0 +1,71 @@
+import { NetworkVMType } from '@avalabs/core-chains-sdk';
+import { ChainList, Network } from '@core/types';
+import type { NetworkListV2Response } from '~/api-clients/token-aggregator';
+
+type ApiNetworks = NetworkListV2Response['data'];
+type ApiNetwork = ApiNetworks[string];
+
+const toNetwork = (api: ApiNetwork): Network | undefined => {
+  // A network without an RPC URL or native token can't be used here. The
+  // Avalanche X/P-Chains (which come back with a null rpcUrl) are injected
+  // from local config instead, so skipping them is expected.
+  if (!api.rpcUrl || !api.networkToken) {
+    return undefined;
+  }
+
+  return {
+    chainId: api.chainId,
+    chainName: api.chainName,
+    caip2Id: api.caip2Id,
+    vmName: api.vmName as NetworkVMType,
+    rpcUrl: api.rpcUrl,
+    wsUrl: api.wsUrl ?? undefined,
+    isTestnet: api.isTestnet,
+    explorerUrl: api.explorerUrl,
+    subnetExplorerUriId: api.subnetExplorerUriId,
+    logoUri: api.logoUri ?? '',
+    primaryColor: api.primaryColor ?? undefined,
+    description: api.description ?? undefined,
+    platformChainId: api.platformChainId ?? undefined,
+    subnetId: api.subnetId ?? undefined,
+    vmId: api.vmId ?? undefined,
+    networkToken: {
+      name: api.networkToken.name,
+      symbol: api.networkToken.symbol,
+      decimals: api.networkToken.decimals,
+      description: api.networkToken.description ?? '',
+      logoUri: api.networkToken.logoUri ?? '',
+    },
+    utilityAddresses:
+      api.utilityAddresses && typeof api.utilityAddresses.multicall === 'string'
+        ? { multicall: api.utilityAddresses.multicall }
+        : undefined,
+    pricingProviders: api.pricingProviders
+      ? {
+          coingecko: {
+            assetPlatformId: api.pricingProviders.coingecko.assetPlatformId,
+            nativeTokenId:
+              api.pricingProviders.coingecko.nativeTokenId ?? undefined,
+          },
+        }
+      : undefined,
+    isAlwaysEnabled: api.isAlwaysEnabled,
+    isEnabledByDefault: api.isEnabledByDefault,
+  };
+};
+
+// Re-keys the CAIP-2-keyed `/v2/networks` response into the numeric-chainId
+// `ChainList` the rest of the extension expects, dropping entries that can't
+// form a usable network.
+export const mapV2NetworksToChainList = (data: ApiNetworks): ChainList => {
+  const chainList: ChainList = {};
+
+  for (const api of Object.values(data)) {
+    const network = toNetwork(api);
+    if (network) {
+      chainList[network.chainId] = network;
+    }
+  }
+
+  return chainList;
+};


### PR DESCRIPTION
# Summary

Jira ticket: https://ava-labs.atlassian.net/browse/CP-15033
Based on #1023 

<!-- Describe the changes -->
<!-- Link the Jira ticket and Figma designs. Prefer listing expectations vs. linking large docs like PRD -->

## Notes
* Migrates from the `/tokenlist` endpoint to `/v2/networks`, leaving the former as a fallback.

## Testing
* Regression test the extension bootup, onboarding and all the network lists